### PR TITLE
perf(embeddings): drop the openai SDK — call /v1/embeddings over REST

### DIFF
--- a/empirica/core/qdrant/embeddings.py
+++ b/empirica/core/qdrant/embeddings.py
@@ -12,7 +12,7 @@ ENV:
 
 Providers:
 - auto: Auto-detect best available (ollama if running, else local)
-- openai: OpenAI API (requires openai package + API key)
+- openai: OpenAI API (REST /v1/embeddings, no SDK — just an API key)
 - ollama: Local Ollama server (bge-m3, nomic-embed-text, qwen3-embedding, etc.)
 - jina: Jina AI API (jina-embeddings-v3, jina-colbert-v2)
 - voyage: Voyage AI API (voyage-3.5, voyage-3-lite)
@@ -28,11 +28,6 @@ logger = logging.getLogger(__name__)
 
 # Cache for Ollama availability check
 _ollama_available: bool | None = None
-
-try:
-    from openai import OpenAI  # type: ignore
-except Exception:  # pragma: no cover
-    OpenAI = None  # lazy import guard
 
 # Default models and their vector dimensions per provider
 DEFAULT_MODELS = {
@@ -220,9 +215,12 @@ class EmbeddingsProvider:
         self._vector_size: int | None = None
 
         if self.provider == "openai":
-            if OpenAI is None:
-                raise RuntimeError("openai package not available; install openai>=1.0")
-            self._client = OpenAI()
+            # OpenAI uses its REST API directly (no SDK dependency) — the
+            # /v1/embeddings endpoint is a plain POST, same shape as jina/voyage.
+            self._openai_api_key = os.getenv("OPENAI_API_KEY", file_conf.get("openai_api_key"))
+            if not self._openai_api_key:
+                raise RuntimeError("OPENAI_API_KEY env var or openai_api_key in ~/.empirica/embeddings.conf required for provider=openai")
+            self._client = None
             self._vector_size = MODEL_DIMENSIONS.get(self.model, 1536)
         elif self.provider == "ollama":
             # Ollama uses REST API - no special client needed
@@ -262,8 +260,7 @@ class EmbeddingsProvider:
         text = text or ""
 
         if self.provider == "openai":
-            resp = self._client.embeddings.create(model=self.model, input=text)  # type: ignore
-            return resp.data[0].embedding  # type: ignore
+            return self._embed_openai(text)
 
         if self.provider == "ollama":
             return self._embed_ollama(text)
@@ -392,6 +389,47 @@ class EmbeddingsProvider:
         except Exception as e:
             logger.warning(f"Batch embed failed: {e} — falling back to sequential")
             return [self.embed(t) for t in texts]
+
+    def _embed_openai(self, text: str) -> list[float]:
+        """Embed using the OpenAI REST API (text-embedding-3-*, etc.).
+
+        Calls /v1/embeddings directly with ``requests`` — no ``openai`` SDK
+        dependency. The endpoint shape is identical to jina/voyage, so this
+        mirrors those providers. Empirica's default stack runs locally
+        (ollama/qwen3-embedding); the openai provider is opt-in.
+        """
+        import requests
+
+        url = "https://api.openai.com/v1/embeddings"
+        headers = {
+            "Authorization": f"Bearer {self._openai_api_key}",
+            "Content-Type": "application/json"
+        }
+        payload = {
+            "model": self.model,
+            "input": text
+        }
+
+        try:
+            resp = requests.post(url, json=payload, headers=headers, timeout=30)
+            resp.raise_for_status()
+            data = resp.json()
+            embedding = data.get("data", [{}])[0].get("embedding", [])
+
+            if not embedding:
+                logger.warning(f"OpenAI returned empty embedding for model {self.model}")
+                return self._embed_local_hash(text)
+
+            # Cache vector size
+            if self._vector_size is None:
+                self._vector_size = len(embedding)
+                logger.info(f"OpenAI {self.model} vector size: {self._vector_size}")
+
+            return embedding
+
+        except requests.exceptions.RequestException as e:
+            logger.warning(f"OpenAI embedding failed: {e} - falling back to local hash")
+            return self._embed_local_hash(text)
 
     def _embed_jina(self, text: str) -> list[float]:
         """Embed using Jina AI API (jina-embeddings-v3, etc.)."""

--- a/tests/test_embeddings_no_openai_sdk.py
+++ b/tests/test_embeddings_no_openai_sdk.py
@@ -1,0 +1,88 @@
+"""Regression tests: the embeddings module must not depend on the openai SDK.
+
+Empirica's default embeddings stack runs locally (ollama / qwen3-embedding).
+The ``openai`` provider is opt-in and hits the REST ``/v1/embeddings`` endpoint
+directly via ``requests`` — the same shape as the jina/voyage providers — so
+the heavyweight ``openai`` SDK is no longer a dependency.
+
+Diagnosed 2026-06-18: a top-level ``from openai import OpenAI`` in
+``embeddings.py`` loaded the SDK (~0.5s) whenever the module was imported and
+openai happened to be installed. That eager cost tripped #116's Python-3.11
+``/health`` hot path. These tests lock the SDK back out and verify the openai
+provider still works over plain HTTP.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from unittest.mock import MagicMock, patch
+
+from empirica.core.qdrant.embeddings import EmbeddingsProvider
+
+
+def test_importing_embeddings_does_not_pull_openai_sdk():
+    """Importing the module must not drag in the openai SDK.
+
+    Runs in a fresh subprocess so prior imports in this test session can't
+    mask a stray eager import.
+    """
+    code = (
+        "import empirica.core.qdrant.embeddings\n"
+        "import sys\n"
+        "assert 'openai' not in sys.modules, "
+        "'embeddings.py eagerly imported the openai SDK'\n"
+        "print('ok')\n"
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "ok" in proc.stdout
+
+
+def test_openai_provider_uses_rest_not_sdk():
+    """The openai provider must embed via a requests.post to /v1/embeddings,
+    carrying the API key as a bearer — with no openai client object."""
+    env = {"EMPIRICA_EMBEDDINGS_PROVIDER": "openai", "OPENAI_API_KEY": "sk-test"}
+    with patch.dict("os.environ", env, clear=False), \
+            patch("empirica.core.qdrant.embeddings._load_config_file",
+                  return_value={}):
+        provider = EmbeddingsProvider()
+        # No SDK client is instantiated — the provider talks REST.
+        assert provider._client is None
+
+        fake_resp = MagicMock()
+        fake_resp.json.return_value = {"data": [{"embedding": [0.1, 0.2, 0.3]}]}
+        fake_resp.raise_for_status.return_value = None
+
+        with patch("requests.post", return_value=fake_resp) as mock_post:
+            vec = provider.embed("hello world")
+
+        assert vec == [0.1, 0.2, 0.3]
+        assert mock_post.call_count == 1
+        url = mock_post.call_args.args[0] if mock_post.call_args.args \
+            else mock_post.call_args.kwargs.get("url")
+        assert "api.openai.com/v1/embeddings" in url
+        headers = mock_post.call_args.kwargs["headers"]
+        assert headers["Authorization"] == "Bearer sk-test"
+
+
+def test_openai_provider_requires_api_key():
+    """Missing OPENAI_API_KEY must fail fast at construction, not at embed time."""
+    with patch.dict("os.environ", {"EMPIRICA_EMBEDDINGS_PROVIDER": "openai"},
+                    clear=False), \
+            patch("empirica.core.qdrant.embeddings._load_config_file",
+                  return_value={}):
+        # Ensure no key leaks in from the ambient env.
+        import os
+        os.environ.pop("OPENAI_API_KEY", None)
+        try:
+            EmbeddingsProvider()
+        except RuntimeError as e:
+            assert "OPENAI_API_KEY" in str(e)
+        else:
+            raise AssertionError("expected RuntimeError when OPENAI_API_KEY is unset")


### PR DESCRIPTION
## Problem

The `openai` embeddings provider used the SDK for exactly two calls — `OpenAI()` and `client.embeddings.create()`. That's a single `POST https://api.openai.com/v1/embeddings`, the same endpoint shape the **jina** and **voyage** providers already hit with plain `requests` (no SDK).

The SDK was never a declared dependency (absent from `pyproject.toml`), but the top-level `try: from openai import OpenAI` in `embeddings.py` loaded it **eagerly** (~0.5s) whenever the module was imported and `openai` happened to be present in the env. That eager cost was the root mechanism behind #116's Python-3.11 `/health` hot-path CI failure.

Empirica's default stack embeds **locally** (ollama / qwen3-embedding); the openai provider is opt-in.

## Fix

- Remove the module-level `openai` import.
- The openai provider now reads `OPENAI_API_KEY` (env or `~/.empirica/embeddings.conf`) at construction — fail-fast if absent, matching jina/voyage.
- New `_embed_openai()` mirrors `_embed_jina()`: `requests.post` to `/v1/embeddings`, bearer auth, local-hash fallback on error.
- `requests` is already a hard dependency, so **no new deps** — the openai SDK simply disappears from the import graph.

## Tests

`tests/test_embeddings_no_openai_sdk.py`:
- importing `empirica.core.qdrant.embeddings` must NOT pull the `openai` SDK (subprocess-isolated invariant)
- openai provider embeds over REST with the bearer header
- missing `OPENAI_API_KEY` fails fast at construction

Local: 9 passed (new suite + qdrant retrieval regressions). `import empirica.core.qdrant.embeddings` confirmed to leave `openai` out of `sys.modules`. Same theme as #119 (kars85's httpx/GitPython lazy-import trim).

🤖 Generated with [Claude Code](https://claude.com/claude-code)