### PR TITLE
fix(cli): Handle invalid JSON in project repos field during switch

### DIFF
--- a/empirica/cli/command_handlers/project_commands.py
+++ b/empirica/cli/command_handlers/project_commands.py
@@ -2244,7 +2244,13 @@ def handle_project_switch_command(args):
             return None
         
         project_name = project['name']
-        repos = json.loads(project['repos']) if project.get('repos') else []
+        repos_raw = project.get('repos')
+        repos = []
+        if repos_raw and repos_raw.strip():
+            try:
+                repos = json.loads(repos_raw)
+            except json.JSONDecodeError:
+                repos = []
         
         # 3. Try to find project git root
         project_path = None


### PR DESCRIPTION
## Summary
- Fix crash in `project-switch` when a project's `repos` field contains invalid JSON
- Adds defensive JSON parsing with graceful fallback to empty list
- Prevents `JSONDecodeError: Expecting value: line 1 column 2` crash

## Problem
When switching projects, if a project has an empty string or malformed JSON in the `repos` field, the command crashes:
```
JSONDecodeError: Expecting value: line 1 column 2 (char 1)
```

## Solution
Replace direct `json.loads()` with try/except wrapper that defaults to empty list on parse failure.

## Test plan
- [x] Reproduced the bug with `empirica project-switch "2600 Empirica-SaaS"`
- [x] Verified fix allows switch to complete successfully
- [ ] Run existing test suite

---
Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>