### PR TITLE
fix(setup): Remove stale claude_dir reference in _configure_settings

### DIFF
--- a/empirica/cli/command_handlers/setup_claude_code.py
+++ b/empirica/cli/command_handlers/setup_claude_code.py
@@ -133,7 +133,6 @@ def _configure_settings(settings, settings_file, plugin_dir, python_cmd, force, 
     if output_format != 'json':
         print("\n⚙️  Configuring settings.json...")
 
-    settings_file = claude_dir / "settings.json"
     settings = _ensure_json_file(settings_file, {})
 
     # Ensure enabledPlugins exists


### PR DESCRIPTION
## Summary
- Removes `settings_file = claude_dir / "settings.json"` from the extracted `_configure_settings()` function
- `claude_dir` is not in scope after the refactoring in 88d5b21a - causes `NameError: name 'claude_dir' is not defined`
- `settings_file` is already passed as a parameter and has the correct value

## Test plan
- [x] `empirica setup-claude-code --force` completes without error
- [x] Settings.json is correctly updated with hooks and plugin config

🤖 Generated with [Claude Code](https://claude.com/claude-code)