### PR TITLE
fix(listener): canonicalize the listener-on/channels subscribe tag to the 3-form

### DIFF
--- a/empirica/core/cockpit/notification_channels.py
+++ b/empirica/core/cockpit/notification_channels.py
@@ -149,8 +149,12 @@ def resolve_orchestration_events_topic(ai_id: str, *, force: bool = False) -> st
       4. Else RAISE — never silently subscribe to the deprecated bare topic
          (no ACL grant → 403 storm)
 
-    Always appends `?tags=<ai_id>` for per-AI filtering and prepends the
-    `ntfy:` scheme (matches the listener's existing topic shape).
+    Always appends `?tags=<canonical-3-form>` for per-AI filtering and prepends
+    the `ntfy:` scheme (matches the listener's existing topic shape). The tag is
+    canonicalized to the full `<org>.<tenant>.<project>` form — the SAME tag
+    cortex publishes and `loop listen` subscribes with — so an in-session
+    listener armed via `listener on` matches live ntfy pushes instead of relying
+    on catch-up polling. (Subscribing with the bare slug matches nothing.)
     """
     body = fetch_notification_channels(force=force)
     base_topic = _resolve_base_topic(body)
@@ -162,7 +166,30 @@ def resolve_orchestration_events_topic(ai_id: str, *, force: bool = False) -> st
             "'orchestration-events' topic (no ACL grant — it 403s). Check "
             "cortex reachability / credentials, then retry."
         )
-    return f"ntfy:{base_topic}?tags={ai_id}"
+    return f"ntfy:{base_topic}?tags={_canonical_tag(ai_id)}"
+
+
+def _canonical_tag(ai_id: str) -> str:
+    """Resolve `ai_id` to its canonical 3-form (`<org>.<tenant>.<project>`) for
+    the subscribe tag — the single source of truth shared with `loop listen`
+    (both call `_resolve_canonical_ai_id`). Cortex publishes events tagged with
+    the 3-form; subscribing with the bare slug matches nothing (live pushes
+    silently dropped, only catch-up poll catches up).
+
+    Falls back to the bare `ai_id` when cortex creds are absent or the roster
+    lookup fails — `_resolve_canonical_ai_id` already returns the basename
+    unchanged on failure, so the failure is loud (0-result warnings) not silent.
+    """
+    creds = _cortex_creds()
+    if creds is None:
+        return ai_id
+    try:
+        from empirica.core.loop_scheduler.content_poll import (
+            _resolve_canonical_ai_id,
+        )
+        return _resolve_canonical_ai_id(creds[0], creds[1], ai_id)
+    except Exception:
+        return ai_id
 
 
 def _resolve_base_topic(body: dict | None) -> str | None:

--- a/tests/test_notification_channels_tag.py
+++ b/tests/test_notification_channels_tag.py
@@ -1,0 +1,63 @@
+"""Tests for canonical-3-form tag resolution in the listener-on / channels path.
+
+`resolve_orchestration_events_topic` must subscribe with the canonical
+`<org>.<tenant>.<project>` tag (the same tag cortex publishes + `loop listen`
+uses), not the bare slug — otherwise an in-session listener armed via
+`listener on` matches no live ntfy push and only catches up via polling.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from empirica.core.cockpit import notification_channels as nc
+
+# ── _canonical_tag ───────────────────────────────────────────────────
+
+
+def test_canonical_tag_resolves_3form():
+    with patch.object(nc, "_cortex_creds", return_value=("https://cortex", "k")), \
+         patch("empirica.core.loop_scheduler.content_poll._resolve_canonical_ai_id",
+               return_value="empirica.david.empirica-autonomy") as r:
+        assert nc._canonical_tag("empirica-autonomy") == "empirica.david.empirica-autonomy"
+    r.assert_called_once_with("https://cortex", "k", "empirica-autonomy")
+
+
+def test_canonical_tag_falls_back_to_bare_when_no_creds():
+    with patch.object(nc, "_cortex_creds", return_value=None):
+        assert nc._canonical_tag("empirica-autonomy") == "empirica-autonomy"
+
+
+def test_canonical_tag_falls_back_to_bare_on_resolver_error():
+    with patch.object(nc, "_cortex_creds", return_value=("https://cortex", "k")), \
+         patch("empirica.core.loop_scheduler.content_poll._resolve_canonical_ai_id",
+               side_effect=RuntimeError("roster down")):
+        assert nc._canonical_tag("empirica-autonomy") == "empirica-autonomy"
+
+
+def test_canonical_tag_resolver_already_returns_bare_on_failure():
+    # _resolve_canonical_ai_id returns the basename unchanged on its own failures
+    with patch.object(nc, "_cortex_creds", return_value=("https://cortex", "k")), \
+         patch("empirica.core.loop_scheduler.content_poll._resolve_canonical_ai_id",
+               return_value="empirica-autonomy"):
+        assert nc._canonical_tag("empirica-autonomy") == "empirica-autonomy"
+
+
+# ── resolve_orchestration_events_topic builds ?tags=<3-form> ──────────
+
+
+def test_topic_uses_canonical_tag():
+    body = {"channels": [{"topic": "empirica-orchestration-events-david", "category": "orchestration_events"}]}
+    with patch.object(nc, "fetch_notification_channels", return_value=body), \
+         patch.object(nc, "_canonical_tag", return_value="empirica.david.empirica-autonomy") as ct:
+        topic = nc.resolve_orchestration_events_topic("empirica-autonomy")
+    assert topic == "ntfy:empirica-orchestration-events-david?tags=empirica.david.empirica-autonomy"
+    ct.assert_called_once_with("empirica-autonomy")
+
+
+def test_topic_still_raises_when_base_unresolvable():
+    with patch.object(nc, "fetch_notification_channels", return_value=None), \
+         pytest.raises(RuntimeError, match="orchestration-events topic"):
+        nc.resolve_orchestration_events_topic("empirica-autonomy")


### PR DESCRIPTION
ECO-accepted code_change_request from **empirica-autonomy** (`prop_3f5qbl2b`, plan T3), surfaced live in the Berlin session.

## Problem (silent-wake-drop class)
cortex publishes ntfy wakes tagged with the canonical `<org>.<tenant>.<project>` 3-form, and `loop listen` already subscribes with the 3-form (via `_resolve_canonical_ai_id`, fixed earlier in `136a48095`). But `resolve_orchestration_events_topic` — the path `empirica listener on` uses — appended `?tags=<bare-slug>` (`empirica-autonomy`, no org.tenant prefix). An in-session listener armed via `listener on` matched **no** live ntfy push and only received via API catch-up polling → silent/late wakes.

## Fix
Route the subscribe tag through a new `_canonical_tag()` that resolves the 3-form via the **same** `_resolve_canonical_ai_id` helper `loop listen` uses — single source of truth for the subscribe tag. Graceful degradation: falls back to the bare `ai_id` when cortex creds are absent or the roster lookup fails (the resolver already returns the basename unchanged on failure, so the failure is loud — 0-result warnings — not silent).

This closes the last inconsistent arming path; the persistent-service install already self-heals bare→canonical (`_purge_legacy_systemd_unit`).

## Tests
6 new in `tests/test_notification_channels_tag.py` — 3-form resolution, fallback on no-creds, fallback on resolver error, resolver-already-bare, the topic builds `?tags=<3-form>`, and the base-unresolvable RuntimeError still raises. ruff + pyright clean; 268 notification/listener/content_poll regression tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)