### PR TITLE
fix(cli): Use global database for project-list, project-switch, project-bootstrap

### DIFF
--- a/empirica/cli/command_handlers/project_commands.py
+++ b/empirica/cli/command_handlers/project_commands.py
@@ -161,8 +161,10 @@ def handle_project_list_command(args):
     """Handle project-list command"""
     try:
         from empirica.data.session_database import SessionDatabase
-        
-        db = SessionDatabase()
+        from empirica.config.path_resolver import get_global_session_db_path
+
+        # Always use global database for project registry
+        db = SessionDatabase(db_path=str(get_global_session_db_path()))
         cursor = db.conn.cursor()
         
         # Get all projects
@@ -208,6 +210,7 @@ def handle_project_bootstrap_command(args):
         from empirica.data.session_database import SessionDatabase
         from empirica.config.project_config_loader import get_current_subject
         from empirica.cli.utils.project_resolver import resolve_project_id
+        from empirica.config.path_resolver import get_global_session_db_path
         import subprocess
 
         output_format = getattr(args, 'output', 'human')
@@ -236,7 +239,8 @@ def handle_project_bootstrap_command(args):
 
                 git_repo = get_current_git_repo()
                 if git_repo:
-                    db = SessionDatabase()
+                    # Use global database for project registry lookup
+                    db = SessionDatabase(db_path=str(get_global_session_db_path()))
                     project_id = resolve_project_by_git_repo(git_repo, db)
 
                     if not project_id:
@@ -275,7 +279,8 @@ def handle_project_bootstrap_command(args):
                 )
         else:
             # Resolve project name to UUID if needed
-            db = SessionDatabase()
+            # Use global database for project registry lookup
+            db = SessionDatabase(db_path=str(get_global_session_db_path()))
             project_id = resolve_project_id(project_id, db)
             db.close()
         
@@ -297,8 +302,9 @@ def handle_project_bootstrap_command(args):
         subject = getattr(args, 'subject', None)
         if subject is None:
             subject = get_current_subject()  # Auto-detect from directory
-        
-        db = SessionDatabase()
+
+        # Use global database for project data (breadcrumbs, findings, goals)
+        db = SessionDatabase(db_path=str(get_global_session_db_path()))
 
         # Get new parameters
         session_id = getattr(args, 'session_id', None)
@@ -2204,12 +2210,14 @@ def handle_project_switch_command(args):
     """
     try:
         from empirica.data.session_database import SessionDatabase
-        
+        from empirica.config.path_resolver import get_global_session_db_path
+
         project_identifier = args.project_identifier
         output_format = getattr(args, 'output', 'human')
-        
-        db = SessionDatabase()
-        
+
+        # Always use global database for project registry lookup
+        db = SessionDatabase(db_path=str(get_global_session_db_path()))
+
         # 1. Resolve project (by name or ID)
         project_id = db.projects.resolve_project_id(project_identifier)
         

--- a/empirica/config/path_resolver.py
+++ b/empirica/config/path_resolver.py
@@ -223,6 +223,27 @@ def get_session_db_path() -> Path:
     return db_path
 
 
+def get_global_session_db_path() -> Path:
+    """
+    Get path to GLOBAL sessions database (~/.empirica/sessions/sessions.db).
+
+    This always returns the global database path, ignoring any local .empirica
+    folders. Use this for operations that need the global projects registry
+    (e.g., project-list, project-switch).
+
+    The hub-and-spoke architecture stores:
+    - GLOBAL (~/.empirica/): projects registry, CRM, cross-project data
+    - LOCAL (project/.empirica/): sessions, goals, findings for that project
+
+    Returns:
+        Path to global sessions.db (always ~/.empirica/sessions/sessions.db)
+    """
+    global_root = Path.home() / '.empirica'
+    db_path = global_root / 'sessions' / 'sessions.db'
+    logger.debug(f"📍 Using GLOBAL sessions path: {db_path}")
+    return db_path
+
+
 def get_identity_dir() -> Path:
     """Get identity keys directory."""
     config = load_empirica_config()


### PR DESCRIPTION
## Summary
- Fix project commands failing when run from directories with local `.empirica` folders
- Add `get_global_session_db_path()` helper function
- Update `project-list`, `project-switch`, and `project-bootstrap` to use global database

## Problem
When running `empirica project-list` or `project-switch` from inside a directory that has its own `.empirica` folder (e.g., the Empirica source code at `~/empirica`), the commands would:
- Show 0 projects (for `project-list`)
- Fail with "Project not found" (for `project-switch`)

This happened because the CLI looked at the **local** database instead of the **global** registry at `~/.empirica/sessions/sessions.db`.

## Solution
Added `get_global_session_db_path()` to `path_resolver.py` that always returns the global database path, and updated the project commands to use it.

This follows the hub-and-spoke architecture documented in CLAUDE.md:
- **GLOBAL** (`~/.empirica/`): projects registry, CRM, cross-project data
- **LOCAL** (`project/.empirica/`): sessions, goals, findings for that specific project

## Test plan
- [x] Run `empirica project-list` from `~/empirica` (source folder with local .empirica)
- [x] Run `empirica project-switch "2600 Empirica-SaaS"` from same location
- [x] Verify both commands now use global database and find all 39 projects

---
Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>