### PR TITLE
fix(chocolatey): fix Windows install scripts + wire choco push into release pipeline

### DIFF
--- a/packaging/chocolatey/tools/chocolateyinstall.ps1
+++ b/packaging/chocolatey/tools/chocolateyinstall.ps1
@@ -29,6 +29,7 @@ if ($pythonVersion -notmatch 'Python 3\.(1[1-9]|[2-9]\d)') {
 # Install via pip
 Write-Host "Installing Empirica via pip..." -ForegroundColor Cyan
 $pipArgs = @(
+    '-m', 'pip',
     'install',
     '--upgrade',
     "empirica==$packageVersion"
@@ -41,7 +42,7 @@ $exitCode = Start-ChocolateyProcessAsAdmin `
     -WorkingDirectory $env:TEMP
 
 if ($exitCode -eq 0) {
-    Write-Host "✓ Empirica installed successfully!" -ForegroundColor Green
+    Write-Host "Empirica installed successfully!" -ForegroundColor Green
     Write-Host ""
     Write-Host "Quick Start:" -ForegroundColor Cyan
     Write-Host "  empirica bootstrap --ai-id myagent --level extended"

--- a/packaging/chocolatey/tools/chocolateyuninstall.ps1
+++ b/packaging/chocolatey/tools/chocolateyuninstall.ps1
@@ -8,6 +8,7 @@ Write-Host "Uninstalling Empirica..." -ForegroundColor Cyan
 
 # Uninstall via pip
 $pipArgs = @(
+    '-m', 'pip',
     'uninstall',
     '-y',
     'empirica'
@@ -20,7 +21,7 @@ $exitCode = Start-ChocolateyProcessAsAdmin `
     -WorkingDirectory $env:TEMP
 
 if ($exitCode -eq 0) {
-    Write-Host "✓ Empirica uninstalled successfully!" -ForegroundColor Green
+    Write-Host "Empirica uninstalled successfully!" -ForegroundColor Green
 } else {
     Write-Warning "Uninstallation may have failed with exit code: $exitCode"
 }

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -254,9 +254,16 @@ class ReleaseManager:
 
     def build_and_push_chocolatey(self):
         """Build Chocolatey .nupkg and push to chocolatey.org"""
+        import os
+        import shutil
+
         log("\n" + "=" * 60)
         log("🍫 Building and pushing Chocolatey package")
         log("=" * 60)
+
+        if not shutil.which("choco"):
+            info("choco CLI not found — skipping Chocolatey publish (run from Windows or a Choco-enabled CI runner)")
+            return
 
         choco_dir = self.repo_root / "packaging/chocolatey"
         nuspec = choco_dir / "empirica.nuspec"
@@ -272,9 +279,15 @@ class ReleaseManager:
         if not nupkg.exists() and not self.dry_run:
             error(f"Expected .nupkg not found: {nupkg}")
 
+        api_key = os.environ.get("CHOCOLATEY_API_KEY")
+        if not api_key:
+            warning("CHOCOLATEY_API_KEY not set — built .nupkg but skipping push (set the env var or run 'choco apikey set')")
+            return
+
         self.run_command([
             "choco", "push", str(nupkg),
             "--source", "https://push.chocolatey.org/",
+            "--api-key", api_key,
         ], cwd=str(choco_dir))
         success(f"Pushed to chocolatey.org: empirica {self.version}")
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -229,6 +229,55 @@ class ReleaseManager:
         else:
             info(f"Would update Chocolatey nuspec: {nuspec_path}")
 
+    def update_chocolatey_checksum(self):
+        """Update SHA256 checksum in Chocolatey install script"""
+        install_ps1 = self.repo_root / "packaging/chocolatey/tools/chocolateyinstall.ps1"
+        if not install_ps1.exists():
+            warning(f"Chocolatey install script not found: {install_ps1}")
+            return
+
+        if not self.tarball_sha256:
+            warning("No SHA256 available — skipping Chocolatey checksum update")
+            return
+
+        content = install_ps1.read_text()
+        content = re.sub(
+            r"\$checksum\s*=\s*'[a-fA-F0-9]+'",
+            f"$checksum = '{self.tarball_sha256}'",
+            content,
+        )
+        if not self.dry_run:
+            install_ps1.write_text(content)
+            success(f"Updated Chocolatey checksum: {install_ps1}")
+        else:
+            info(f"Would update Chocolatey checksum: {install_ps1}")
+
+    def build_and_push_chocolatey(self):
+        """Build Chocolatey .nupkg and push to chocolatey.org"""
+        log("\n" + "=" * 60)
+        log("🍫 Building and pushing Chocolatey package")
+        log("=" * 60)
+
+        choco_dir = self.repo_root / "packaging/chocolatey"
+        nuspec = choco_dir / "empirica.nuspec"
+        if not nuspec.exists():
+            warning(f"Chocolatey nuspec not found: {nuspec}")
+            return
+
+        nupkg = choco_dir / f"empirica.{self.version}.nupkg"
+
+        self.run_command(["choco", "pack"], cwd=str(choco_dir))
+        success(f"Built: {nupkg}")
+
+        if not nupkg.exists() and not self.dry_run:
+            error(f"Expected .nupkg not found: {nupkg}")
+
+        self.run_command([
+            "choco", "push", str(nupkg),
+            "--source", "https://push.chocolatey.org/",
+        ], cwd=str(choco_dir))
+        success(f"Pushed to chocolatey.org: empirica {self.version}")
+
     def update_version_strings(self):
         """Update version strings in all source files not covered by other methods.
 
@@ -926,6 +975,7 @@ brew install empirica
             self.update_homebrew_formula()
             self.update_dockerfile()
             self.update_chocolatey_nuspec()
+            self.update_chocolatey_checksum()
 
             # Gate: import smoke test
             if not self.run_import_check():
@@ -994,6 +1044,7 @@ brew install empirica
             self.build_and_push_docker()
             self.create_github_release()
             self.update_homebrew_tap()
+            self.build_and_push_chocolatey()
 
             # Switch back to develop
             if not self.dry_run:
@@ -1010,6 +1061,7 @@ brew install empirica
             info(f"Docker: docker pull nubaeon/empirica:{self.version}-alpine")
             info(f"GitHub: https://github.com/Nubaeon/empirica/releases/tag/v{self.version}")
             info(f"Homebrew: brew upgrade empirica")
+            info(f"Chocolatey: choco upgrade empirica")
 
         except Exception as e:
             error(f"Publish failed: {e}")
@@ -1050,6 +1102,7 @@ brew install empirica
             self.update_homebrew_formula()
             self.update_dockerfile()
             self.update_chocolatey_nuspec()
+            self.update_chocolatey_checksum()
 
             # Gate: import smoke test
             if not self.run_import_check():
@@ -1066,6 +1119,7 @@ brew install empirica
             self.build_and_push_docker()
             self.create_github_release()
             self.update_homebrew_tap()
+            self.build_and_push_chocolatey()
 
             # Switch back to develop
             if not self.dry_run:
@@ -1082,6 +1136,7 @@ brew install empirica
             info(f"Docker: docker pull nubaeon/empirica:{self.version}-alpine")
             info(f"GitHub: https://github.com/Nubaeon/empirica/releases/tag/v{self.version}")
             info(f"Homebrew: brew upgrade empirica")
+            info(f"Chocolatey: choco upgrade empirica")
 
         except Exception as e:
             error(f"Release failed: {e}")


### PR DESCRIPTION
## Summary

- **Fix Unicode parse failure**: Replace `✓` (checkmark) in `chocolateyinstall.ps1` and `chocolateyuninstall.ps1` that broke PowerShell string parsing — `choco install` and `choco uninstall` both failed with `The string is missing the terminator: ".`
- **Fix pip resolution in elevated context**: Use `python -m pip` instead of bare pip args via `Start-ChocolateyProcessAsAdmin`, which can't always resolve pip in the elevated process
- **Wire SHA256 into install script**: Add `update_chocolatey_checksum()` to `release.py` that flows the PyPI tarball SHA256 into `chocolateyinstall.ps1` (previously a TODO `0000…0000` placeholder)
- **Wire `choco push` into release pipeline**: Add `build_and_push_chocolatey()` to `release.py` — called from `--publish` and one-shot `run()` after Homebrew tap push, matching the existing pattern

## Context

Per #93 — preparing for Chocolatey package listing under my account. These are the foundational fixes needed before the first `choco push` to chocolatey.org.

## Test plan

- [x] `choco pack` builds `empirica.1.8.14.nupkg` cleanly
- [x] `choco install empirica -s . -y` succeeds (previously failed on Unicode parse error)
- [x] `empirica --version` confirms 1.8.14 installed
- [x] `choco uninstall empirica -y` succeeds (previously failed on same Unicode parse error)
- [x] `python scripts/release.py --dry-run --publish` shows Chocolatey pack/push steps in output
- [x] `python -c "import ast; ast.parse(open('scripts/release.py').read())"` — syntax valid

Tested on Windows 11 Enterprise, Chocolatey v2.4.1, Python 3.13.1.

Refs: #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)