### PR TITLE
[codex] Guard Qdrant writes against collection dimension drift

### DIFF
--- a/empirica/cli/command_handlers/setup_claude_code.py
+++ b/empirica/cli/command_handlers/setup_claude_code.py
@@ -780,7 +780,9 @@ def handle_setup_claude_code_command(args):
                         print("✓ Ollama: installed, qwen3-embedding available (1024d)")
                     elif "nomic-embed-text" in result.stdout:
                         embedding_ok = True
-                        print("✓ Ollama: installed, nomic-embed-text available (consider upgrading to qwen3-embedding)")
+                        print("✓ Ollama: installed, nomic-embed-text available (768d)")
+                        print("    If Qdrant collections were created at 1024d, switch models and run:")
+                        print("    empirica rebuild --qdrant")
                     else:
                         print("⚠ Ollama: installed, but no embedding model pulled")
                         print("    Fix: ollama pull qwen3-embedding")

--- a/empirica/core/bus_persistence.py
+++ b/empirica/core/bus_persistence.py
@@ -175,8 +175,6 @@ class QdrantBusObserver(EpistemicObserver):
         self.session_id = session_id
         self._available = self._check_available()
         self._event_count = 0
-        if self._available:
-            self._ensure_collection()
 
     def _check_available(self) -> bool:
         """Check if Qdrant is available."""
@@ -193,23 +191,18 @@ class QdrantBusObserver(EpistemicObserver):
                 _get_qdrant_client,
                 _get_vector_size,
             )
+            from empirica.core.qdrant.connection import _ensure_collection_matches_vector
             client = _get_qdrant_client()
             if client is None:
                 self._available = False
                 return
 
-            collections = [c.name for c in client.get_collections().collections]
-            if self.COLLECTION_NAME not in collections:
-                from qdrant_client.models import Distance, VectorParams
-                vector_size = _get_vector_size()
-                client.create_collection(
-                    collection_name=self.COLLECTION_NAME,
-                    vectors_config=VectorParams(
-                        size=vector_size,
-                        distance=Distance.COSINE,
-                    ),
-                )
-                logger.info(f"Created Qdrant collection: {self.COLLECTION_NAME}")
+            _ensure_collection_matches_vector(
+                client,
+                self.COLLECTION_NAME,
+                _get_vector_size(),
+                create_if_missing=False,
+            )
         except Exception as e:
             logger.debug(f"Could not ensure Qdrant collection: {e}")
             self._available = False
@@ -223,21 +216,25 @@ class QdrantBusObserver(EpistemicObserver):
             from qdrant_client.models import PointStruct
 
             from empirica.core.qdrant.vector_store import (
-                _get_embedding_safe,
                 _get_qdrant_client,
             )
+            from empirica.core.qdrant.connection import _get_embedding_for_collection
 
             # Create searchable text from event
             event_text = (
                 f"{event.event_type}: {event.agent_id} "
                 f"{json.dumps(event.data)[:500]}"
             )
-            embedding = _get_embedding_safe(event_text)
-            if embedding is None:
-                return
-
             client = _get_qdrant_client()
             if client is None:
+                return
+            embedding = _get_embedding_for_collection(
+                client,
+                self.COLLECTION_NAME,
+                event_text,
+                create_if_missing=True,
+            )
+            if embedding is None:
                 return
 
             point_id = str(uuid.uuid4())
@@ -278,18 +275,19 @@ class QdrantBusObserver(EpistemicObserver):
 
         try:
             from qdrant_client.models import FieldCondition, Filter, MatchValue
-
-            from empirica.core.qdrant.vector_store import (
-                _get_embedding_safe,
-                _get_qdrant_client,
-            )
-
-            embedding = _get_embedding_safe(query_text)
-            if embedding is None:
-                return []
+            from empirica.core.qdrant.connection import _get_embedding_for_collection
+            from empirica.core.qdrant.vector_store import _get_qdrant_client
 
             client = _get_qdrant_client()
             if client is None:
+                return []
+            embedding = _get_embedding_for_collection(
+                client,
+                self.COLLECTION_NAME,
+                query_text,
+                create_if_missing=False,
+            )
+            if embedding is None:
                 return []
 
             query_filter = None

--- a/empirica/core/qdrant/connection.py
+++ b/empirica/core/qdrant/connection.py
@@ -16,6 +16,10 @@ logger = logging.getLogger(__name__)
 _qdrant_available = None
 _qdrant_warned = False
 
+
+class CollectionDimensionMismatchError(RuntimeError):
+    """Raised when an existing Qdrant collection and embeddings provider disagree."""
+
 def _check_qdrant_available() -> bool:
     """Check if Qdrant is available and enabled."""
     global _qdrant_available, _qdrant_warned
@@ -77,6 +81,131 @@ def _get_vector_size() -> int:
     except Exception as e:
         logger.debug(f"Could not get vector size: {e}, defaulting to 1024")
         return 1024
+
+
+def _get_provider_context() -> str:
+    """Return a short provider/model label for mismatch errors."""
+    try:
+        from .embeddings import get_provider_info
+
+        info = get_provider_info()
+        provider = info.get("provider", "unknown")
+        model = info.get("model", "unknown")
+        return f"{provider}/{model}"
+    except Exception:
+        return "current embeddings configuration"
+
+
+def _extract_vector_size(vectors_config) -> int | None:
+    """Extract vector size from Qdrant's collection config structure."""
+    size = getattr(vectors_config, "size", None)
+    if isinstance(size, int):
+        return size
+    if isinstance(vectors_config, dict):
+        for params in vectors_config.values():
+            nested_size = getattr(params, "size", None)
+            if isinstance(nested_size, int):
+                return nested_size
+    return None
+
+
+def _get_collection_vector_size(client, collection_name: str) -> int | None:
+    """Read the configured vector size for an existing Qdrant collection."""
+    try:
+        coll_info = client.get_collection(collection_name)
+        vectors_config = coll_info.config.params.vectors
+        return _extract_vector_size(vectors_config)
+    except Exception as e:
+        logger.debug(f"Could not read collection dimensions for {collection_name}: {e}")
+        return None
+
+
+def _create_collection_with_size(client, collection_name: str, vector_size: int) -> None:
+    """Create a single-vector cosine collection with the resolved dimension."""
+    _, Distance, VectorParams, _ = _get_qdrant_imports()
+    client.create_collection(
+        collection_name=collection_name,
+        vectors_config=VectorParams(size=vector_size, distance=Distance.COSINE),
+    )
+
+
+def _ensure_collection_matches_vector(
+    client,
+    collection_name: str,
+    vector_size: int,
+    *,
+    create_if_missing: bool = False,
+) -> bool:
+    """Ensure a collection exists with the same dimension as the resolved embeddings."""
+    if client.collection_exists(collection_name):
+        existing_size = _get_collection_vector_size(client, collection_name)
+        if existing_size is not None and existing_size != vector_size:
+            provider_context = _get_provider_context()
+            raise CollectionDimensionMismatchError(
+                f"Qdrant collection '{collection_name}' is configured for {existing_size}d vectors, "
+                f"but {provider_context} resolved to {vector_size}d. "
+                "Update EMPIRICA_EMBEDDINGS_MODEL (or related provider config) and rebuild Qdrant with "
+                "`empirica rebuild --qdrant` before writing semantic data."
+            )
+        return False
+
+    if create_if_missing:
+        _create_collection_with_size(client, collection_name, vector_size)
+        logger.info(f"Created Qdrant collection {collection_name} with {vector_size} dimensions")
+        return True
+
+    return False
+
+
+def _get_embedding_for_collection(
+    client,
+    collection_name: str,
+    text: str,
+    *,
+    create_if_missing: bool = False,
+) -> list[float] | None:
+    """Embed text and verify the target collection matches the embedding dimension."""
+    embedding = _get_embedding_safe(text)
+    if embedding is None:
+        return None
+    _ensure_collection_matches_vector(
+        client,
+        collection_name,
+        len(embedding),
+        create_if_missing=create_if_missing,
+    )
+    return embedding
+
+
+def _get_embeddings_batch_for_collection(
+    client,
+    collection_name: str,
+    texts: list[str],
+    *,
+    create_if_missing: bool = False,
+) -> list[list[float] | None]:
+    """Batch embed texts and verify the target collection matches the batch dimension."""
+    vectors = _get_embeddings_batch(texts)
+    first_vector = next((vector for vector in vectors if vector is not None), None)
+    if first_vector is None:
+        return vectors
+
+    vector_size = len(first_vector)
+    _ensure_collection_matches_vector(
+        client,
+        collection_name,
+        vector_size,
+        create_if_missing=create_if_missing,
+    )
+
+    for vector in vectors:
+        if vector is not None and len(vector) != vector_size:
+            provider_context = _get_provider_context()
+            raise CollectionDimensionMismatchError(
+                f"Embeddings batch for '{collection_name}' returned mixed dimensions "
+                f"under {provider_context}. Rebuild Qdrant after fixing the configured model."
+            )
+    return vectors
 
 
 def _get_qdrant_client():

--- a/empirica/core/qdrant/memory.py
+++ b/empirica/core/qdrant/memory.py
@@ -14,11 +14,10 @@ from empirica.core.qdrant.collections import (
 )
 from empirica.core.qdrant.connection import (
     _check_qdrant_available,
-    _get_embedding_safe,
-    _get_embeddings_batch,
+    _get_embedding_for_collection,
+    _get_embeddings_batch_for_collection,
     _get_qdrant_client,
     _get_qdrant_imports,
-    _get_vector_size,
     _rest_search,
     logger,
 )
@@ -50,18 +49,13 @@ def embed_single_memory_item(
         return False
 
     try:
-        _, Distance, VectorParams, PointStruct = _get_qdrant_imports()
+        _, _, _, PointStruct = _get_qdrant_imports()
         client = _get_qdrant_client()
         if client is None:
             return False
         coll = _memory_collection(project_id)
 
-        # Ensure collection exists
-        if not client.collection_exists(coll):
-            vector_size = _get_vector_size()
-            client.create_collection(coll, vectors_config=VectorParams(size=vector_size, distance=Distance.COSINE))
-
-        vector = _get_embedding_safe(text)
+        vector = _get_embedding_for_collection(client, coll, text, create_if_missing=True)
         if vector is None:
             return False
 
@@ -103,22 +97,20 @@ def upsert_docs(project_id: str, docs: list[dict]) -> int:
         return 0
 
     try:
-        _, Distance, VectorParams, PointStruct = _get_qdrant_imports()
+        _, _, _, PointStruct = _get_qdrant_imports()
         client = _get_qdrant_client()
         if client is None:
             return 0
         coll = _docs_collection(project_id)
 
-        if not client.collection_exists(coll):
-            vector_size = _get_vector_size()
-            client.create_collection(
-                coll,
-                vectors_config=VectorParams(size=vector_size, distance=Distance.COSINE),
-            )
-
         points = []
         for d in docs:
-            vector = _get_embedding_safe(d.get("text", ""))
+            vector = _get_embedding_for_collection(
+                client,
+                coll,
+                d.get("text", ""),
+                create_if_missing=not client.collection_exists(coll),
+            )
             if vector is None:
                 continue
             payload = {
@@ -160,7 +152,12 @@ def upsert_memory(project_id: str, items: list[dict]) -> int:
         vectors = []
         for i in range(0, len(texts), embed_batch_size):
             batch_texts = texts[i:i + embed_batch_size]
-            batch_vectors = _get_embeddings_batch(batch_texts)
+            batch_vectors = _get_embeddings_batch_for_collection(
+                client,
+                coll,
+                batch_texts,
+                create_if_missing=not client.collection_exists(coll),
+            )
             vectors.extend(batch_vectors)
 
         points = []
@@ -242,10 +239,6 @@ def search(project_id: str, query_text: str, kind: str = "focused", limit: int =
     if not _check_qdrant_available():
         return empty_result
 
-    qvec = _get_embedding_safe(query_text)
-    if qvec is None:
-        return empty_result
-
     # Collection config: (name, collection_fn, payload_fields)
     _SEARCH_COLLECTIONS = {
         "docs": (_docs_collection, ["doc_path", "tags", "concepts"]),
@@ -296,6 +289,10 @@ def search(project_id: str, query_text: str, kind: str = "focused", limit: int =
         try:
             coll_name = coll_fn(project_id)
             if client.collection_exists(coll_name):
+                qvec = _get_embedding_for_collection(client, coll_name, query_text, create_if_missing=False)
+                if qvec is None:
+                    results[kind_name] = []
+                    continue
                 resp = client.query_points(
                     collection_name=coll_name, query=qvec, limit=limit,
                     with_payload=True, query_filter=query_filter)
@@ -320,7 +317,15 @@ def search(project_id: str, query_text: str, kind: str = "focused", limit: int =
             if kind_name not in _SEARCH_COLLECTIONS:
                 continue
             coll_fn, fields = _SEARCH_COLLECTIONS[kind_name]
-            raw = _rest_search(coll_fn(project_id), qvec, limit)
+            coll_name = coll_fn(project_id)
+            if client.collection_exists(coll_name):
+                qvec = _get_embedding_for_collection(client, coll_name, query_text, create_if_missing=False)
+            else:
+                qvec = None
+            if qvec is None:
+                results[kind_name] = []
+                continue
+            raw = _rest_search(coll_name, qvec, limit)
             results[kind_name] = [
                 {"score": d.get('score', 0.0),
                  **{f: (d.get('payload') or {}).get(f) for f in fields}}

--- a/tests/unit/cli/test_project_search_docs_regressions.py
+++ b/tests/unit/cli/test_project_search_docs_regressions.py
@@ -18,7 +18,6 @@ def test_project_search_focused_includes_docs_by_default():
     client = type("DummyClient", (), {"collection_exists": lambda self, name: False})()
 
     with patch("empirica.core.qdrant.memory._check_qdrant_available", return_value=True), \
-         patch("empirica.core.qdrant.memory._get_embedding_safe", return_value=[0.1, 0.2, 0.3]), \
          patch("empirica.core.qdrant.memory._get_qdrant_client", return_value=client):
         results = search("project-id", "workflow state model")
 

--- a/tests/unit/test_qdrant_retrieval_regressions.py
+++ b/tests/unit/test_qdrant_retrieval_regressions.py
@@ -7,6 +7,10 @@ from empirica.cli.command_handlers.project_embed import (
     _has_indexed_python_files,
     _resolve_doc_path,
 )
+from empirica.core.qdrant.connection import (
+    CollectionDimensionMismatchError,
+    _ensure_collection_matches_vector,
+)
 from empirica.core.qdrant.embeddings import EmbeddingsProvider
 from empirica.core.qdrant.memory import upsert_docs
 
@@ -74,8 +78,8 @@ def test_upsert_docs_creates_collection_before_upsert():
     client.upsert_calls = []
     client.collection_exists = lambda name: False
 
-    def create_collection(name, vectors_config):
-        client.created = (name, vectors_config)
+    def create_collection(name=None, vectors_config=None, collection_name=None):
+        client.created = (collection_name or name, vectors_config)
 
     def upsert(collection_name, points):
         client.upsert_calls.append((collection_name, points))
@@ -86,17 +90,48 @@ def test_upsert_docs_creates_collection_before_upsert():
     with patch("empirica.core.qdrant.memory._check_qdrant_available", return_value=True), \
          patch("empirica.core.qdrant.memory._get_qdrant_imports", return_value=(None, DummyDistance, DummyVectorParams, DummyPointStruct)), \
          patch("empirica.core.qdrant.memory._get_qdrant_client", return_value=client), \
-         patch("empirica.core.qdrant.memory._get_vector_size", return_value=384), \
-         patch("empirica.core.qdrant.memory._get_embedding_safe", return_value=[0.1, 0.2, 0.3]), \
+         patch("empirica.core.qdrant.connection._get_qdrant_imports", return_value=(None, DummyDistance, DummyVectorParams, DummyPointStruct)), \
+         patch("empirica.core.qdrant.connection._get_embedding_safe", return_value=[0.1, 0.2, 0.3]), \
          patch("empirica.core.qdrant.memory._docs_collection", return_value="project_test_docs"):
         count = upsert_docs("project-id", [{"id": 1, "text": "hello", "metadata": {"doc_path": "a.md"}}])
 
     assert count == 1
     assert client.created is not None
     assert client.created[0] == "project_test_docs"
-    assert client.created[1].size == 384
+    assert client.created[1].size == 3
     assert client.created[1].distance == DummyDistance.COSINE
     assert len(client.upsert_calls) == 1
+
+
+def test_dimension_guard_raises_before_mismatched_qdrant_write():
+    class DummyCollectionInfo:
+        class Config:
+            class Params:
+                class Vectors:
+                    size = 1024
+
+                vectors = Vectors()
+
+            params = Params()
+
+        config = Config()
+
+    client = type("DummyClient", (), {})()
+    client.collection_exists = lambda name: True
+    client.get_collection = lambda name: DummyCollectionInfo()
+
+    with patch("empirica.core.qdrant.connection._get_provider_context", return_value="ollama/nomic-embed-text"):
+        try:
+            _ensure_collection_matches_vector(client, "epistemic_events", 768, create_if_missing=False)
+            raised = None
+        except Exception as exc:  # pragma: no branch - assertion below validates type
+            raised = exc
+
+    assert isinstance(raised, CollectionDimensionMismatchError)
+    assert "epistemic_events" in str(raised)
+    assert "1024d" in str(raised)
+    assert "768d" in str(raised)
+    assert "rebuild --qdrant" in str(raised)
 
 
 def test_embed_ollama_retries_with_smaller_prompts_before_fallback():


### PR DESCRIPTION
## Summary

This PR adds a shared Qdrant dimension guard so Empirica stops before a mismatched semantic write instead of letting collection schema and embedding size drift apart.

Fixes Nubaeon/empirica#82.

## Root Cause

Empirica could create a collection using `_get_vector_size()` and later write into it using `_get_embedding_safe()`. If the configured embedding model changed, or `_get_vector_size()` fell back differently from the live embedding provider, the collection and write-time vector length could diverge.

That was especially easy to hit with `nomic-embed-text` (768d) after existing 1024d collections had already been created.

## What Changed

- added `CollectionDimensionMismatchError` plus shared helpers in `empirica/core/qdrant/connection.py`
- collections can now be created lazily from the actual embedding length used on first write
- existing collections are validated before writes and searches, with an explicit `empirica rebuild --qdrant` hint on mismatch
- wired the guard into the core memory path and `QdrantBusObserver` / `epistemic_events`
- tightened `setup-claude-code` output so `nomic-embed-text` warns about the rebuild path instead of looking like a harmless alternative
- updated and expanded regression tests around collection creation and mismatch detection

## Validation

- `pytest tests/unit/test_qdrant_retrieval_regressions.py -q`
- `pytest tests/unit/cli/test_project_search_docs_regressions.py -q`
- `pytest tests/unit/cli/test_project_search_project_resolution.py -q`
- `python -m compileall empirica/core/qdrant/connection.py empirica/core/qdrant/memory.py empirica/core/bus_persistence.py empirica/cli/command_handlers/setup_claude_code.py`