### PR TITLE
test: tighten TestGetActiveProjectPath env isolation + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to Empirica will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **Session-create race on concurrent Claude Code sessions** (#90, #91 by
+  @kars85) — `session-init.py` called `create_session_and_bootstrap()` before
+  `_write_instance_projects()`, so the subprocess's `session-create` read stale
+  `instance_projects/{instance_id}.json` from a previous session. On Windows
+  without tmux, all terminals share `instance_id=win-default`, making the race
+  reliably reproducible with two concurrent VS Code windows in different
+  projects. `active_session_{instance_id}` ended up stamped with the wrong
+  `project_path`, failing epistemic gates with "project not found". Fix extends
+  the existing `EMPIRICA_CWD_RELIABLE` env-var contract (already consumed by
+  `path_resolver.py` for cross-project bleed detection) to
+  `session_resolver.get_active_project_path()` — CWD wins at priority -1 when
+  the flag is set and `.empirica/project.yaml` exists in CWD.
+
+### Tests
+- Tightened `TestGetActiveProjectPath` fallthrough tests to isolate `HOME` and
+  pin an unused `EMPIRICA_INSTANCE_ID`, so `get_instance_id()` can't read the
+  developer's real `~/.empirica/instance_projects/` during test runs. Weak
+  `result != str(tmp_path) or result is None` assertions replaced with strict
+  `result is None`.
+
 ## [1.8.10] - 2026-04-23
 
 ### Added

--- a/tests/test_session_resolver.py
+++ b/tests/test_session_resolver.py
@@ -132,48 +132,68 @@ def test_resolve_invalid_alias():
 class TestGetActiveProjectPath:
     """Tests for get_active_project_path CWD-reliable override (issue #90)."""
 
+    @staticmethod
+    def _isolate_home(tmp_path, monkeypatch):
+        """Redirect HOME/USERPROFILE to tmp_path so get_instance_id() can't
+        read the developer's real ~/.empirica/instance_projects/. Pins an
+        isolated instance_id that points at a non-existent file so the
+        fallthrough paths return None rather than opportunistic matches."""
+        fake_home = tmp_path / 'home'
+        fake_home.mkdir(exist_ok=True)
+        monkeypatch.setenv('HOME', str(fake_home))
+        monkeypatch.setenv('USERPROFILE', str(fake_home))
+        monkeypatch.setenv('EMPIRICA_INSTANCE_ID', 'test-isolated')
+
     def test_cwd_reliable_with_project_yaml(self, tmp_path, monkeypatch):
         """When EMPIRICA_CWD_RELIABLE=true and CWD has .empirica/project.yaml, return CWD."""
         from empirica.utils.session_resolver import get_active_project_path
 
-        empirica_dir = tmp_path / '.empirica'
-        empirica_dir.mkdir()
+        self._isolate_home(tmp_path, monkeypatch)
+        project_dir = tmp_path / 'project'
+        empirica_dir = project_dir / '.empirica'
+        empirica_dir.mkdir(parents=True)
         (empirica_dir / 'project.yaml').write_text('project_id: test-123\n')
 
         monkeypatch.setenv('EMPIRICA_CWD_RELIABLE', 'true')
-        monkeypatch.chdir(tmp_path)
+        monkeypatch.chdir(project_dir)
 
         result = get_active_project_path()
-        assert result == str(tmp_path)
+        assert result == str(project_dir)
 
     def test_cwd_reliable_without_project_yaml(self, tmp_path, monkeypatch):
         """When EMPIRICA_CWD_RELIABLE=true but no project.yaml, fall through to other sources."""
         from empirica.utils.session_resolver import get_active_project_path
 
+        self._isolate_home(tmp_path, monkeypatch)
         monkeypatch.setenv('EMPIRICA_CWD_RELIABLE', 'true')
         monkeypatch.chdir(tmp_path)
 
-        # Should NOT return tmp_path (no .empirica/project.yaml guard)
+        # No project.yaml guard, no instance_projects file, no active_work — must be None
         result = get_active_project_path()
-        assert result != str(tmp_path) or result is None
+        assert result is None
 
     def test_no_cwd_reliable_flag(self, tmp_path, monkeypatch):
         """Without EMPIRICA_CWD_RELIABLE, CWD is never used even with project.yaml."""
         from empirica.utils.session_resolver import get_active_project_path
 
-        empirica_dir = tmp_path / '.empirica'
-        empirica_dir.mkdir()
+        self._isolate_home(tmp_path, monkeypatch)
+        project_dir = tmp_path / 'project'
+        empirica_dir = project_dir / '.empirica'
+        empirica_dir.mkdir(parents=True)
         (empirica_dir / 'project.yaml').write_text('project_id: test-123\n')
 
         monkeypatch.delenv('EMPIRICA_CWD_RELIABLE', raising=False)
-        monkeypatch.chdir(tmp_path)
+        monkeypatch.chdir(project_dir)
 
+        # No flag means CWD check never fires; with isolated HOME the fallthrough
+        # finds nothing either, so the result must be None.
         result = get_active_project_path()
-        # Should NOT return CWD — falls through to instance_projects/active_work
-        assert result != str(tmp_path) or result is None
+        assert result is None
 
     def test_cwd_reliable_beats_stale_instance_projects(self, tmp_path, monkeypatch):
         """CWD override takes priority over stale instance_projects data."""
+        import json
+
         from empirica.utils.session_resolver import get_active_project_path
 
         # Set up CWD project
@@ -188,7 +208,6 @@ class TestGetActiveProjectPath:
         stale_project.mkdir()
         instance_dir = tmp_path / 'home' / '.empirica' / 'instance_projects'
         instance_dir.mkdir(parents=True)
-        import json
         (instance_dir / 'win-default.json').write_text(json.dumps({
             'project_path': str(stale_project)
         }))


### PR DESCRIPTION
## Summary

Follow-up to #91. Hardens the two fallthrough tests added in that PR and adds a CHANGELOG entry crediting @kars85.

### The weakness

`test_cwd_reliable_without_project_yaml` and `test_no_cwd_reliable_flag` didn't monkeypatch `HOME`/`USERPROFILE`, so `get_instance_id()` could read the developer's real `~/.empirica/instance_projects/` during test runs. Their assertions used `result != str(tmp_path) or result is None` — which passes opportunistically whenever the dev's instance_projects happens to not point at `tmp_path`, rather than confirming the expected fallthrough behavior.

### The fix

- New `_isolate_home` helper redirects `HOME`/`USERPROFILE` to `tmp_path` and pins `EMPIRICA_INSTANCE_ID` to a value with no backing file, guaranteeing fallthrough returns `None`.
- Tightened assertions to strict `result is None`.
- No behavior change to `test_cwd_reliable_beats_stale_instance_projects` — it was already correctly isolated.

### CHANGELOG

Added `[Unreleased]` section documenting both #91 and this test hardening, crediting @kars85 for the original fix.

## Test plan

- [x] `pytest tests/test_session_resolver.py::TestGetActiveProjectPath -v` — 4 passed (0.04s)
- [x] No behavior change to production code (`session_resolver.py` untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)