### PR TITLE
fix(mesh): persist strict canonical 3-form seat into project.yaml (session_init mis-seat, empirica half)

### DIFF
--- a/empirica/cli/command_handlers/setup_claude_code.py
+++ b/empirica/cli/command_handlers/setup_claude_code.py
@@ -1013,6 +1013,19 @@ def _persist_tenant_metadata(
         if value is not None and existing.get(key) != value:
             existing[key] = value
             changed = True
+    # Derive the strict canonical 3-form seat (`org.tenant.project`) from the
+    # effective mesh_id_prefix + the project's ai_id, and persist it so the
+    # daemon/model can pass `seat` to cortex_session_init without re-composing.
+    # Self-heals: recomputes even when the three fields above were unchanged
+    # (e.g. a project.yaml that has mesh_id_prefix + ai_id but no seat yet).
+    from empirica.config.project_config_loader import compose_canonical_seat
+    seat = compose_canonical_seat(
+        mesh_id_prefix=existing.get("mesh_id_prefix") or "",
+        ai_id=existing.get("ai_id") or "",
+    )
+    if seat is not None and existing.get("canonical_seat") != seat:
+        existing["canonical_seat"] = seat
+        changed = True
     if not changed:
         return False
     project_yaml.write_text(

--- a/empirica/config/project_config_loader.py
+++ b/empirica/config/project_config_loader.py
@@ -255,3 +255,28 @@ def compose_ai_id_forms(
         "tenant": f"{tenant_slug}_{basename}",
         "mesh": f"{mesh_id_prefix}_{basename}",
     }
+
+
+def compose_canonical_seat(*, mesh_id_prefix: str, ai_id: str) -> str | None:
+    """Compose the strict canonical 3-form mesh seat `org.tenant.project`.
+
+    This is the DOT-separated wire form that cortex's strict-canonical
+    resolver (`find_users_for_ai_id`, which decodes via `split('.', 2)`)
+    and the `seat` parameter of `cortex_session_init` expect. It is
+    DISTINCT from `compose_ai_id_forms` above, whose `_`-joined forms are
+    the older mesh-addressing convention — do not use those for `seat`.
+
+    `mesh_id_prefix` is the `<org>.<tenant>` prefix cortex returns in
+    session_init / `/v1/tenant/me` (e.g. `empirica.david`); `ai_id` is the
+    project's canonical basename (e.g. `empirica`). Result:
+    `empirica.david.empirica`.
+
+    Returns None when either input is empty, so callers can skip writing a
+    malformed seat (a wrong-form seat is rejected silently by the
+    strict-canonical send resolver).
+    """
+    prefix = (mesh_id_prefix or "").strip().rstrip(".")
+    basename = (ai_id or "").strip()
+    if not prefix or not basename:
+        return None
+    return f"{prefix}.{basename}"

--- a/tests/test_canonical_seat.py
+++ b/tests/test_canonical_seat.py
@@ -1,0 +1,112 @@
+"""Tests for the strict canonical 3-form mesh seat composition + persistence.
+
+The `seat` parameter of cortex_session_init and the strict-canonical send
+resolver expect the DOT-form `org.tenant.project` (decoded via
+`split('.', 2)`). A wrong-form seat is rejected silently, so empirica must
+compose it correctly and persist it into project.yaml for the daemon/model
+to pass.
+"""
+
+from __future__ import annotations
+
+import yaml
+
+from empirica.cli.command_handlers.setup_claude_code import _persist_tenant_metadata
+from empirica.config.project_config_loader import compose_canonical_seat
+
+# ── composer ─────────────────────────────────────────────────────────
+
+def test_compose_canonical_seat_basic():
+    assert compose_canonical_seat(
+        mesh_id_prefix="empirica.david", ai_id="empirica"
+    ) == "empirica.david.empirica"
+
+
+def test_compose_canonical_seat_strips_trailing_dot():
+    # cortex hands the prefix without a trailing dot, but be defensive.
+    assert compose_canonical_seat(
+        mesh_id_prefix="empirica.david.", ai_id="empirica-cortex"
+    ) == "empirica.david.empirica-cortex"
+
+
+def test_compose_canonical_seat_none_on_empty():
+    # Don't manufacture a malformed seat — wrong-form seats fail silently.
+    assert compose_canonical_seat(mesh_id_prefix="", ai_id="empirica") is None
+    assert compose_canonical_seat(mesh_id_prefix="empirica.david", ai_id="") is None
+    assert compose_canonical_seat(mesh_id_prefix="  ", ai_id="  ") is None
+
+
+# ── persistence (self-healing canonical_seat) ────────────────────────
+
+def _write_yaml(path, obj):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(obj, sort_keys=False), encoding="utf-8")
+
+
+def test_persist_writes_canonical_seat(tmp_path):
+    """Persisting tenant fields also derives + writes the canonical_seat."""
+    pj = tmp_path / ".empirica" / "project.yaml"
+    _write_yaml(pj, {"ai_id": "empirica"})
+
+    changed = _persist_tenant_metadata(
+        tmp_path, org_id="org-empirica", tenant_slug="david",
+        mesh_id_prefix="empirica.david",
+    )
+    assert changed is True
+    out = yaml.safe_load(pj.read_text())
+    assert out["mesh_id_prefix"] == "empirica.david"
+    assert out["canonical_seat"] == "empirica.david.empirica"
+
+
+def test_persist_heals_seat_when_core_fields_unchanged(tmp_path):
+    """A project.yaml that already has mesh_id_prefix + ai_id but no seat
+    gets the seat backfilled even though the three core fields don't change."""
+    pj = tmp_path / ".empirica" / "project.yaml"
+    _write_yaml(pj, {
+        "ai_id": "empirica",
+        "org_id": "org-empirica",
+        "tenant_slug": "david",
+        "mesh_id_prefix": "empirica.david",
+        # no canonical_seat
+    })
+
+    changed = _persist_tenant_metadata(
+        tmp_path, org_id="org-empirica", tenant_slug="david",
+        mesh_id_prefix="empirica.david",
+    )
+    assert changed is True  # seat heal alone is a change
+    out = yaml.safe_load(pj.read_text())
+    assert out["canonical_seat"] == "empirica.david.empirica"
+
+
+def test_persist_idempotent_when_seat_already_present(tmp_path):
+    pj = tmp_path / ".empirica" / "project.yaml"
+    _write_yaml(pj, {
+        "ai_id": "empirica",
+        "org_id": "org-empirica",
+        "tenant_slug": "david",
+        "mesh_id_prefix": "empirica.david",
+        "canonical_seat": "empirica.david.empirica",
+    })
+
+    changed = _persist_tenant_metadata(
+        tmp_path, org_id="org-empirica", tenant_slug="david",
+        mesh_id_prefix="empirica.david",
+    )
+    assert changed is False
+
+
+def test_persist_no_seat_without_mesh_prefix(tmp_path):
+    """No mesh_id_prefix → no seat written (can't compose a valid one)."""
+    pj = tmp_path / ".empirica" / "project.yaml"
+    _write_yaml(pj, {"ai_id": "empirica"})
+
+    changed = _persist_tenant_metadata(
+        tmp_path, org_id="org-empirica", tenant_slug="david",
+        mesh_id_prefix=None,
+    )
+    out = yaml.safe_load(pj.read_text())
+    assert "canonical_seat" not in out
+    # org_id + tenant_slug still persisted
+    assert changed is True
+    assert out["org_id"] == "org-empirica"


### PR DESCRIPTION
Empirica's **Phase 2** half of the recurring session_init mis-seat fix (bug 729e845d), split with cortex per David's ratified contract. Cortex owns the resolver + the non-breaking **Phase 1 degrade — now live** (cortex `9187631`): `__seat_identity__` no longer emits the imperative wrong-seat line; multi-project sessions return `my_canonical_seat: null` + `seat_status: multi_project_no_seat` instead of mis-seating to the tenant primary.

## What this adds
cortex_session_init's `seat` param + the strict-canonical send resolver decode `org.tenant.project` via `split('.', 2)` — the **dot** form. Empirica's only existing composer (`compose_ai_id_forms`) produces the older `_`-joined forms, which are the **wrong shape** for `seat` (a wrong-form seat is rejected *silently* — the exact bug class). So:

- **`compose_canonical_seat(mesh_id_prefix, ai_id)`** — the dot-form composer. `mesh_id_prefix` is cortex's `<org>.<tenant>` prefix (e.g. `empirica.david`), already dot-form in the session_init / `/v1/tenant/me` response. Returns `None` on empty input so we never persist a malformed seat.
- **`_persist_tenant_metadata`** now derives + writes **`canonical_seat`** into project.yaml. Self-healing: recomputes even when the three core fields are unchanged, so a project.yaml with `mesh_id_prefix` + `ai_id` but no seat gets it backfilled. The daemon/model reads this one field and passes it as `seat` (cortex's live Phase-1 `__seat_identity__` instructs exactly that).

## Verified against live cortex
Phase 1 confirmed live: `mesh_id_prefix: "empirica.david"`, so `seat = empirica.david.empirica`. Composer + persistence verified.

## Tests
`tests/test_canonical_seat.py` (7): composer basic/trailing-dot/empty→None; persistence writes seat, heals-when-core-unchanged, idempotent, no-seat-without-prefix. 62 passed across the tenant/setup/config suites (no regression).

## Follow-up (separate, riskier — scoped as a goal)
A session-init auto-heal that fetches `/v1/tenant/me` when `mesh_id_prefix` is absent entirely, so existing project.yamls (which carry only `ai_id`) heal without re-running setup. Deferred to avoid network-in-SessionStart-hook risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)