### PR TITLE
Fix macOS instance isolation: TTY ?? bug + hook/resolver asymmetry

### DIFF
--- a/empirica/plugins/claude-code-integration/hooks/post-compact.py
+++ b/empirica/plugins/claude-code-integration/hooks/post-compact.py
@@ -29,16 +29,26 @@ except ImportError:
 
 
 def _get_instance_id() -> Optional[str]:
-    """Derive instance ID from environment. TMUX_PANE → TTY → 'default'."""
+    """Derive instance ID from environment. TMUX_PANE → TERM_SESSION_ID → WINDOWID → 'default'.
+
+    NOTE: os.ttyname(sys.stdin.fileno()) is NOT attempted here because hooks
+    receive stdin as a pipe from Claude Code, so it always fails. Use env vars
+    that are reliably inherited instead.
+    """
     tmux_pane = os.environ.get('TMUX_PANE')
     if tmux_pane:
         return f"tmux_{tmux_pane.lstrip('%')}"
-    try:
-        tty_path = os.ttyname(sys.stdin.fileno())
-        safe = tty_path.replace('/', '_').lstrip('_').replace('dev_', '')
-        return f"term_{safe}"
-    except Exception:
-        pass
+
+    # macOS Terminal.app session (matches resolver priority chain)
+    term_session = os.environ.get('TERM_SESSION_ID')
+    if term_session:
+        return f"term:{term_session[:16]}"
+
+    # X11 window ID
+    window_id = os.environ.get('WINDOWID')
+    if window_id:
+        return f"x11:{window_id}"
+
     return "default"
 
 

--- a/empirica/plugins/claude-code-integration/hooks/session-init.py
+++ b/empirica/plugins/claude-code-integration/hooks/session-init.py
@@ -254,20 +254,25 @@ def format_context(ctx: dict) -> str:
 def _get_instance_id() -> str:
     """
     Derive instance ID from environment. Fallback chain:
-    TMUX_PANE → TTY name → 'default'
+    TMUX_PANE → TERM_SESSION_ID → WINDOWID → 'default'
+
+    NOTE: os.ttyname(sys.stdin.fileno()) is NOT attempted here because hooks
+    receive stdin as a pipe from Claude Code, so it always fails. Use env vars
+    that are reliably inherited instead.
     """
     tmux_pane = os.environ.get('TMUX_PANE')
     if tmux_pane:
         return f"tmux_{tmux_pane.lstrip('%')}"
 
-    # Fallback: TTY-based instance ID
-    try:
-        tty_path = os.ttyname(sys.stdin.fileno())
-        # e.g. /dev/pts/3 → term_pts_3, /dev/ttys005 → term_ttys005
-        safe = tty_path.replace('/', '_').lstrip('_').replace('dev_', '')
-        return f"term_{safe}"
-    except:
-        pass
+    # macOS Terminal.app session (matches resolver priority chain)
+    term_session = os.environ.get('TERM_SESSION_ID')
+    if term_session:
+        return f"term:{term_session[:16]}"
+
+    # X11 window ID
+    window_id = os.environ.get('WINDOWID')
+    if window_id:
+        return f"x11:{window_id}"
 
     return "default"
 
@@ -286,13 +291,9 @@ def _write_instance_projects(project_path: str, claude_session_id: str, empirica
         instance_dir.mkdir(parents=True, exist_ok=True)
         instance_file = instance_dir / f'{instance_id}.json'
 
-        # Get TTY key if available
+        # TTY key is not available in hook context (stdin is a pipe)
+        # Instance isolation is handled by instance_id (TMUX_PANE/TERM_SESSION_ID)
         tty_key = None
-        try:
-            tty_path = os.ttyname(sys.stdin.fileno())
-            tty_key = tty_path.replace('/', '-').lstrip('-')
-        except:
-            pass
 
         instance_data = {
             'project_path': project_path,

--- a/empirica/utils/session_resolver.py
+++ b/empirica/utils/session_resolver.py
@@ -66,7 +66,8 @@ def get_tty_key() -> Optional[str]:
                 break
 
             tty = parts[0]
-            if tty and tty != '?':
+            # macOS ps returns '??' for no-TTY processes (not '?' like Linux)
+            if tty and not tty.startswith('?'):
                 return tty.replace('/', '-')
 
             # Move to parent


### PR DESCRIPTION
## Summary
- **P0 fix:** `get_tty_key()` in `session_resolver.py` checked `tty != '?'` but macOS `ps` returns `'??'` for no-TTY processes. All non-tmux sessions were clobbering the same `tty_sessions/??.json` file. Fixed with `not tty.startswith('?')`.
- **P1 fix:** Hook `_get_instance_id()` in `session-init.py` and `post-compact.py` tried `os.ttyname(sys.stdin.fileno())` which always fails (hooks receive stdin as pipe from Claude Code). Replaced with `TERM_SESSION_ID` and `WINDOWID` fallbacks, matching the resolver's priority chain.
- **P3 fix:** Removed dead `os.ttyname(stdin)` call in `_write_instance_projects()` — same pipe issue.

## Reproducer
Run Claude Code **outside tmux** on macOS. The `tty_sessions/??.json` file gets clobbered by every session, and `instance_projects/` stays empty because hooks write to `default.json` while the CLI resolver returns `None` and skips the read.

## Test plan
- [ ] Verify `tty_sessions/` no longer gets `??.json` files on macOS
- [ ] Verify `instance_projects/` populates correctly in non-tmux macOS Terminal
- [ ] Verify tmux behavior unchanged (TMUX_PANE path unaffected)
- [ ] Test project-switch statusline updates correctly after fix

Generated with [Claude Code](https://claude.com/claude-code)