### PR TITLE
fix: auto-embed dead-ends and mistakes to Qdrant on log

### DIFF
--- a/empirica/cli/command_handlers/artifact_log_commands.py
+++ b/empirica/cli/command_handlers/artifact_log_commands.py
@@ -1037,6 +1037,28 @@ def handle_deadend_log_command(args):
             # Non-fatal - log but continue
             logger.warning(f"Git notes storage failed: {git_err}")
 
+        # AUTO-EMBED: Add dead end to Qdrant for semantic search
+        # Without this, dead-ends are invisible to pattern_retrieval.py
+        # at PREFLIGHT/CHECK — the most valuable anti-pattern data is unsearchable.
+        embedded = False
+        if project_id and dead_end_id:
+            try:
+                from empirica.core.qdrant.memory import embed_single_memory_item
+                from datetime import datetime
+                text = f"DEAD END: {approach} Why failed: {why_failed}"
+                embedded = embed_single_memory_item(
+                    project_id=project_id,
+                    item_id=dead_end_id,
+                    text=text,
+                    item_type='dead_end',
+                    session_id=session_id,
+                    goal_id=goal_id,
+                    subtask_id=subtask_id,
+                    timestamp=datetime.now().isoformat()
+                )
+            except Exception as embed_err:
+                logger.warning(f"Auto-embed failed: {embed_err}")
+
         result = {
             "ok": True,
             "dead_end_id": dead_end_id,
@@ -1046,6 +1068,7 @@ def handle_deadend_log_command(args):
             "entity_id": ctx['entity_id'],
             "via": ctx['via'],
             "git_stored": git_stored,
+            "embedded": embedded,
             "message": "Dead end logged to project scope"
         }
 
@@ -1058,6 +1081,8 @@ def handle_deadend_log_command(args):
                 print(f"   Project: {project_id[:8]}...")
             if git_stored:
                 print(f"   📝 Stored in git notes for sync")
+            if embedded:
+                print(f"   🔍 Auto-embedded for semantic search")
 
         return 0  # Success
 

--- a/empirica/cli/command_handlers/mistake_commands.py
+++ b/empirica/cli/command_handlers/mistake_commands.py
@@ -129,6 +129,28 @@ def handle_mistake_log_command(args):
             # Non-fatal - log but continue
             logger.warning(f"Git notes storage failed: {git_err}")
 
+        # AUTO-EMBED: Add mistake to Qdrant for semantic search
+        # Without this, mistakes are invisible to pattern_retrieval.py
+        # at PREFLIGHT/CHECK — preventing the system from warning about
+        # repeated mistake patterns.
+        embedded = False
+        if project_id and mistake_id:
+            try:
+                from empirica.core.qdrant.memory import embed_single_memory_item
+                from datetime import datetime
+                text = f"MISTAKE: {mistake} Prevention: {prevention or 'none specified'}"
+                embedded = embed_single_memory_item(
+                    project_id=project_id,
+                    item_id=mistake_id,
+                    text=text,
+                    item_type='mistake',
+                    session_id=session_id,
+                    goal_id=goal_id,
+                    timestamp=datetime.now().isoformat()
+                )
+            except Exception as embed_err:
+                logger.warning(f"Auto-embed failed: {embed_err}")
+
         # Format output
         result = {
             "ok": True,
@@ -136,6 +158,7 @@ def handle_mistake_log_command(args):
             "session_id": session_id,
             "project_id": project_id,
             "git_stored": git_stored,
+            "embedded": embedded,
             "message": "Mistake logged to project scope"
         }
 
@@ -149,6 +172,8 @@ def handle_mistake_log_command(args):
                 print(f"   Project: {project_id[:8]}...")
             if git_stored:
                 print(f"   📝 Stored in git notes for sync")
+            if embedded:
+                print(f"   🔍 Auto-embedded for semantic search")
             if root_cause_vector:
                 print(f"   Root cause: {root_cause_vector} vector")
             if cost_estimate:


### PR DESCRIPTION
## Summary

- `deadend-log` and `mistake-log` saved to SQLite + git notes but skipped Qdrant embedding
- `finding-log` and `unknown-log` already auto-embed - this was an inconsistency
- 142 dead-ends + 48 mistakes across all projects were invisible to `pattern_retrieval.py` at PREFLIGHT/CHECK
- The most valuable anti-pattern data (what NOT to do) was unsearchable

## Fix

Added `embed_single_memory_item` calls to:
- `artifact_log_commands.py` → `handle_deadend_log_command()` (after git notes, before result formatting)
- `mistake_commands.py` → `handle_mistake_log_command()` (same pattern)

Both match the existing pattern in `finding-log`: non-fatal on failure, logs warning, adds `embedded` field to result, shows "Auto-embedded for semantic search" in human output.

## Test plan

- [x] Verified `embed_single_memory_item` accepts `dead_end` and `mistake` types (tested manually, score 0.775)
- [x] Backfilled all 192 existing artifacts from SQLite to Qdrant (144 dead-ends + 48 mistakes)
- [ ] Run `empirica deadend-log` and verify Qdrant point appears
- [ ] Run `empirica mistake-log` and verify Qdrant point appears
- [ ] Verify `pattern_retrieval.py` finds dead-ends at CHECK gate


🤖 Generated with [Claude Code](https://claude.com/claude-code)