### PR TITLE
fix(skill): Add pre-POSTFLIGHT artifact sweep to epistemic-transaction

### DIFF
--- a/empirica/plugins/claude-code-integration/skills/epistemic-transaction/SKILL.md
+++ b/empirica/plugins/claude-code-integration/skills/epistemic-transaction/SKILL.md
@@ -371,6 +371,15 @@ empirica decision-log --choice "Use middleware factory pattern" \
 
 ### 4e. POSTFLIGHT — Close the Measurement Window
 
+**BEFORE running POSTFLIGHT, always:**
+1. Log all remaining epistemic artifacts (findings, unknowns, decisions, dead-ends, mistakes)
+2. Resolve any unknowns that were answered during the transaction
+3. Complete any goals that were finished
+4. Ask the user: "Any artifacts to log before I close the transaction?"
+
+POSTFLIGHT without artifact sweep = lost data. The measurement window closes
+and unlogged work becomes invisible to calibration. Always log first, then close.
+
 ```bash
 empirica postflight-submit - << 'EOF'
 {


### PR DESCRIPTION
## Summary
- Adds a mandatory artifact sweep checklist before POSTFLIGHT in the epistemic-transaction skill
- Without this, artifacts logged after POSTFLIGHT are outside the measurement window and invisible to calibration
- Found this in practice: transaction enforcer hook warned about open turns, I rushed to POSTFLIGHT first, then logged artifacts afterwards - wrong order

## Changes
- Added 4-step pre-POSTFLIGHT checklist to SKILL.md:
  1. Log all remaining artifacts (findings, unknowns, decisions, dead-ends, mistakes)
  2. Resolve unknowns answered during the transaction
  3. Complete finished goals
  4. Ask user for remaining items

## Test plan
- [ ] Load epistemic-transaction skill in new session
- [ ] Verify the pre-POSTFLIGHT section appears in the skill text
- [ ] Run a transaction and confirm the artifact sweep happens before POSTFLIGHT

🤖 Generated with [Claude Code](https://claude.com/claude-code)