### PR TITLE
fix: use CWD when EMPIRICA_CWD_RELIABLE is set in get_active_project_path

### DIFF
--- a/empirica/utils/session_resolver.py
+++ b/empirica/utils/session_resolver.py
@@ -881,7 +881,8 @@ def get_active_project_path(claude_session_id: str | None = None) -> 'str | None
     CANONICAL function for project resolution. All components should use this
     instead of implementing their own priority chain.
 
-    Priority chain (NO CWD FALLBACK):
+    Priority chain:
+    -1. CWD when EMPIRICA_CWD_RELIABLE=true (caller verified CWD is the project root)
     0. instance_projects/{instance_id}.json - AUTHORITATIVE (updated by hooks AND project-switch CLI)
     1. active_work_{claude_session_id}.json - fallback (only hooks can update, not CLI)
     2. active_work.json - generic fallback (written by project-switch and session-init)
@@ -890,6 +891,10 @@ def get_active_project_path(claude_session_id: str | None = None) -> 'str | None
     AND the project-switch CLI command. active_work is ONLY updated by hooks (which
     have claude_session_id from stdin). project-switch CLI can't update active_work
     because it doesn't know claude_session_id. Therefore instance_projects is more current.
+
+    The CWD override (priority -1) exists because session-init.py chdir's to the
+    resolved project root BEFORE spawning session-create. Without it, session-create
+    reads stale instance_projects data from the previous session.
 
     Args:
         claude_session_id: Optional Claude Code conversation UUID (from hook input)
@@ -906,6 +911,13 @@ def get_active_project_path(claude_session_id: str | None = None) -> 'str | None
         project_path = get_active_project_path()
     """
     from pathlib import Path
+
+    # Priority -1: CWD when caller has verified it (session-init sets this after chdir)
+    if os.environ.get('EMPIRICA_CWD_RELIABLE', '').lower() == 'true':
+        cwd = str(Path.cwd())
+        if (Path(cwd) / '.empirica' / 'project.yaml').exists():
+            logger.debug(f"get_active_project_path: from CWD (EMPIRICA_CWD_RELIABLE): {cwd}")
+            return cwd
 
     active_work_path = None
     instance_path = None

--- a/tests/test_session_resolver.py
+++ b/tests/test_session_resolver.py
@@ -129,5 +129,79 @@ def test_resolve_invalid_alias():
         resolve_session_id("latest:nonexistent-ai-xyz-12345")
 
 
+class TestGetActiveProjectPath:
+    """Tests for get_active_project_path CWD-reliable override (issue #90)."""
+
+    def test_cwd_reliable_with_project_yaml(self, tmp_path, monkeypatch):
+        """When EMPIRICA_CWD_RELIABLE=true and CWD has .empirica/project.yaml, return CWD."""
+        from empirica.utils.session_resolver import get_active_project_path
+
+        empirica_dir = tmp_path / '.empirica'
+        empirica_dir.mkdir()
+        (empirica_dir / 'project.yaml').write_text('project_id: test-123\n')
+
+        monkeypatch.setenv('EMPIRICA_CWD_RELIABLE', 'true')
+        monkeypatch.chdir(tmp_path)
+
+        result = get_active_project_path()
+        assert result == str(tmp_path)
+
+    def test_cwd_reliable_without_project_yaml(self, tmp_path, monkeypatch):
+        """When EMPIRICA_CWD_RELIABLE=true but no project.yaml, fall through to other sources."""
+        from empirica.utils.session_resolver import get_active_project_path
+
+        monkeypatch.setenv('EMPIRICA_CWD_RELIABLE', 'true')
+        monkeypatch.chdir(tmp_path)
+
+        # Should NOT return tmp_path (no .empirica/project.yaml guard)
+        result = get_active_project_path()
+        assert result != str(tmp_path) or result is None
+
+    def test_no_cwd_reliable_flag(self, tmp_path, monkeypatch):
+        """Without EMPIRICA_CWD_RELIABLE, CWD is never used even with project.yaml."""
+        from empirica.utils.session_resolver import get_active_project_path
+
+        empirica_dir = tmp_path / '.empirica'
+        empirica_dir.mkdir()
+        (empirica_dir / 'project.yaml').write_text('project_id: test-123\n')
+
+        monkeypatch.delenv('EMPIRICA_CWD_RELIABLE', raising=False)
+        monkeypatch.chdir(tmp_path)
+
+        result = get_active_project_path()
+        # Should NOT return CWD — falls through to instance_projects/active_work
+        assert result != str(tmp_path) or result is None
+
+    def test_cwd_reliable_beats_stale_instance_projects(self, tmp_path, monkeypatch):
+        """CWD override takes priority over stale instance_projects data."""
+        from empirica.utils.session_resolver import get_active_project_path
+
+        # Set up CWD project
+        cwd_project = tmp_path / 'current_project'
+        cwd_project.mkdir()
+        empirica_dir = cwd_project / '.empirica'
+        empirica_dir.mkdir()
+        (empirica_dir / 'project.yaml').write_text('project_id: current\n')
+
+        # Set up stale instance_projects pointing to a different project
+        stale_project = tmp_path / 'stale_project'
+        stale_project.mkdir()
+        instance_dir = tmp_path / 'home' / '.empirica' / 'instance_projects'
+        instance_dir.mkdir(parents=True)
+        import json
+        (instance_dir / 'win-default.json').write_text(json.dumps({
+            'project_path': str(stale_project)
+        }))
+
+        monkeypatch.setenv('EMPIRICA_CWD_RELIABLE', 'true')
+        monkeypatch.setenv('EMPIRICA_INSTANCE_ID', 'win-default')
+        monkeypatch.setenv('HOME', str(tmp_path / 'home'))
+        monkeypatch.setenv('USERPROFILE', str(tmp_path / 'home'))
+        monkeypatch.chdir(cwd_project)
+
+        result = get_active_project_path()
+        assert result == str(cwd_project)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

- `get_active_project_path()` now checks `EMPIRICA_CWD_RELIABLE=true` and uses CWD as the highest-priority source (priority -1), guarded by `.empirica/project.yaml` existence
- Fixes a race condition where `session-create` reads stale `instance_projects` data before `session-init` can update it, causing `active_session_win-default` to be stamped with the wrong project path

## Root Cause

`session-init.py:main()` calls `create_session_and_bootstrap()` (which shells out to `empirica session-create`) **before** calling `_write_instance_projects()`. Inside `session-create`, `_write_active_session_file()` calls `R.project_path()` → `get_active_project_path(None)`, which reads `instance_projects/{instance_id}.json` — still pointing to the **previous** session's project.

On Windows without tmux, all terminals share `instance_id = "win-default"`, so two concurrent VS Code windows always race over the same singleton file.

`session-init.py` already sets `EMPIRICA_CWD_RELIABLE=true` in the subprocess env (line 255) and does `os.chdir(project_root)` (line 904) before the call. The intent was there — the wiring in `get_active_project_path()` was missing.

## Changes

- **`empirica/utils/session_resolver.py`**: Added CWD check at the top of `get_active_project_path()` when `EMPIRICA_CWD_RELIABLE=true` is set. Guarded by `.empirica/project.yaml` existence to prevent false matches from arbitrary directories.
- **`tests/test_session_resolver.py`**: Added 4 tests covering: CWD with project.yaml, CWD without project.yaml (falls through), no env var (falls through), CWD beats stale instance_projects.

## Test plan

- [x] `test_cwd_reliable_with_project_yaml` — returns CWD when flag set and project.yaml exists
- [x] `test_cwd_reliable_without_project_yaml` — falls through when no project.yaml guard
- [x] `test_no_cwd_reliable_flag` — no behavior change without the env var
- [x] `test_cwd_reliable_beats_stale_instance_projects` — CWD wins over stale instance_projects
- [x] Existing tests unaffected (6 passed, 8 skipped, 1 pre-existing failure in `test_resolve_invalid_alias`)
- [x] Manual verification: applied fix to site-packages, confirmed correct resolution across three scenarios

Fixes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)