### PR TITLE
fix(windows): use os.replace for sentinel state files

### DIFF
--- a/empirica/cli/command_handlers/artifact_log_commands.py
+++ b/empirica/cli/command_handlers/artifact_log_commands.py
@@ -440,7 +440,7 @@ def handle_engagement_focus_command(args):
                 try:
                     with os.fdopen(tmp_fd, 'w') as tmp_f:
                         json.dump(tx_data, tmp_f, indent=2)
-                    os.rename(tmp_path, str(tx_path))
+                    os.replace(tmp_path, str(tx_path))
                 except BaseException:
                     try:
                         os.unlink(tmp_path)

--- a/empirica/cli/command_handlers/session_create.py
+++ b/empirica/cli/command_handlers/session_create.py
@@ -545,7 +545,7 @@ def handle_session_create_command(args):
         # The project_path in the JSON tells us which project's DB to use
         active_session_file = Path.home() / '.empirica' / f'active_session{instance_suffix}'
         active_session_file.parent.mkdir(parents=True, exist_ok=True)
-        # Atomic write: temp file + rename prevents partial reads from concurrent access
+        # Atomic write: temp file + replace prevents partial reads from concurrent access
         # Store JSON with session_id AND project_path so statusline can find
         # the correct DB even when cwd changes (prevents user confusion about data loss)
         import json as _json
@@ -564,7 +564,7 @@ def handle_session_create_command(args):
         try:
             with os.fdopen(tmp_fd, 'w') as tmp_f:
                 tmp_f.write(_json.dumps(active_session_data))
-            os.rename(tmp_path, str(active_session_file))
+            os.replace(tmp_path, str(active_session_file))
         except BaseException:
             try:
                 os.unlink(tmp_path)

--- a/empirica/cli/command_handlers/workflow_commands.py
+++ b/empirica/cli/command_handlers/workflow_commands.py
@@ -470,7 +470,7 @@ def handle_preflight_submit_command(args):
                                 fd, tmp = _tempfile.mkstemp(dir=str(tx_path.parent))
                                 with os.fdopen(fd, 'w') as tf:
                                     _json.dump(tx_data, tf, indent=2)
-                                os.rename(tmp, str(tx_path))
+                                os.replace(tmp, str(tx_path))
                     except Exception as e_avg:
                         logger.debug(f"Avg turns calculation failed (non-fatal): {e_avg}")
             except Exception as e:

--- a/empirica/plugins/claude-code-integration/hooks/context-shift-tracker.py
+++ b/empirica/plugins/claude-code-integration/hooks/context-shift-tracker.py
@@ -138,7 +138,7 @@ def main():
         try:
             with os.fdopen(fd, 'w') as tf:
                 json.dump(counters, tf, indent=2)
-            os.rename(tmp, str(counters_path))
+            os.replace(tmp, str(counters_path))
         except BaseException:
             try:
                 os.unlink(tmp)

--- a/empirica/plugins/claude-code-integration/hooks/sentinel-gate.py
+++ b/empirica/plugins/claude-code-integration/hooks/sentinel-gate.py
@@ -669,7 +669,7 @@ def _try_increment_tool_count(claude_session_id: str | None = None,
         try:
             with os.fdopen(fd, 'w') as tf:
                 json.dump(counters, tf, indent=2)
-            os.rename(tmp, str(counters_path))
+            os.replace(tmp, str(counters_path))
         except BaseException:
             try:
                 os.unlink(tmp)

--- a/empirica/plugins/claude-code-integration/hooks/subagent-stop.py
+++ b/empirica/plugins/claude-code-integration/hooks/subagent-stop.py
@@ -151,7 +151,7 @@ def add_delegated_work_to_parent(tool_call_count: int) -> bool:
         try:
             with os.fdopen(fd, 'w') as tf:
                 json.dump(counters, tf, indent=2)
-            os.rename(tmp, str(counters_path))
+            os.replace(tmp, str(counters_path))
         except BaseException:
             try:
                 os.unlink(tmp)

--- a/empirica/utils/session_resolver.py
+++ b/empirica/utils/session_resolver.py
@@ -1029,7 +1029,7 @@ def write_active_transaction(
     try:
         with os.fdopen(tmp_fd, 'w') as tmp_f:
             json.dump(tx_data, tmp_f, indent=2)
-        os.rename(tmp_path, str(path))
+        os.replace(tmp_path, str(path))
     except BaseException:
         try:
             os.unlink(tmp_path)
@@ -1077,7 +1077,7 @@ def increment_transaction_tool_count(claude_session_id: str = None) -> dict | No
         try:
             with __import__('os').fdopen(tmp_fd, 'w') as tmp_f:
                 json.dump(tx_data, tmp_f, indent=2)
-            __import__('os').rename(tmp_path, str(tx_path))
+            __import__('os').replace(tmp_path, str(tx_path))
         except BaseException:
             try:
                 __import__('os').unlink(tmp_path)
@@ -1245,7 +1245,7 @@ def set_active_engagement(engagement_id: str, claude_session_id: str = None) -> 
         try:
             with os.fdopen(tmp_fd, 'w') as tmp_f:
                 json.dump(tx_data, tmp_f, indent=2)
-            os.rename(tmp_path, str(tx_path))
+            os.replace(tmp_path, str(tx_path))
         except BaseException:
             try:
                 os.unlink(tmp_path)

--- a/tests/unit/test_windows_atomic_state_writes.py
+++ b/tests/unit/test_windows_atomic_state_writes.py
@@ -1,0 +1,42 @@
+import json
+import os
+from pathlib import Path
+
+from empirica.utils import session_resolver
+
+
+def test_write_active_transaction_overwrites_existing_file_with_os_replace(monkeypatch, tmp_path):
+    """Regression: Windows os.rename() cannot overwrite an existing sentinel file."""
+    monkeypatch.setattr(session_resolver, "_get_instance_suffix", lambda: "_win-default")
+
+    replace_calls: list[tuple[str, str]] = []
+    original_replace = os.replace
+
+    def tracking_replace(src: str, dst: str) -> None:
+        replace_calls.append((src, dst))
+        original_replace(src, dst)
+
+    def fail_rename(*_args, **_kwargs):
+        raise AssertionError("write_active_transaction should use os.replace, not os.rename")
+
+    monkeypatch.setattr(os, "replace", tracking_replace)
+    monkeypatch.setattr(os, "rename", fail_rename)
+
+    tx_path = tmp_path / ".empirica" / "active_transaction_win-default.json"
+    tx_path.parent.mkdir(parents=True, exist_ok=True)
+    tx_path.write_text('{"transaction_id":"stale","status":"closed"}', encoding="utf-8")
+
+    session_resolver.write_active_transaction(
+        transaction_id="new-transaction-id",
+        session_id="new-session-id",
+        preflight_timestamp=123.0,
+        status="open",
+        project_path=str(tmp_path),
+    )
+
+    written = json.loads(tx_path.read_text(encoding="utf-8"))
+    assert written["transaction_id"] == "new-transaction-id"
+    assert written["session_id"] == "new-session-id"
+    assert written["status"] == "open"
+    assert replace_calls
+    assert Path(replace_calls[0][1]) == tx_path


### PR DESCRIPTION
## Summary
This replaces Windows-unsafe `os.rename(...)` overwrite calls in the Claude/Sentinel state-file paths with `os.replace(...)`.

On Windows, `os.rename(tmp, dst)` raises `FileExistsError` when `dst` already exists. That can leave stale `.empirica/active_transaction*.json` and related state files behind even though the DB transaction advanced successfully, which in turn makes Sentinel read a closed transaction and block the next praxic tool.

Fixes #84.

## What changed
- Replaced overwrite writes from `os.rename(...)` to `os.replace(...)` in:
  - `empirica/utils/session_resolver.py`
  - `empirica/cli/command_handlers/workflow_commands.py`
  - `empirica/cli/command_handlers/session_create.py`
  - `empirica/cli/command_handlers/artifact_log_commands.py`
  - `empirica/plugins/claude-code-integration/hooks/sentinel-gate.py`
  - `empirica/plugins/claude-code-integration/hooks/context-shift-tracker.py`
  - `empirica/plugins/claude-code-integration/hooks/subagent-stop.py`
- Added a regression test that fails if `write_active_transaction(...)` falls back to `os.rename(...)` and verifies overwriting an existing sentinel file succeeds.

## Validation
- `pytest tests/test_session_resolver.py tests/unit/test_windows_atomic_state_writes.py -q`
- Manual Windows repro: `os.rename(tmp, existing_dst)` raises `FileExistsError`, while `os.replace(tmp, existing_dst)` succeeds on the same machine.
