### PR TITLE
fix(serve): gate /listeners behind entity-mint token + document serve API surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to Empirica will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+Serve-daemon hardening and a lighter import surface: the entity-mint and listener
+endpoints are now service-token guarded when the daemon binds beyond loopback, the
+`openai` embeddings provider drops its SDK dependency, and CLI startup sheds two heavy
+imports.
+
+### Added
+- **`GET /api/v1/listeners`** — the serve daemon exposes the registered mesh listeners plus heartbeat freshness, merged from the on-disk registry and health markers, so the Chrome extension can flag silent receive failures (a listener that's alive but no longer receiving) without reading `~/.empirica/` directly. Read-only.
+- **Service-token auth for the hosted entity-mint endpoint** — `POST /api/v1/entities` (and `GET /api/v1/listeners`) are guarded by an `emk_…` bearer token when the daemon binds beyond loopback. Configure the valid-token set via `EMPIRICA_ENTITY_MINT_TOKENS` (comma-separated, rotation-friendly). The daemon refuses to start when bound to a non-loopback host with no token configured (fail-closed), so these surfaces are never exposed unauthenticated. Loopback (same-box) daemons stay auth-free and unchanged.
+
+### Changed
+- **`empirica serve` `/health` reflects the actual configured backends** — Ollama and Qdrant reachability probes now resolve their URLs the same way embeddings does (env var → `~/.empirica/config.yaml` `embeddings.ollama_url` → localhost) instead of always probing hardcoded `localhost:11434` / `localhost:6333`.
+- **`openai` embeddings provider is now REST-only** — the `openai` Python SDK is no longer a dependency; embeddings call the `/v1/embeddings` endpoint directly over HTTP. `OPENAI_API_KEY` is still used for auth; no behaviour change for users.
+- **Faster CLI startup** — `httpx` and `GitPython` imports are deferred off the CLI startup path, trimming cold-start overhead for commands that never touch them.
+
+### Fixed
+- **`listener-on` subscribe tag is canonicalized to the 3-form**, so wake routing addresses the correct practitioner.
+- **Listener garbage collection no longer reaps live launchd-supervised workers** on macOS — liveness derives from the running process rather than the launchd plist location.
+
 ## [1.12.1] — 2026-06-16
 
 A managed-Forgejo publishing path for projects with no public remote, the compliance-report diagnostics emit (an account-gated free funnel into Cortex's System │ Diagnostics surface), plus a sentinel-gating correctness fix and two listener/hook reliability fixes.

--- a/docs/reference/api/SERVE_API.md
+++ b/docs/reference/api/SERVE_API.md
@@ -4,9 +4,22 @@ The `empirica serve` daemon is a localhost FastAPI server that provides REST end
 for the Empirica Chrome extension. The extension extracts epistemic artifacts client-side
 (in TypeScript) and sends them to this daemon for storage in the Empirica database.
 
-**Security model:** Localhost-only by default (`127.0.0.1`). No authentication is required.
-CORS is configured to allow all origins so that `chrome-extension://` URLs can reach the
-server. The security boundary is the network interface, not CORS.
+**Security model:** Localhost-only by default (`127.0.0.1`). For the same-box extension
+case the security boundary is the network interface, not CORS (which is configured to
+allow `chrome-extension://` and localhost origins).
+
+Two surfaces change this picture when the daemon is bound **beyond loopback**:
+
+- **`POST /api/v1/entities`** (the contact-mint endpoint) is guarded by an entity-mint
+  service token — see [Entity Mint](#post-apiv1entities-entity-mint).
+- **`GET /api/v1/listeners`** is guarded by the same token (it exposes listener topic
+  names and last-message bodies).
+
+The daemon **refuses to start** (`assert_bind_safe`) when bound to a non-loopback host
+with no token configured, so the mint and listener surfaces are never exposed
+unauthenticated. Configure the valid-token set via `EMPIRICA_ENTITY_MINT_TOKENS`
+(comma-separated `emk_…` tokens). Loopback (same-box) daemons stay auth-free — the guard
+is inactive when no token set is configured, so the extension's local reads are unchanged.
 
 **Source:** `empirica/api/serve_app.py`
 
@@ -61,8 +74,11 @@ Health check endpoint. Reports daemon status, availability of optional integrati
 
 **Response:** `HealthResponse` (200 OK)
 
-The endpoint probes `localhost:11434` (Ollama) and `localhost:6333` (Qdrant) with a
-2-second timeout to determine availability.
+The endpoint probes the **configured** Ollama and Qdrant backends with a 2-second timeout
+to determine availability. The URLs are resolved the same way embeddings resolves them —
+`EMPIRICA_OLLAMA_URL` / `EMPIRICA_QDRANT_URL` env var → `~/.empirica/config.yaml`
+(`embeddings.ollama_url`) → `localhost:11434` / `localhost:6333` — so a remote backend is
+probed at its real address rather than always reporting localhost.
 
 The active-project fields (`project_id`, `project_path`, `project_name`,
 `project_slug`, `repo_url`) are populated from the daemon's project resolution at
@@ -89,6 +105,68 @@ curl http://localhost:8000/api/v1/health
   "project_slug": "empirica",
   "repo_url": "https://github.com/Nubaeon/empirica"
 }
+```
+
+---
+
+### POST /api/v1/entities (Entity Mint)
+
+Idempotently mint a **contact** into the workspace `entity_registry`. Re-minting with the
+same identity (email first, then a deterministic name/company slug) returns the existing
+`entity_id` with `created=false` — so the same call is a safe no-op on repeat. The returned
+id is the canonical `contact_id` that same-box consumers (e.g. a CRM MCP server) carry as
+their foreign key.
+
+**Auth:** guarded by an entity-mint service-token bearer **when the daemon binds beyond
+loopback** (the hosted deployment). On a loopback daemon the guard is inactive and no bearer
+is required. See the [Security model](#empirica-serve-api-reference) above and
+`empirica/api/entity_mint_auth.py`.
+
+**Request:** `EntityCreateRequest`
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `type` | str | Must be `"contact"` (v1 mints contacts only; `422` otherwise) |
+| `name` | str | Required, contact display name |
+| `email` | str? | Primary identity key for idempotency |
+| `phone` | str? | |
+| `role` | str? | |
+| `company_name` | str? | Part of the fallback identity slug when no email |
+| `description` | str? | |
+| `metadata` | dict? | Extra fields merged into the registry row |
+
+**Response:** `{ok, entity_id, created, matched_by}` (200) — `created` is `false` on a
+verified no-op. `422` for a non-contact type; `400` on mint failure; `401` on
+missing/invalid token when the guard is active.
+
+```bash
+# Non-loopback (guarded) daemon:
+curl -X POST http://host:8000/api/v1/entities \
+  -H "Authorization: Bearer emk_…" \
+  -H "Content-Type: application/json" \
+  -d '{"type":"contact","name":"Ada Lovelace","email":"ada@example.com"}'
+```
+
+---
+
+### GET /api/v1/listeners
+
+Registered mesh listeners plus heartbeat freshness, merged from the on-disk listener
+registry and per-instance health markers. Lets the extension flag silent receive failures
+(a listener that's alive but no longer receiving) without reading `~/.empirica/` directly.
+Read-only.
+
+**Auth:** guarded by the same entity-mint service token as `/api/v1/entities` — the rows
+carry listener `topic` names (which are ntfy subscribe credentials) and `last_message`
+bodies, so a network-exposed daemon must not serve them unauthenticated. The guard is
+inactive on a loopback daemon, so the extension's local read is unchanged.
+
+**Response:** `ListenersResponse` → `{ok, listeners: [ListenerRow]}`. Each `ListenerRow`:
+`instance_id`, `name`, `description`, `topic`, `wake_count`, `last_wake_at`, `last_message`,
+`registered_at`, `health_status` (`ok`|`degraded`|`null`), `health_loop`, `health_ts`.
+
+```bash
+curl http://localhost:8000/api/v1/listeners
 ```
 
 ---
@@ -332,9 +410,8 @@ curl 'http://localhost:8000/api/v1/assumptions?confidence_min=0.7'
 
 Companion to `GET /api/v1/sources` (metadata-only): returns the actual content
 behind a single source row, so a UI viewer can render inline. Added to close
-the source-viewer gap surfaced by extension `prop_fzb63fnlx5` + `prop_bcsecxo2rr`
-— the daemon previously served metadata only, so viewers rendered empty when a
-user clicked through.
+the source-viewer gap — the daemon previously served metadata only, so viewers
+rendered empty when a user clicked through.
 
 ### Response shapes (client branches on `kind`)
 

--- a/empirica/api/serve_app.py
+++ b/empirica/api/serve_app.py
@@ -19,9 +19,11 @@ import logging
 import os
 from pathlib import Path
 
-from fastapi import FastAPI, HTTPException
+from fastapi import Depends, FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel, Field
+
+from empirica.api.entity_mint_auth import verify_mint_bearer
 
 logger = logging.getLogger(__name__)
 
@@ -258,12 +260,24 @@ def create_serve_app() -> FastAPI:
             logger.error(f"Profile sync failed: {e}", exc_info=True)
             raise HTTPException(status_code=500, detail=str(e)) from e
 
-    @app.get("/api/v1/listeners", response_model=ListenersResponse)
+    @app.get(
+        "/api/v1/listeners",
+        response_model=ListenersResponse,
+        dependencies=[Depends(verify_mint_bearer)],
+    )
     async def listeners():  # pyright: ignore[reportUnusedFunction]
         """Registered mesh listeners + heartbeat freshness, merged from the
         on-disk registry + health markers. Lets the extension flag silent
         receive failures (seat alive but deaf) without reading ~/.empirica/
-        directly. Read-only, localhost — same trust surface as /health."""
+        directly. Read-only.
+
+        Guarded by the entity-mint service token: the rows carry listener
+        topic names (ntfy subscribe credentials) and last-message bodies, so
+        a network-exposed daemon must not serve them unauthenticated. The
+        guard is inactive when no token set is configured (the loopback
+        same-box case the extension uses), so local reads are unchanged;
+        a non-loopback bind already requires EMPIRICA_ENTITY_MINT_TOKENS via
+        assert_bind_safe, which then also gates this route."""
         return ListenersResponse(
             ok=True,
             listeners=[ListenerRow(**row) for row in _gather_listeners()],

--- a/tests/test_serve_listeners.py
+++ b/tests/test_serve_listeners.py
@@ -98,3 +98,35 @@ def test_endpoint_returns_rows(fake_home):
     assert body["ok"] is True
     insts = {row["instance_id"] for row in body["listeners"]}
     assert insts == {"empirica", "ecodex"}
+
+
+def test_endpoint_open_when_guard_inactive(fake_home, monkeypatch):
+    """No token set configured (loopback case) → no auth required.
+
+    This is the extension's local read; it must stay unauthenticated.
+    """
+    monkeypatch.delenv("EMPIRICA_ENTITY_MINT_TOKENS", raising=False)
+    client = TestClient(sa.create_serve_app())
+    assert client.get("/api/v1/listeners").status_code == 200
+
+
+def test_endpoint_401_when_guard_active_and_no_bearer(fake_home, monkeypatch):
+    """Token set configured (non-loopback deployment) → bearer required.
+
+    The rows carry ntfy topic names + last-message bodies, so a
+    network-exposed daemon must not serve them unauthenticated.
+    """
+    monkeypatch.setenv("EMPIRICA_ENTITY_MINT_TOKENS", "emk_secret_one")
+    client = TestClient(sa.create_serve_app())
+    assert client.get("/api/v1/listeners").status_code == 401
+
+
+def test_endpoint_200_when_guard_active_with_valid_bearer(fake_home, monkeypatch):
+    monkeypatch.setenv("EMPIRICA_ENTITY_MINT_TOKENS", "emk_secret_one,emk_secret_two")
+    client = TestClient(sa.create_serve_app())
+    r = client.get(
+        "/api/v1/listeners",
+        headers={"Authorization": "Bearer emk_secret_two"},
+    )
+    assert r.status_code == 200
+    assert r.json()["ok"] is True


### PR DESCRIPTION
Follow-ups from the pre-1.12.2 audit sweep (security + docs-align reviews).

## Security (low-sev, from the sec review)
`GET /api/v1/listeners` was unauthenticated. On a **non-loopback** bind it discloses listener `topic` names (ntfy subscribe credentials) and raw `last_message` bodies. Now gated behind the same `verify_mint_bearer` dependency as `/api/v1/entities`:
- **Loopback (no token set):** guard inactive → unchanged, the extension's local read still works unauthenticated.
- **Non-loopback:** already requires `EMPIRICA_ENTITY_MINT_TOKENS` via `assert_bind_safe`, which now also gates this route.

+3 integration tests: open-on-loopback, 401-without-bearer, 200-with-valid-bearer.

## Docs (release blocker, from the docs-align check)
- `SERVE_API.md` **"No authentication is required"** was stale — rewrote the security model to cover the entity-mint/listeners token + the fail-closed non-loopback bind.
- Documented the `POST /api/v1/entities` mint route (shipped in 1.12.0, never documented) and the new `GET /api/v1/listeners` route.
- `/health` doc no longer claims hardcoded `localhost` probes — it resolves the configured ollama/qdrant URLs.
- Scrubbed two peer-AI proposal IDs from the source-content section (public-docs policy).

## CHANGELOG
- Added the `[Unreleased]` section (none existed) covering #114–#120 — the input for the 1.12.2 release notes.

Audit verdicts: security **SAFE TO SHIP** (this was the only finding), code audit **CLEAN**, docs had this one blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)