### PR TITLE
fix: SQLite UPDATE...ORDER BY syntax error in sentinel override sync

### DIFF
--- a/empirica/cli/command_handlers/workflow_commands.py
+++ b/empirica/cli/command_handlers/workflow_commands.py
@@ -1451,9 +1451,12 @@ def handle_check_submit_command(args):
                                 db2 = _get_db_for_session(session_id)
                                 db2.conn.execute("""
                                     UPDATE reflexes SET reflex_data = json_set(reflex_data, '$.decision', ?)
-                                    WHERE session_id = ? AND phase = 'CHECK'
-                                    AND transaction_id = ?
-                                    ORDER BY timestamp DESC LIMIT 1
+                                    WHERE id = (
+                                        SELECT id FROM reflexes
+                                        WHERE session_id = ? AND phase = 'CHECK'
+                                        AND transaction_id = ?
+                                        ORDER BY timestamp DESC LIMIT 1
+                                    )
                                 """, (new_decision, session_id, check_transaction_id2))
                                 db2.conn.commit()
                                 db2.close()


### PR DESCRIPTION
## Summary

- SQLite does not support `ORDER BY` and `LIMIT` in `UPDATE` statements (that's MySQL syntax)
- Line 1452 of `workflow_commands.py` silently failed with `near "ORDER": syntax error`
- This caused the CHECK/Sentinel split-brain: CHECK returned `proceed` to the AI but sentinel-gate read the old `investigate` from the DB
- The AI sees proceed, tries to act, sentinel blocks with investigate. Deadlock.

## Fix

```sql
-- Before (MySQL syntax, fails on SQLite):
UPDATE reflexes SET reflex_data = json_set(...)
WHERE session_id = ? AND phase = 'CHECK' AND transaction_id = ?
ORDER BY timestamp DESC LIMIT 1

-- After (standard SQLite):
UPDATE reflexes SET reflex_data = json_set(...)
WHERE id = (
    SELECT id FROM reflexes
    WHERE session_id = ? AND phase = 'CHECK' AND transaction_id = ?
    ORDER BY timestamp DESC LIMIT 1
)
```

## Impact

This bug affected every CHECK that triggered a sentinel override. The error was logged as a warning (`Failed to sync sentinel override to DB`) but the tool call was allowed to proceed - so the immediate CHECK worked, but subsequent tool calls in the same transaction would be blocked because sentinel-gate read the stale pre-override decision from the DB.

## Test plan

- [ ] Run CHECK, verify no `Failed to sync` warning in logs
- [ ] Verify sentinel-gate reads the overridden decision after CHECK
- [ ] Multiple CHECK rounds in same transaction should not deadlock


Generated with [Claude Code](https://claude.com/claude-code)