### PR TITLE
fix(qdrant): Match hash fallback vector dimensions to configured provider

### DIFF
--- a/empirica/core/qdrant/connection.py
+++ b/empirica/core/qdrant/connection.py
@@ -58,13 +58,13 @@ def _get_embedding_safe(text: str) -> Optional[List[float]]:
 
 
 def _get_vector_size() -> int:
-    """Get vector size from embeddings provider. Defaults to 1536 on error."""
+    """Get vector size from embeddings provider. Defaults to 768 on error (matches Ollama/nomic-embed-text)."""
     try:
         from .embeddings import get_vector_size
         return get_vector_size()
     except Exception as e:
-        logger.debug(f"Could not get vector size: {e}, defaulting to 1536")
-        return 1536
+        logger.debug(f"Could not get vector size: {e}, defaulting to 768")
+        return 768
 
 
 def _get_qdrant_client():


### PR DESCRIPTION
## Summary
- When Ollama is cold/unavailable, the hash fallback embedding produced 1536-dim vectors but all Qdrant collections are 768-dim (Ollama/nomic-embed-text)
- This caused `Vector dimension error: expected dim: 768, got 1536` on every POSTFLIGHT and calibration search when Ollama was slow to respond
- Hash fallback now uses the configured provider's vector size instead of hardcoded 1536

## Changes
- `embeddings.py`: `_embed_local_hash()` uses `self._vector_size` instead of hardcoded 1536
- `embeddings.py`: Auto-fallback to local provider tracks `_auto_fallback` flag and matches Ollama's 768-dim
- `connection.py`: `_get_vector_size()` default changed from 1536 to 768

## Test plan
- [x] Verified all 629 Qdrant collections are 768-dim
- [x] Normal path (Ollama available): produces 768-dim vectors
- [x] Fallback path (Ollama down): produces 768-dim vectors (was 1536)
- [x] Auto-fallback provider sets correct vector_size
- [x] Calibration search that was failing now works
- [x] POSTFLIGHT completes without dimension errors

Generated with [Claude Code](https://claude.com/claude-code)