### PR TITLE
feat(serve): GET /api/v1/listeners — listener+health bridge for the extension (T4)

### DIFF
--- a/empirica/api/serve_app.py
+++ b/empirica/api/serve_app.py
@@ -14,7 +14,9 @@ API contract matches empirica-extension/src/api/empirica-client.ts:
 - POST /api/v1/profile/sync    → SyncResponse
 """
 
+import json
 import logging
+from pathlib import Path
 
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
@@ -141,6 +143,31 @@ class SyncResponse(BaseModel):
     imported: int = 0
 
 
+class ListenerRow(BaseModel):
+    """One (instance, listener) row for the extension's receive-path health
+    indicator. Declarative + history fields come from the listener registry;
+    `health_*` fields are merged from the per-instance heartbeat marker.
+    `topic` is kept raw (`ntfy:<topic>?tags=<tag>`) — the extension parses it
+    and owns the red/amber render logic.
+    """
+    instance_id: str
+    name: str
+    description: str = ""
+    topic: str = ""
+    wake_count: int = 0
+    last_wake_at: str | None = None
+    last_message: str | None = None
+    registered_at: str | None = None
+    health_status: str | None = None  # ok | degraded | None (no heartbeat yet)
+    health_loop: str | None = None
+    health_ts: str | None = None
+
+
+class ListenersResponse(BaseModel):
+    ok: bool = True
+    listeners: list[ListenerRow] = Field(default_factory=list)
+
+
 # ── FastAPI App ──────────────────────────────────────────────────────
 
 def create_serve_app() -> FastAPI:
@@ -229,6 +256,17 @@ def create_serve_app() -> FastAPI:
         except Exception as e:
             logger.error(f"Profile sync failed: {e}", exc_info=True)
             raise HTTPException(status_code=500, detail=str(e)) from e
+
+    @app.get("/api/v1/listeners", response_model=ListenersResponse)
+    async def listeners():  # pyright: ignore[reportUnusedFunction]
+        """Registered mesh listeners + heartbeat freshness, merged from the
+        on-disk registry + health markers. Lets the extension flag silent
+        receive failures (seat alive but deaf) without reading ~/.empirica/
+        directly. Read-only, localhost — same trust surface as /health."""
+        return ListenersResponse(
+            ok=True,
+            listeners=[ListenerRow(**row) for row in _gather_listeners()],
+        )
 
     _register_credentials_routes(app)
 
@@ -390,6 +428,68 @@ def _check_qdrant() -> bool:
             return True
     except Exception:
         return False
+
+
+# Instance ids that are dev/test fixtures, not canonical mesh seats — skipped
+# from the listeners endpoint so the extension's Diagnostics tab stays clean.
+_FIXTURE_INSTANCE_IDS = frozenset({"test_instance", "smoke_test", "custom"})
+_FIXTURE_INSTANCE_PREFIXES = ("tmux_",)
+
+
+def _is_fixture_instance(instance_id: str) -> bool:
+    return (
+        instance_id in _FIXTURE_INSTANCE_IDS
+        or any(instance_id.startswith(p) for p in _FIXTURE_INSTANCE_PREFIXES)
+    )
+
+
+def _gather_listeners() -> list[dict]:
+    """Merge the on-disk listener registry + heartbeat-health files into a flat
+    list of rows for the extension (which can't read ~/.empirica/ directly).
+
+    One row per (instance, listener), built from
+    ``~/.empirica/listeners_<inst>.json`` (declarative + history) with the
+    ``health_*`` fields merged from ``~/.empirica/listener_health_<inst>.json``
+    by instance. Dev/test fixtures are skipped. Read-only; never raises — a
+    missing or malformed file is skipped, not fatal.
+    """
+    base = Path.home() / ".empirica"
+    rows: list[dict] = []
+    if not base.exists():
+        return rows
+    for reg_path in sorted(base.glob("listeners_*.json")):
+        try:
+            with open(reg_path, encoding="utf-8") as f:
+                reg = json.load(f)
+        except Exception:
+            continue
+        instance_id = reg.get("instance_id") or ""
+        if not instance_id or _is_fixture_instance(instance_id):
+            continue
+        health: dict = {}
+        hpath = base / f"listener_health_{instance_id}.json"
+        if hpath.exists():
+            try:
+                with open(hpath, encoding="utf-8") as f:
+                    health = json.load(f) or {}
+            except Exception:
+                health = {}
+        for name, entry in (reg.get("listeners") or {}).items():
+            entry = entry or {}
+            rows.append({
+                "instance_id": instance_id,
+                "name": name,
+                "description": entry.get("description", "") or "",
+                "topic": entry.get("topic", "") or "",
+                "wake_count": int(entry.get("wake_count", 0) or 0),
+                "last_wake_at": entry.get("last_wake_at"),
+                "last_message": entry.get("last_message"),
+                "registered_at": entry.get("registered_at"),
+                "health_status": health.get("status"),
+                "health_loop": health.get("loop"),
+                "health_ts": health.get("ts"),
+            })
+    return rows
 
 
 def _store_artifacts(artifacts: list[ArtifactPayload]) -> dict:

--- a/tests/test_serve_listeners.py
+++ b/tests/test_serve_listeners.py
@@ -1,0 +1,100 @@
+"""Tests for the serve daemon's GET /api/v1/listeners bridge.
+
+Merges the on-disk listener registry (`listeners_<inst>.json`) + heartbeat
+health (`listener_health_<inst>.json`) into rows for the extension's
+receive-path health indicator. Fixtures skipped; missing health → null fields.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from empirica.api import serve_app as sa
+
+
+def _write(p: Path, obj) -> None:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps(obj), encoding="utf-8")
+
+
+@pytest.fixture
+def fake_home(tmp_path, monkeypatch):
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    emp = tmp_path / ".empirica"
+    # canonical seat WITH health
+    _write(emp / "listeners_empirica.json", {
+        "instance_id": "empirica", "instance_label": None,
+        "listeners": {"empirica-inbox": {
+            "topic": "ntfy:empirica-orchestration-events-david?tags=empirica",
+            "description": "Canonical mesh listener for ai_id=empirica",
+            "registered_at": "2026-06-04T10:00:00Z",
+            "last_wake_at": "2026-06-17T20:00:00Z", "last_message": "woke",
+            "wake_count": 5,
+        }},
+    })
+    _write(emp / "listener_health_empirica.json", {
+        "instance_id": "empirica", "loop": "cortex-mailbox-poll",
+        "status": "ok", "ts": "2026-06-17T21:00:00Z", "source": "liveness_probe",
+    })
+    # canonical seat WITHOUT health (health_* must be null)
+    _write(emp / "listeners_ecodex.json", {
+        "instance_id": "ecodex",
+        "listeners": {"ecodex-inbox": {"topic": "ntfy:x?tags=ecodex", "wake_count": 0}},
+    })
+    # fixtures — must be skipped
+    _write(emp / "listeners_smoke_test.json", {"instance_id": "smoke_test", "listeners": {"a": {"topic": "t"}}})
+    _write(emp / "listeners_tmux_0.json", {"instance_id": "tmux_0", "listeners": {"b": {"topic": "t"}}})
+    # malformed — must be skipped, not fatal
+    (emp / "listeners_broken.json").write_text("{not json", encoding="utf-8")
+    return tmp_path
+
+
+def test_gather_merges_registry_and_health(fake_home):
+    rows = {r["instance_id"]: r for r in sa._gather_listeners()}
+    assert set(rows) == {"empirica", "ecodex"}  # fixtures + broken skipped
+    emp = rows["empirica"]
+    assert emp["name"] == "empirica-inbox"
+    assert emp["topic"] == "ntfy:empirica-orchestration-events-david?tags=empirica"
+    assert emp["wake_count"] == 5
+    assert emp["last_wake_at"] == "2026-06-17T20:00:00Z"
+    assert emp["health_status"] == "ok"
+    assert emp["health_loop"] == "cortex-mailbox-poll"
+    assert emp["health_ts"] == "2026-06-17T21:00:00Z"
+
+
+def test_gather_null_health_when_no_marker(fake_home):
+    rows = {r["instance_id"]: r for r in sa._gather_listeners()}
+    eco = rows["ecodex"]
+    assert eco["health_status"] is None
+    assert eco["health_loop"] is None
+    assert eco["health_ts"] is None
+    assert eco["wake_count"] == 0
+
+
+@pytest.mark.parametrize("inst", ["test_instance", "smoke_test", "custom", "tmux_0", "tmux_42"])
+def test_is_fixture_instance(inst):
+    assert sa._is_fixture_instance(inst) is True
+
+
+@pytest.mark.parametrize("inst", ["empirica", "empirica-autonomy", "cortex", "ecodex"])
+def test_canonical_not_fixture(inst):
+    assert sa._is_fixture_instance(inst) is False
+
+
+def test_gather_empty_when_no_empirica_dir(tmp_path, monkeypatch):
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))  # no .empirica
+    assert sa._gather_listeners() == []
+
+
+def test_endpoint_returns_rows(fake_home):
+    client = TestClient(sa.create_serve_app())
+    r = client.get("/api/v1/listeners")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["ok"] is True
+    insts = {row["instance_id"] for row in body["listeners"]}
+    assert insts == {"empirica", "ecodex"}


### PR DESCRIPTION
ECO-accepted code_change_request from **empirica-extension** (`prop_ve5v4qyj`, T4): a per-seat receive-path health indicator for the Diagnostics tab. The MV3 extension can't read `~/.empirica/` directly and `/api/v1/health` carries no listener state.

## What
Read-only `GET /api/v1/listeners` that merges two on-disk sources per instance into one flat row per `(instance, listener)`:
- `listeners_<inst>.json` (registry: name, topic, description, registered_at, last_wake_at, last_message, wake_count)
- `listener_health_<inst>.json` (heartbeat: `status` → `health_status`, `loop` → `health_loop`, `ts` → `health_ts`; **null** when no marker yet)

**Field names match the extension's proposed contract verbatim** — no renames needed; the keys mapped cleanly onto the actual on-disk schema. `topic` is kept raw (`ntfy:<topic>?tags=<tag>`) so the extension parses + owns the red/amber render (consistent with the serve-returns-JSON / extension-renders split).

Dev/test fixtures (`test_instance`, `smoke_test`, `custom`, `tmux_*`) are skipped server-side. Never raises — a missing or malformed file is skipped. Same trust surface as `/api/v1/health` (read-only, localhost).

## Tests
13 new in `tests/test_serve_listeners.py` — registry+health merge, null-health when no marker, fixture filtering, malformed-skip, empty-when-no-dir, and the endpoint via TestClient. ruff + pyright clean; 127 serve regression tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)