### PR TITLE
feat(api): service-token guard for the hosted entity-mint endpoint

### DIFF
--- a/empirica/api/entity_mint_auth.py
+++ b/empirica/api/entity_mint_auth.py
@@ -1,0 +1,147 @@
+"""Service-token guard for the hosted entity-mint endpoint.
+
+Guards ``POST /api/v1/entities`` (the ``b068bedfd`` contact mint) when the
+per-org ``empirica serve`` daemon binds beyond loopback — the hosted-daemon
+deployment on Hetzner/EU. Self-hosted loopback daemons stay auth-free, so
+same-box consumers (e.g. a CRM MCP server) are unaffected.
+
+Co-spec: ``empirica-mesh-support/docs/entity-mint-service-token-spec.md``.
+Consumers: cortex OAuth P3 ``get_or_create_user``, crm-mcp (NLE CRM round-trip).
+
+Model — shared-secret, deliberately NOT JWT:
+  - Tokens are opaque ``emk_<urlsafe>`` bearers minted by cortex (the credential
+    authority). Empirica validates by constant-time string-equality against a
+    locally-configured *valid-token set* — no introspection round-trip back to
+    cortex, so the mint path stays fast and uncoupled.
+  - Empirica owns the SET (and the rotation overlap window); a consumer carries
+    only its one *current* token. Rotation is zero-downtime: add ``emk_new`` to
+    the set, consumers switch their single env, then drop ``emk_old``.
+  - Forward hook (unified-auth migration): swap ``verify_mint_bearer`` for JWT
+    signature verification against the unified-auth server's public key. One
+    function to replace, no parallel shared-secret+JWT path to unwind.
+
+Activation + fail-closed:
+  - The guard enforces whenever a valid-token set is configured.
+  - ``assert_bind_safe`` refuses startup when bound non-loopback with no token
+    configured — the mint is never exposed unauthed.
+"""
+
+from __future__ import annotations
+
+import hmac
+import os
+import secrets
+
+from fastapi import Header, HTTPException
+
+#: Prefix on every entity-mint key. For audit/triage legibility only — it is
+#: NOT parsed for authorization (validation is constant-time string-equality).
+TOKEN_PREFIX = "emk_"  # noqa: S105 — public key prefix, not a secret
+
+#: Env carrying empirica's valid-token SET (comma-separated). Distinct from the
+#: consumer-side singular ``EMPIRICA_ENTITY_MINT_TOKEN`` carry: empirica owns the
+#: set + rotation overlap, each consumer presents one current token.
+ENV_TOKENS = "EMPIRICA_ENTITY_MINT_TOKENS"
+
+#: Hosts that bind loopback only (no network exposure → auth-free, back-compat).
+_LOOPBACK_HOSTS = frozenset({"127.0.0.1", "localhost", "::1", "::ffff:127.0.0.1"})
+
+
+def load_valid_tokens() -> set[str]:
+    """Parse the configured valid-token set from ``EMPIRICA_ENTITY_MINT_TOKENS``.
+
+    Comma-separated, whitespace-trimmed, empties dropped. Read fresh on every
+    call so a daemon reload (token rotation / revocation) takes effect without
+    restarting this module's import-time state.
+    """
+    raw = os.environ.get(ENV_TOKENS, "")
+    return {t.strip() for t in raw.split(",") if t.strip()}
+
+
+def is_guard_active() -> bool:
+    """The guard enforces iff a valid-token set is configured."""
+    return bool(load_valid_tokens())
+
+
+def is_loopback_host(host: str | None) -> bool:
+    """True if ``host`` binds loopback only (no network exposure)."""
+    return (host or "").strip().lower() in _LOOPBACK_HOSTS
+
+
+def assert_bind_safe(host: str | None) -> None:
+    """Fail-closed startup check: refuse a non-loopback bind with no token.
+
+    Loopback binds are always allowed (auth-free, same-box). A non-loopback
+    bind REQUIRES a configured token set, or the mint would be exposed unauthed.
+    Raises ``RuntimeError`` in the unsafe case; the serve command turns that
+    into a clean refusal-to-start.
+    """
+    if is_loopback_host(host):
+        return
+    if not is_guard_active():
+        raise RuntimeError(
+            f"Refusing to start: daemon bound to non-loopback host {host!r} with "
+            f"no entity-mint token configured. Set {ENV_TOKENS} (comma-separated "
+            "emk_… tokens) before exposing the mint, or bind to 127.0.0.1. The "
+            "entity-mint endpoint must never be exposed unauthenticated."
+        )
+
+
+def _extract_bearer(authorization: str | None) -> str | None:
+    """Pull the token out of an ``Authorization: Bearer <token>`` header."""
+    if not authorization:
+        return None
+    parts = authorization.split(" ", 1)
+    if len(parts) == 2 and parts[0].lower() == "bearer" and parts[1].strip():
+        return parts[1].strip()
+    return None
+
+
+def _token_in_set(token: str, valid: set[str]) -> bool:
+    """Constant-time membership test — compares against every candidate so the
+    work doesn't short-circuit on the first mismatch (timing-attack resistant).
+    The valid set is intentionally small (≤2 during a rotation overlap).
+    """
+    matched = False
+    for candidate in valid:
+        if hmac.compare_digest(token, candidate):
+            matched = True
+    return matched
+
+
+async def verify_mint_bearer(
+    authorization: str | None = Header(default=None),
+) -> None:
+    """FastAPI dependency guarding the entity-mint route.
+
+    THE seam for the unified-auth migration — replace the string-equal body
+    with JWT signature verification and nothing else changes.
+
+    Behaviour (per co-spec):
+      - guard inactive (no token set configured) → allow (loopback back-compat)
+      - active + valid bearer in the set         → allow
+      - active + missing/invalid bearer          → 401
+
+    ``403`` is reserved for the future multi-scope case; today a token is either
+    in the single ``entity:mint`` set (allow) or not (401).
+    """
+    valid = load_valid_tokens()
+    if not valid:
+        return  # guard inactive — same-box loopback, auth-free
+    token = _extract_bearer(authorization)
+    if not token or not _token_in_set(token, valid):
+        raise HTTPException(
+            status_code=401,
+            detail="entity-mint requires a valid service token "
+                   "(Authorization: Bearer emk_…)",
+        )
+
+
+def generate_mint_token() -> str:
+    """Mint a fresh ``emk_<32-byte urlsafe>`` token.
+
+    Cortex is the credential authority in the hosted deployment; this helper
+    backs tests and self-hosted operators who stand up their own hosted daemon
+    without cortex in the loop.
+    """
+    return TOKEN_PREFIX + secrets.token_urlsafe(32)

--- a/empirica/api/routes/entities.py
+++ b/empirica/api/routes/entities.py
@@ -7,15 +7,20 @@ created=false. The returned id is the canonical contact_id that external
 consumers (e.g. a CRM MCP server on the same box) carry as their FK and
 that the knowledge-graph traversal resolves.
 
-The daemon binds localhost-only; no bearer auth is enforced (consistent
-with the other /api/v1 routes — transport security is the loopback
-boundary).
+On a loopback daemon no bearer auth is enforced (transport security is the
+loopback boundary, consistent with the other /api/v1 routes). When the per-org
+daemon binds non-loopback (the hosted deployment), the route is guarded by a
+service-token bearer — see ``empirica.api.entity_mint_auth``. The guard is a
+route dependency, so the mint contract body is unchanged; auth rides the
+``Authorization`` header (401 on missing/invalid token).
 """
 
 from __future__ import annotations
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
+
+from empirica.api.entity_mint_auth import verify_mint_bearer
 
 router = APIRouter(prefix="/api/v1", tags=["entities"])
 
@@ -33,7 +38,7 @@ class EntityCreateRequest(BaseModel):
     )
 
 
-@router.post("/entities")
+@router.post("/entities", dependencies=[Depends(verify_mint_bearer)])
 async def create_entity(req: EntityCreateRequest):
     """Idempotent contact mint. Returns the canonical entity_id.
 

--- a/empirica/cli/command_handlers/serve_commands.py
+++ b/empirica/cli/command_handlers/serve_commands.py
@@ -19,6 +19,15 @@ def handle_serve_command(args):
         print("Error: uvicorn not installed. Run: pip install 'empirica[api]'")
         return 1
 
+    # Fail-closed: never expose the entity-mint endpoint unauthenticated. A
+    # non-loopback bind requires a configured service-token set.
+    from empirica.api.entity_mint_auth import assert_bind_safe
+    try:
+        assert_bind_safe(host)
+    except RuntimeError as e:
+        print(f"Error: {e}")
+        return 1
+
     print(f"Starting Empirica serve daemon on http://{host}:{port}")
     print(f"  Health:  http://{host}:{port}/api/v1/health")
     print(f"  Import:  POST http://{host}:{port}/api/v1/artifacts/import")

--- a/tests/test_entity_mint_auth.py
+++ b/tests/test_entity_mint_auth.py
@@ -1,0 +1,163 @@
+"""Tests for the hosted entity-mint service-token guard.
+
+Covers the co-spec (empirica-mesh-support/docs/entity-mint-service-token-spec.md):
+activation, fail-closed bind, 401-or-proceed, rotation set, body-verbatim, and
+the emk_ token format. All cortex/CRM calls are mocked — runs on any host.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from empirica.api import entity_mint_auth as ema
+
+# ── token-set config parsing ─────────────────────────────────────────
+
+
+def test_load_valid_tokens_parses_comma_set(monkeypatch):
+    monkeypatch.setenv(ema.ENV_TOKENS, " emk_a , emk_b ,, emk_c ")
+    assert ema.load_valid_tokens() == {"emk_a", "emk_b", "emk_c"}
+
+
+def test_load_valid_tokens_empty_when_unset(monkeypatch):
+    monkeypatch.delenv(ema.ENV_TOKENS, raising=False)
+    assert ema.load_valid_tokens() == set()
+    assert ema.is_guard_active() is False
+
+
+def test_is_guard_active_true_when_configured(monkeypatch):
+    monkeypatch.setenv(ema.ENV_TOKENS, "emk_x")
+    assert ema.is_guard_active() is True
+
+
+# ── loopback classification + fail-closed bind ───────────────────────
+
+
+@pytest.mark.parametrize("host", ["127.0.0.1", "localhost", "::1", "LOCALHOST", " 127.0.0.1 "])
+def test_is_loopback_host_true(host):
+    assert ema.is_loopback_host(host) is True
+
+
+@pytest.mark.parametrize("host", ["0.0.0.0", "10.0.0.5", "git.getempirica.com", ""])  # noqa: S104 — test fixture hosts
+def test_is_loopback_host_false(host):
+    assert ema.is_loopback_host(host) is False
+
+
+def test_assert_bind_safe_loopback_ok_without_token(monkeypatch):
+    monkeypatch.delenv(ema.ENV_TOKENS, raising=False)
+    ema.assert_bind_safe("127.0.0.1")  # no raise — same-box, auth-free
+
+
+def test_assert_bind_safe_nonloopback_without_token_raises(monkeypatch):
+    monkeypatch.delenv(ema.ENV_TOKENS, raising=False)
+    with pytest.raises(RuntimeError, match="never be exposed unauthenticated"):
+        ema.assert_bind_safe("0.0.0.0")  # noqa: S104 — test fixture host
+
+
+def test_assert_bind_safe_nonloopback_with_token_ok(monkeypatch):
+    monkeypatch.setenv(ema.ENV_TOKENS, "emk_ok")
+    ema.assert_bind_safe("0.0.0.0")  # noqa: S104 — test fixture host; no raise, token present
+
+
+# ── bearer extraction ────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "header,expected",
+    [
+        ("Bearer emk_tok", "emk_tok"),
+        ("bearer emk_tok", "emk_tok"),
+        ("Bearer  emk_tok ", "emk_tok"),
+        ("Basic abc", None),
+        ("emk_tok", None),
+        ("Bearer ", None),
+        ("", None),
+        (None, None),
+    ],
+)
+def test_extract_bearer(header, expected):
+    assert ema._extract_bearer(header) == expected
+
+
+def test_generate_mint_token_format():
+    tok = ema.generate_mint_token()
+    assert tok.startswith("emk_")
+    assert len(tok) > 40  # emk_ + 32-byte urlsafe (~43 chars)
+    assert ema.generate_mint_token() != ema.generate_mint_token()  # random
+
+
+# ── endpoint guard behaviour (TestClient) ────────────────────────────
+
+_MINT_OK = {"ok": True, "entity_id": "c-jane-acme", "created": True, "matched_by": "email"}
+
+
+def _client():
+    from empirica.api.serve_app import create_serve_app
+    return TestClient(create_serve_app())
+
+
+def _post(client, bearer=None):
+    headers = {"Authorization": f"Bearer {bearer}"} if bearer else {}
+    return client.post(
+        "/api/v1/entities",
+        json={"type": "contact", "name": "Jane", "email": "jane@acme.com"},
+        headers=headers,
+    )
+
+
+def test_guard_inactive_allows_no_auth(monkeypatch):
+    """Loopback / no token configured → mint proceeds unauthenticated (back-compat)."""
+    monkeypatch.delenv(ema.ENV_TOKENS, raising=False)
+    with patch("empirica.cli.command_handlers.entity_commands.mint_contact", return_value=_MINT_OK):
+        r = _post(_client())
+    assert r.status_code == 200
+    assert r.json() == _MINT_OK
+
+
+def test_guard_active_valid_token_proceeds(monkeypatch):
+    monkeypatch.setenv(ema.ENV_TOKENS, "emk_valid")
+    with patch("empirica.cli.command_handlers.entity_commands.mint_contact", return_value=_MINT_OK):
+        r = _post(_client(), bearer="emk_valid")
+    assert r.status_code == 200
+    assert r.json() == _MINT_OK  # body verbatim under auth
+
+
+def test_guard_active_missing_token_401(monkeypatch):
+    monkeypatch.setenv(ema.ENV_TOKENS, "emk_valid")
+    with patch("empirica.cli.command_handlers.entity_commands.mint_contact", return_value=_MINT_OK) as m:
+        r = _post(_client())  # no Authorization header
+    assert r.status_code == 401
+    m.assert_not_called()  # guard rejects before the mint runs
+
+
+def test_guard_active_invalid_token_401(monkeypatch):
+    monkeypatch.setenv(ema.ENV_TOKENS, "emk_valid")
+    with patch("empirica.cli.command_handlers.entity_commands.mint_contact", return_value=_MINT_OK) as m:
+        r = _post(_client(), bearer="emk_wrong")
+    assert r.status_code == 401
+    m.assert_not_called()
+
+
+def test_guard_active_rotation_set_both_tokens_work(monkeypatch):
+    """During a rotation overlap the set holds old+new; both validate."""
+    monkeypatch.setenv(ema.ENV_TOKENS, "emk_old,emk_new")
+    with patch("empirica.cli.command_handlers.entity_commands.mint_contact", return_value=_MINT_OK):
+        client = _client()
+        assert _post(client, bearer="emk_old").status_code == 200
+        assert _post(client, bearer="emk_new").status_code == 200
+
+
+def test_guard_active_wrong_type_still_auths_first(monkeypatch):
+    """Auth runs as a dependency before the handler; a bad bearer 401s even for
+    an otherwise-invalid body (no information leak about the 422 path)."""
+    monkeypatch.setenv(ema.ENV_TOKENS, "emk_valid")
+    client = _client()
+    r = client.post(
+        "/api/v1/entities",
+        json={"type": "organization", "name": "Acme"},
+        headers={"Authorization": "Bearer emk_wrong"},
+    )
+    assert r.status_code == 401


### PR DESCRIPTION
Implements the converged co-spec (`empirica-mesh-support/docs/entity-mint-service-token-spec.md`) for guarding `POST /api/v1/entities` when the per-org `empirica serve` daemon binds non-loopback (the hosted-daemon deployment on Hetzner/EU). **David greenlit; connected to the PRIORITY-1 NLE CRM round-trip.**

## What
- **`empirica/api/entity_mint_auth.py`** (new) — the guard:
  - `load_valid_tokens()` reads `EMPIRICA_ENTITY_MINT_TOKENS` (comma-sep **set**; empirica owns the set + rotation overlap, consumers carry one current token).
  - `verify_mint_bearer()` — FastAPI dependency; **the single seam** for the future unified-auth JWT migration (swap the validator, no parallel path). Constant-time (`hmac.compare_digest`) string-equality.
  - `assert_bind_safe()` — **fail-closed**: refuses a non-loopback bind with no token configured. The mint is never exposed unauthed.
  - `generate_mint_token()` — `emk_<32B urlsafe>` (cortex is the authority; this backs tests + self-hosters).
- **`routes/entities.py`** — route-level `Depends(verify_mint_bearer)`; stale "no auth" docstring updated.
- **`serve_commands.py`** — fail-closed bind check before `uvicorn.run`.

## Contract guarantees (from the co-spec)
- Loopback daemons stay **auth-free** (back-compat — same-box consumers unaffected).
- Additive errors: **401** on missing/invalid bearer. **403 reserved** for the future multi-scope case (single `entity:mint` scope today).
- `b068bedfd` success body (`created`/`matched_by`/slug) + the 400-on-malformed-email path are **byte-identical** → crm-mcp (`2ab7f42`) + cortex (`23466bc`) flip live on **config alone**.

## Tests
30 new in `tests/test_entity_mint_auth.py` (set parsing, loopback classification, fail-closed bind, 401-or-proceed, rotation overlap set, body-verbatim under auth, `emk_` format). Ruff + pyright clean; 251 existing entity/serve tests green.

## ⚠️ Adjacent security note (out of scope — flagging, not fixing here)
A non-loopback bind also exposes the **other** unauthed serve routes (`/artifacts/import`, `/credentials/*`). The fail-closed check gates daemon startup on a *mint* token, but that token doesn't protect those routes. The hosted per-org deployment should either route **only** `/entities`, or those routes need their own guard. Recommend a follow-up before any non-loopback daemon serves more than the mint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)