### PR TITLE
perf(cli): defer httpx and GitPython imports off the CLI startup path

### DIFF
--- a/empirica/cli/asyncio_fix.py
+++ b/empirica/cli/asyncio_fix.py
@@ -38,21 +38,29 @@ def patch_asyncio_for_mcp():
     # Suppress warnings FIRST
     suppress_asyncio_warnings()
 
-    # Patch httpx to not complain about event loop closure
-    try:
-        import httpx
-        # Monkey-patch httpx AsyncClient.__del__ to ignore errors
-        original_del = getattr(httpx.AsyncClient, "__del__", None)
-        if original_del is not None:
-            def safe_del(self) -> None:
-                """Safely cleanup AsyncClient, ignoring event loop closure errors."""
-                try:
-                    original_del(self)
-                except Exception:
-                    pass  # Ignore all cleanup errors
-            httpx.AsyncClient.__del__ = safe_del  # pyright: ignore[reportAttributeAccessIssue]
-    except (ImportError, AttributeError):
-        pass  # httpx not installed or already patched
+    # Patch httpx to not complain about event loop closure — but ONLY if httpx
+    # has already been imported by something else (an MCP/cloud-embedding path).
+    # Importing httpx here purely to patch __del__ costs ~190ms on EVERY CLI
+    # invocation, even for commands that never make a network call. The
+    # ResourceWarnings / "Event loop is closed" messages this guards against are
+    # already silenced unconditionally by suppress_asyncio_warnings() above, so
+    # skipping the monkey-patch when httpx is absent is functionally safe.
+    import sys
+    httpx = sys.modules.get("httpx")
+    if httpx is not None:
+        try:
+            # Monkey-patch httpx AsyncClient.__del__ to ignore errors
+            original_del = getattr(httpx.AsyncClient, "__del__", None)
+            if original_del is not None:
+                def safe_del(self) -> None:
+                    """Safely cleanup AsyncClient, ignoring event loop closure errors."""
+                    try:
+                        original_del(self)
+                    except Exception:
+                        pass  # Ignore all cleanup errors
+                httpx.AsyncClient.__del__ = safe_del  # pyright: ignore[reportAttributeAccessIssue]
+        except AttributeError:
+            pass  # httpx internals changed — nothing to patch
 
     # Store reference to avoid premature closure
     _event_loop_ref = None

--- a/empirica/core/git_ops/signed_operations.py
+++ b/empirica/core/git_ops/signed_operations.py
@@ -31,24 +31,49 @@ from datetime import datetime, timezone  # type: ignore[reportAttributeAccessIss
 from pathlib import Path
 from typing import Any
 
-# Temporarily remove empirica.core.git from sys.modules to import GitPython 'git' module
-_empirica_git_module = sys.modules.pop('empirica.core.git', None)
+# GitPython is a heavy import (~140ms). It is only needed when an actual git
+# operation runs (commit/verify/git-notes I/O), never just to import this
+# module. We load it lazily so that `import empirica.cli` — which transitively
+# imports this module via the command-handler re-export shim — does not pay the
+# GitPython cost for commands that never touch git (e.g. goals-list).
+#
+# The names GitRepo, GitCommandError and GIT_PYTHON_AVAILABLE resolve on first
+# access: externally via PEP 562 module __getattr__, internally via the
+# _load_gitpython() call at the top of SignedGitOperations.__init__ (the only
+# entry point through which git operations are reached).
+_GIT_LOADED = False
 
-try:
-    # Now import the actual GitPython library
-    import git
-    GitRepo = git.Repo
-    GitCommandError = git.GitCommandError
-    GIT_PYTHON_AVAILABLE = True
-except ImportError:
-    # GitPython not installed - use fallback
-    GitRepo = None
-    GitCommandError = Exception
-    GIT_PYTHON_AVAILABLE = False
-finally:
-    # Restore empirica.core.git if it was there
-    if _empirica_git_module is not None:
-        sys.modules['empirica.core.git'] = _empirica_git_module
+
+def _load_gitpython() -> None:
+    """Import GitPython on demand and publish the module-level names. Idempotent."""
+    global _GIT_LOADED, GitRepo, GitCommandError, GIT_PYTHON_AVAILABLE
+    if _GIT_LOADED:
+        return
+    # Temporarily remove empirica.core.git so the import resolves the real
+    # GitPython 'git' module rather than our package sharing the leaf name.
+    _empirica_git_module = sys.modules.pop('empirica.core.git', None)
+    try:
+        import git
+        GitRepo = git.Repo
+        GitCommandError = git.GitCommandError
+        GIT_PYTHON_AVAILABLE = True
+    except ImportError:
+        # GitPython not installed - use fallback
+        GitRepo = None
+        GitCommandError = Exception
+        GIT_PYTHON_AVAILABLE = False
+    finally:
+        if _empirica_git_module is not None:
+            sys.modules['empirica.core.git'] = _empirica_git_module
+    _GIT_LOADED = True
+
+
+def __getattr__(name: str):
+    """PEP 562 lazy access for the GitPython-backed module names."""
+    if name in ("GitRepo", "GitCommandError", "GIT_PYTHON_AVAILABLE"):
+        _load_gitpython()
+        return globals()[name]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 from empirica.core.persona.signing_persona import SigningPersona  # noqa: E402 — after sys.modules guard
 
@@ -101,6 +126,8 @@ class SignedGitOperations:
             git.InvalidGitRepositoryError: If path is not a git repo
             ImportError: If GitPython not installed
         """
+        # Resolve GitPython lazily on first construction (see module header).
+        _load_gitpython()
         if not GIT_PYTHON_AVAILABLE:
             raise ImportError("GitPython not installed - git operations unavailable. Install with: pip install gitpython")
 

--- a/tests/test_cli_lazy_imports.py
+++ b/tests/test_cli_lazy_imports.py
@@ -1,0 +1,96 @@
+"""Regression tests: CLI import must not eagerly load heavy optional deps.
+
+Diagnosed 2026-06-17: `import empirica.cli` cost ~1.0s on Windows while
+`import empirica` alone cost ~70ms. An `-X importtime` trace pinned the gap
+to two heavy *leaf* dependencies pulled in at module-import time, even for
+trivial commands like `goals-list` that never touch them:
+
+  - httpx (~190ms) — imported by ``empirica.cli.asyncio_fix`` whose
+    ``patch_asyncio_for_mcp()`` ran at CLI import (cli_core.py) purely to
+    monkey-patch ``httpx.AsyncClient.__del__`` for MCP server cleanup.
+  - GitPython ``git`` (~140ms) — imported at module top in
+    ``empirica.core.git_ops.signed_operations`` via the canonical git-notes
+    chain that ``command_handlers`` re-exports.
+
+Both are now imported lazily (only when a command actually needs them).
+These tests lock in the invariant so the regression can't silently return.
+
+The check runs in a fresh subprocess so prior imports in the test session
+can't mask a stray eager import.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+# Heavy optional deps that must NOT be pulled in just by importing the CLI.
+_FORBIDDEN_AT_CLI_IMPORT = ("httpx", "git")
+
+
+def _modules_after(import_target: str) -> set[str]:
+    """Return sys.modules keys after importing ``import_target`` in a fresh
+    interpreter. Isolated so the parent test process can't contaminate it."""
+    code = (
+        f"import {import_target}\n"
+        "import sys, json\n"
+        "print(json.dumps(sorted(sys.modules)))\n"
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert proc.returncode == 0, (
+        f"importing {import_target} failed:\n{proc.stderr}"
+    )
+    import json
+
+    return set(json.loads(proc.stdout.strip().splitlines()[-1]))
+
+
+def test_cli_import_does_not_pull_httpx():
+    """httpx is ~190ms and only needed for MCP/cloud paths, not the CLI core."""
+    loaded = _modules_after("empirica.cli")
+    assert "httpx" not in loaded, (
+        "empirica.cli eagerly imported httpx — the asyncio_fix httpx "
+        "monkey-patch must stay lazy (only patch when httpx is already loaded)."
+    )
+
+
+def test_cli_import_does_not_pull_gitpython():
+    """GitPython is ~140ms and only needed for git-notes write paths."""
+    loaded = _modules_after("empirica.cli")
+    assert "git" not in loaded, (
+        "empirica.cli eagerly imported GitPython ('git') — "
+        "signed_operations must import it lazily inside its methods."
+    )
+
+
+def test_signed_operations_import_is_light():
+    """Importing the git-notes module itself must not drag in GitPython."""
+    loaded = _modules_after("empirica.core.git_ops.signed_operations")
+    assert "git" not in loaded, (
+        "signed_operations eagerly imported GitPython at module top."
+    )
+
+
+def test_gitpython_still_usable_when_needed():
+    """Lazy loading must not break actual git operations: the module-level
+    names still resolve GitPython on demand."""
+    code = (
+        "from empirica.core.git_ops import signed_operations as so\n"
+        "assert so.GIT_PYTHON_AVAILABLE is True, 'GitPython should resolve lazily'\n"
+        "assert so.GitRepo is not None\n"
+        "import sys; assert 'git' in sys.modules, 'access should have loaded git'\n"
+        "print('ok')\n"
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "ok" in proc.stdout


### PR DESCRIPTION
## Problem

`import empirica.cli` costs ~1.0s on Windows vs ~70ms for `import empirica`. Since every `empirica <subcommand>` (and ceremony calls like `preflight-submit`/`check-submit`/`postflight-submit`) pays this on a cold interpreter, the per-command overhead is felt directly — a full preflight→check→postflight cycle burns ~3s of pure import time.

An `-X importtime` trace pins ~330ms of the gap to two heavy **leaf** dependencies pulled in at import time even for commands that never touch them (e.g. `goals-list`):

- **httpx (~190ms)** — `empirica/cli/asyncio_fix.py`'s `patch_asyncio_for_mcp()` runs at CLI import (`cli_core.py`) and imports httpx solely to monkey-patch `httpx.AsyncClient.__del__` for MCP-server event-loop cleanup.
- **GitPython `git` (~140ms)** — `empirica/core/git_ops/signed_operations.py` imports `git` at module top, dragged in transitively via the canonical git-notes chain that `command_handlers` re-exports.

Confirmed still present on `develop` (1.12.x): `asyncio_fix.py:43 import httpx`, `signed_operations.py:39 import git`.

## Fix

Two surgical lazy-imports, no dispatch/behaviour changes:

1. **`asyncio_fix.py`** — only apply the httpx `__del__` monkey-patch when httpx is **already** in `sys.modules` (an MCP/cloud path loaded it). The ResourceWarnings it guards are already silenced unconditionally by `suppress_asyncio_warnings()`, so skipping the patch when httpx is absent is functionally safe.
2. **`signed_operations.py`** — load GitPython lazily: PEP 562 module `__getattr__` for external access to `GitRepo`/`GitCommandError`/`GIT_PYTHON_AVAILABLE`, plus a `_load_gitpython()` call at the top of `SignedGitOperations.__init__` (the sole entry point through which git ops are reached). Git operations still work on demand.

## Result

`import empirica.cli`: **896ms → 654ms** median (~27% faster, ~240ms/call). httpx/git still load on demand when a command actually needs them.

## Tests

- New `tests/test_cli_lazy_imports.py` locks the invariant (subprocess-isolated: `import empirica.cli` must not load httpx/git; git still resolves lazily when accessed).
- Full local regression run on the affected areas (git-notes signing, persona, preflight/postflight): **57 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)