### PR TITLE
fix(dialect): translate strftime('%s', 'now') to EXTRACT(EPOCH FROM NOW())

### DIFF
--- a/empirica/data/schema/dialect.py
+++ b/empirica/data/schema/dialect.py
@@ -10,6 +10,7 @@ Transformations applied:
 - BOOLEAN DEFAULT 0 → BOOLEAN DEFAULT FALSE
 - BOOLEAN DEFAULT 1 → BOOLEAN DEFAULT TRUE
 - Column name 'do' → '"do"' (reserved word quoting)
+- strftime('%s', 'now') → EXTRACT(EPOCH FROM NOW())  (UNIX-epoch float default)
 """
 
 import logging
@@ -70,6 +71,20 @@ def adapt_schema_sql(sql: str, dialect: str) -> str:
         r'(\s+)(do)(\s+REAL)',
         r'\1"do"\3',
         adapted
+    )
+
+    # 5. strftime('%s', 'now') → EXTRACT(EPOCH FROM NOW())
+    # SQLite uses strftime to get a UNIX-epoch float for `created_at REAL` defaults
+    # (verification_schema.py:82, verification_schema.py:151, migrations.py:1085 in v1.9.0).
+    # Postgres has no strftime; EXTRACT(EPOCH FROM NOW()) returns DOUBLE PRECISION
+    # which auto-casts to REAL. Tolerant of optional whitespace inside the call.
+    # Without this translation, fresh project-bootstrap on a Postgres backend fails with
+    # `function strftime(unknown, unknown) does not exist` mid-migration.
+    adapted = re.sub(
+        r"strftime\s*\(\s*'%s'\s*,\s*'now'\s*\)",
+        "EXTRACT(EPOCH FROM NOW())",
+        adapted,
+        flags=re.IGNORECASE
     )
 
     return adapted


### PR DESCRIPTION
## Summary

Adds a fifth translation pattern to `adapt_schema_sql` in `empirica/data/schema/dialect.py` so PostgreSQL deployments can complete fresh schema migration. Closes Nubaeon/empirica#101.

The `strftime('%s', 'now')` SQLite default expression appears in `created_at REAL DEFAULT (...)` columns across:
- `empirica/data/schema/verification_schema.py:82` (verification_runs)
- `empirica/data/schema/verification_schema.py:151` (verification_issues)
- `empirica/data/migrations/migrations.py:1085` (extended schema)

The dialect adapter passed those defaults through unchanged, so PostgreSQL rejected schema creation with `function strftime(unknown, unknown) does not exist`.

## Translation

```
strftime('%s', 'now')   →   EXTRACT(EPOCH FROM NOW())
```

Both yield UNIX-epoch seconds. PostgreSQL `EXTRACT(EPOCH FROM NOW())` returns `DOUBLE PRECISION`, which auto-casts to `REAL`. The regex tolerates optional whitespace inside the call so future SQL formatting tweaks won't silently regress.

## Diff

Single file, +15 lines (5 lines of regex + 10 lines of comment explaining why):

```python
# 5. strftime('%s', 'now') → EXTRACT(EPOCH FROM NOW())
# SQLite uses strftime to get a UNIX-epoch float for `created_at REAL` defaults
# (verification_schema.py:82, verification_schema.py:151, migrations.py:1085 in v1.9.0).
# Postgres has no strftime; EXTRACT(EPOCH FROM NOW()) returns DOUBLE PRECISION
# which auto-casts to REAL. Tolerant of optional whitespace inside the call.
# Without this translation, fresh project-bootstrap on a Postgres backend fails with
# `function strftime(unknown, unknown) does not exist` mid-migration.
adapted = re.sub(
    r"strftime\s*\(\s*'%s'\s*,\s*'now'\s*\)",
    "EXTRACT(EPOCH FROM NOW())",
    adapted,
    flags=re.IGNORECASE
)
```

Inserted between the existing 4th transformation (`'do'` column quoting) and the `return adapted` at the bottom of `adapt_schema_sql`. Module docstring also updated to list the new transformation alongside the four existing ones.

## Regression-safety

- The regex only fires on the `dialect == "postgresql"` branch (line 35–36 of `adapt_schema_sql` early-returns for `sqlite`). **No behavior change for SQLite users.**
- Pattern is anchored to the literal string `strftime('%s', 'now')` with optional surrounding whitespace — any other `strftime(...)` call with different arguments (none currently exist in the codebase) would not match and would still pass through unchanged. If those appear later, they'll need their own translation rules and the failure will be loud (PostgreSQL rejecting the unknown function), not silent.
- Module docstring reflects the addition alongside the existing four transformations.

## Verification (local)

Repro before this change: `empirica project-bootstrap --project-id <fresh>` against PostgreSQL backend → failure with `strftime(unknown, unknown) does not exist`.

Verified after this change on Windows with two Python 3.13 site-packages installs of Empirica 1.9.0 (patched both copies, ran end-to-end):

```
empirica project-create --name <fresh-project> --path <path> --type infrastructure  # ok
empirica project-bootstrap --project-id <fresh-project> --depth auto                # ok ✓
empirica session-create --ai-id claude-code --project-id <fresh-project>            # ok
node <abc-empirica.mjs wrapper> --project-id <fresh-project> session-create         # ok
```

## What's NOT in this PR

- Tests for `adapt_schema_sql` — `tests/` doesn't currently have a `test_dialect.py`. Adding regression coverage for all five translations (the four existing + this new one) would be valuable but is its own change. Happy to follow up with a separate test PR if reviewers want.
- A broader audit of SQLite-only constructs across the schema (other date functions, `IF NOT EXISTS` semantics, etc.) — `strftime` was the load-bearing one for `project-bootstrap` since it appears in three different schemas; the rest deserve a dedicated audit pass that's separate from this hot-path fix.

## Discovery context

Surfaced while dogfooding `/abc` Phase C epistemic gates from a canonical-skill consumer fixture in a separate downstream project (`_config-selftest`). Every fresh-project cycle was skipping Gates 3/3.5/4 because `project-bootstrap` aborted before the schema was usable. Resolution narrative tracked downstream at `kars85/_config#68`.

---

🤖 Filed via cross-fork contribution from [`kars85/empirica`](https://github.com/kars85/empirica) (where I keep my workflow-specific branches). Backed by `kars85/empirica@3c93db58` already merged to that fork's `main`.
