### PR TITLE
chore: add CODEOWNERS for Windows/Chocolatey routing

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Windows & Chocolatey packaging — auto-route to @kars85
+packaging/chocolatey/    @kars85
+*.ps1                    @kars85
+docs/windows/            @kars85


### PR DESCRIPTION
## Summary
- Adds `.github/CODEOWNERS` routing `packaging/chocolatey/`, `*.ps1`, and `docs/windows/` to @kars85
- Enables auto-review assignment for Windows domain PRs
- Follow-up from #94 discussion with @Nubaeon

## Notes
Once `require_code_owner_reviews: true` is enabled on branch protection, domain PRs will auto-route without manual reviewer assignment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)