### PR TITLE
fix(listener): gc no longer reaps live launchd-supervised workers

### DIFF
--- a/empirica/core/cockpit/listener_processes.py
+++ b/empirica/core/cockpit/listener_processes.py
@@ -77,6 +77,55 @@ def walk_listener_processes() -> list[dict]:
     return procs
 
 
+def _ai_id_from_listener_cmdline(cmdline: str) -> str | None:
+    """Extract the ai_id from a listener cmdline.
+
+    loop_listen: ``empirica loop listen --instance <ai_id>``.
+    log_tail:    grep filter ``"instance_id": "<ai_id>"``.
+    """
+    m = re.search(r"--instance\s+(\S+)", cmdline)
+    if m:
+        return m.group(1).strip("'\"")
+    m = re.search(r'"instance_id":\s*"([^"]+)"', cmdline)
+    if m:
+        return m.group(1)
+    return None
+
+
+def _is_supervised_listener(proc: dict) -> bool:
+    """True if a PID-1 ``loop_listen`` proc is a live OS-supervised worker.
+
+    macOS launchd reparents its supervised services to PID 1 (unlike
+    systemd-user, whose children's parent is the ``systemd --user`` process,
+    never PID 1). So on macOS a live launchd-backed worker looks exactly like an
+    orphan to the PPID-1 walk — without this check, ``gc --apply`` reaps live
+    workers (→ KeepAlive respawn → churn). Guarded to darwin only: on
+    systemd hosts PID 1 genuinely means orphaned, so the check must not run
+    there (it would protect real Linux orphans that coexist with a live
+    service). Only ``loop_listen`` is OS-supervised — a ``log_tail`` Monitor
+    bridge is per-session and is a genuine orphan when reparented. Delegates to
+    ``is_listener_running``, whose launchd branch was corrected in the
+    duplicate-listener fix.
+    """
+    if proc.get("kind") != "loop_listen":
+        return False
+    import sys
+    # getattr form avoids the static literal-narrowing that would otherwise
+    # mark the macOS branch unreachable on a non-darwin analysis host.
+    if getattr(sys, "platform", "") != "darwin":
+        return False
+    ai = _ai_id_from_listener_cmdline(proc.get("cmdline", ""))
+    if not ai:
+        return False
+    try:
+        from empirica.core.loop_scheduler.persistent_listener import (
+            is_listener_running,
+        )
+        return is_listener_running(ai)
+    except Exception:
+        return False
+
+
 def walk_orphan_listener_processes(ai_id: str | None = None) -> list[dict]:
     """Listener processes whose parent session is dead (reparented to PID 1).
 
@@ -96,7 +145,9 @@ def walk_orphan_listener_processes(ai_id: str | None = None) -> list[dict]:
             p for p in orphans
             if instance_re.search(p["cmdline"]) or tail_marker in p["cmdline"]
         ]
-    return orphans
+    # Drop live launchd-supervised workers — on macOS they're reparented to
+    # PID 1 and would otherwise be mis-flagged as orphans and reaped.
+    return [p for p in orphans if not _is_supervised_listener(p)]
 
 
 def reap_processes(

--- a/tests/test_listener_processes.py
+++ b/tests/test_listener_processes.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 import signal
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -221,3 +222,42 @@ def test_off_reaps_orphans_and_removes_state_file(tmp_path, monkeypatch, capsys)
     assert out['reaped_orphans'][0]['removed'] is True
     # next_step protocol unchanged
     assert out['next_step']['tool'] == 'TaskStop'
+
+
+# ─── launchd-supervised exclusion (prop_vicjvq4: gc reaped live workers) ──
+
+_IS_RUNNING = "empirica.core.loop_scheduler.persistent_listener.is_listener_running"
+
+
+def test_ai_id_from_listener_cmdline():
+    from empirica.core.cockpit.listener_processes import _ai_id_from_listener_cmdline as f
+    assert f("empirica loop listen --instance empirica-outreach") == "empirica-outreach"
+    assert f('tail -F x | grep \'"instance_id": "empirica-pilot"\'') == "empirica-pilot"
+    assert f("random unrelated command") is None
+
+
+def test_macos_excludes_launchd_backed_loop_listen_but_keeps_log_tail(monkeypatch):
+    """On macOS, launchd reparents live workers to PID 1 — they must NOT be
+    reaped when the service is up. A log_tail bridge stays a real orphan."""
+    monkeypatch.setattr(sys, "platform", "darwin")
+    with patch(_IS_RUNNING, return_value=True), _patched_ps():
+        orphans = walk_orphan_listener_processes()
+    assert all(o["kind"] != "loop_listen" for o in orphans)   # live workers spared
+    assert any(o["kind"] == "log_tail" for o in orphans)      # session bridge still orphan
+
+
+def test_macos_reaps_unbacked_loop_listen(monkeypatch):
+    """macOS but no loaded launchd service for the ai_id → genuine orphan."""
+    monkeypatch.setattr(sys, "platform", "darwin")
+    with patch(_IS_RUNNING, return_value=False), _patched_ps():
+        orphans = walk_orphan_listener_processes()
+    assert any(o["kind"] == "loop_listen" for o in orphans)
+
+
+def test_linux_unchanged_ppid1_is_orphan(monkeypatch):
+    """systemd-user supervision never reparents to PID 1, so PID 1 genuinely
+    means orphaned — the launchd exclusion must not run on linux."""
+    monkeypatch.setattr(sys, "platform", "linux")
+    with _patched_ps():
+        orphans = walk_orphan_listener_processes()
+    assert any(o["kind"] == "loop_listen" for o in orphans)


### PR DESCRIPTION
## Problem
Philipp independently verified (14/14, mesh `prop_vicjvq4`) that `empirica listener gc` reaps **live** launchd workers on macOS. `walk_orphan_listener_processes` flags every `PPID==1` listener proc as an orphan — but **launchd reparents its supervised services to PID 1** (unlike systemd-user, whose children's parent is `systemd --user`, never PID 1). So live launchd-backed workers look exactly like orphans; `gc --apply` kills them → KeepAlive respawn → exit-2 churn, no net cleanup.

Same OS-detection-gap class as the duplicate-listener fix (`ae3aa324d`).

## Fix
Exclude a `PPID==1` `loop_listen` proc from orphans when its ai_id is launchd-backed, reusing the (already launchd-correct) `is_listener_running`.
- **macOS-only** — on systemd hosts PID 1 genuinely means orphaned, so the exclusion must not run there (it would protect real Linux orphans coexisting with a live service).
- **`loop_listen`-only** — a `log_tail` Monitor bridge is per-session and is a genuine orphan when reparented.

## Tests
4 new (macOS excludes backed `loop_listen` + keeps `log_tail` orphan; macOS reaps unbacked; linux unchanged; ai_id extraction). 17/17 pass, ruff + pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)