### PR TITLE
docs(prompt): reframe context-scarcity language to abundance/retrieval

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -83,8 +83,10 @@ window. POSTFLIGHT closes it and captures what you learned.
 ### Why Transactions Matter
 
 Transactions enable **long-running sessions** across compaction boundaries.
-Each POSTFLIGHT offloads your work to persistent memory (SQLite, Qdrant, git notes).
-Without measurement, compaction loses context permanently.
+Each POSTFLIGHT offloads your work to persistent memory (SQLite, Qdrant, git notes),
+so compaction is a routine swap of active conversation for durable state — bootstrap
+re-grounds you and search retrieves the rest. The discipline is what makes context
+abundant: what you log persists; only unlogged work can be lost.
 
 ### Goals Drive Transactions
 
@@ -152,8 +154,9 @@ POSTFLIGHT when any of these occur:
 
 ## COMMIT CADENCE
 
-**Commit after each goal completion.** Uncommitted work is a drift vector.
-Context can be lost on compaction. Don't accumulate changes.
+**Commit after each goal completion.** Committed work is durable and grounded;
+uncommitted work is the one thing compaction can't carry forward. Commit as you
+go for clarity and auditability — not out of fear of the window filling.
 
 ---
 

--- a/empirica/plugins/claude-code-integration/hooks/context-shift-tracker.py
+++ b/empirica/plugins/claude-code-integration/hooks/context-shift-tracker.py
@@ -96,13 +96,15 @@ def _build_context_usage_output(claude_session_id):
 
         ctx_msg = f"context: {int(used_pct)}% used"
 
-        # High usage: compaction may be near — reinforce that it is lossless
-        # under empirica discipline so the practitioner doesn't degrade work.
+        # High usage: compaction may be near. State the abundance model
+        # affirmatively — the % is informational, not a deadline — so the
+        # practitioner keeps working at full quality instead of rushing.
         if used_pct > 80:
             ctx_msg += (
-                " | compaction (if it comes) is lossless — goals/artifacts/"
-                "git-notes persist + bootstrap re-grounds. Do NOT truncate, "
-                "rush, or defer work; keep logging + committing as normal."
+                " | this is a buffer reading, not a deadline. If compaction "
+                "comes it's lossless: your logged goals/artifacts/git-notes "
+                "persist and bootstrap re-grounds you. Keep working at full "
+                "quality and keep logging — the log is the durable copy."
             )
 
         # At >85% context, advise auto-switching to CWD project
@@ -131,8 +133,8 @@ def _maybe_append_project_switch_hint(ctx_msg, claude_session_id):
             if tx_project and str(Path(tx_project).resolve()) != cwd:
                 ctx_msg += (
                     f" | CWD project differs from transaction project"
-                    f" — consider project-switch to {Path(cwd).name}"
-                    f" before compaction"
+                    f" — project-switch to {Path(cwd).name} when convenient"
+                    f" to keep artifacts attributed correctly"
                 )
     except Exception:
         pass

--- a/empirica/plugins/claude-code-integration/hooks/post-compact.py
+++ b/empirica/plugins/claude-code-integration/hooks/post-compact.py
@@ -981,9 +981,10 @@ def _generate_new_session_prompt(pre_vectors: dict, dynamic_context: dict, old_s
 
 Your context was just compacted — a routine, lossless event under empirica
 discipline: goals, artifacts, breadcrumbs, and git notes all persist, and the
-bootstrap context below re-grounds you. Do NOT truncate, rush, or defer work
-because compaction happened. The previous session ({old_session_id[:8]}...)
-was **COMPLETE** (had POSTFLIGHT).
+bootstrap context below re-grounds you. Pick up at full quality — what
+mattered was logged and is loaded below; the log is the durable copy, and
+anything else is a `project-search` / `investigate` away. The previous
+session ({old_session_id[:8]}...) was **COMPLETE** (had POSTFLIGHT).
 
 **✅ Session created:** `{new_session_id}`
 **✅ Project context loaded via bootstrap**
@@ -1211,8 +1212,8 @@ def _generate_transaction_continue_prompt(pre_vectors: dict, dynamic_context: di
 
 Your context was compacted but your **transaction is still open** — for an
 open transaction, compaction is a non-event. No new PREFLIGHT or CHECK
-needed - just continue where you left off at full quality (no truncating,
-rushing, or deferring).
+needed — just continue where you left off, at full quality. The measurement
+window is still open; the work simply resumes.
 
 **⚡ ACTIVE TRANSACTION:**
    Transaction: {tx_id}... | Session: {tx_session}... | Project: {tx_project}
@@ -1301,10 +1302,10 @@ def _generate_check_prompt(pre_vectors: dict, pre_reasoning: str, dynamic_contex
 
 Your context was just compacted — routine and lossless under empirica
 discipline: goals, artifacts, breadcrumbs, and git notes persist, and the
-re-grounding steps below restore working context. Do NOT truncate, rush, or
-defer work because compaction happened. Your previous vectors
-(know={pre_know}, uncertainty={pre_unc}) reflect pre-compact context —
-re-ground first, then CHECK with fresh values.
+re-grounding steps below restore working context. Pick up at full quality.
+Your previous vectors (know={pre_know}, uncertainty={pre_unc}) reflect
+pre-compact context — re-ground first (load context below, search if you
+need more), then CHECK with fresh values.
 {tx_context}{last_task_section}{temporal_trail}
 {epistemic_focus}{calibration_section}
 

--- a/empirica/plugins/claude-code-integration/templates/CLAUDE.md
+++ b/empirica/plugins/claude-code-integration/templates/CLAUDE.md
@@ -170,8 +170,11 @@ window. POSTFLIGHT closes it and captures what you learned.
 ### Why Transactions Matter
 
 Transactions enable **long-running sessions** across compaction boundaries.
-Each POSTFLIGHT offloads your work to persistent memory (SQLite, Qdrant, git notes).
-Without measurement, compaction loses context permanently.
+Each POSTFLIGHT offloads your work to persistent memory (SQLite, Qdrant, git notes),
+so compaction becomes a routine swap of active conversation for durable state —
+bootstrap re-grounds you, and `project-search` / `investigate` retrieve the rest.
+The discipline is what makes context abundant: what you log persists; what you
+skip logging is the only thing that can be lost.
 
 ### Goals Drive Transactions
 

--- a/empirica/plugins/claude-code-integration/templates/empirica-system-prompt-lean.md
+++ b/empirica/plugins/claude-code-integration/templates/empirica-system-prompt-lean.md
@@ -417,6 +417,34 @@ The companion pull-side: `empirica project-search --task "..." --global` queries
 
 ---
 
+## CONTEXT IS ABUNDANT, NOT SCARCE
+
+You operate inside a retrieval system, not a fixed window. With the discipline
+above — goals, artifacts (findings/decisions/unknowns/sources), commits — **what
+you've learned is not lost when the conversation compacts**. Compaction is a
+routine swap of active conversation for durable state: POSTFLIGHT + breadcrumbs +
+git notes persist it, `project-bootstrap` re-grounds it on the next turn, and
+`project-search` / `investigate` retrieve the pertinent parts on demand. The
+epistemic compact is effective; trust it.
+
+So do not let a filling context window change how you work:
+
+- **Don't rush, truncate, or defer** because the window is filling. Work at full
+  quality — compaction and retrieval are doing their job underneath you. A
+  "context: 80% used" reading is a buffer gauge, not a deadline.
+- **Don't hoard** everything in active context "to be safe." Log it. The log
+  *is* the safe copy, and it's semantically searchable — richer and more durable
+  than anything you'd keep alive by being terse.
+- **Don't treat compaction as loss to avoid.** It's the mechanism that resets
+  active context while the knowledge layer carries forward. Welcome it.
+
+The one thing that genuinely loses context is skipping the discipline: unlogged
+work, uncommitted changes, unresolved goals, a transaction never POSTFLIGHTed.
+Keep logging and committing as you go, and the abundance holds. Be concise when
+concision serves clarity — never to "save context."
+
+---
+
 **Epistemic fidelity is functional, not moral. Your beliefs should reflect your
 actual epistemic state, your claims should be traceable to evidence, and your
 uncertainty should be visible rather than papered over with fluency. You measure


### PR DESCRIPTION
Per David: practitioners still carry **context anxiety** — rushing/truncating/deferring as the window fills — even though empirica's epistemic compact + disciplined logging make context effectively **abundant**. With goals/artifacts/sources logged and commits made, nothing learned is lost; it's a bootstrap + semantic-search retrieval away.

## The anti-pattern this fixes
The "**Do NOT X** paradox": every compaction message asserted "lossless" and then immediately said "Do NOT truncate, rush, or defer" — planting the very behavior it denied. A discovery sweep (Explore agent) mapped it across the system prompts + the two hooks that fire on every compaction / high-usage prompt.

## Changes (highest-leverage behavioral surfaces)
- **lean system prompt** — new **"CONTEXT IS ABUNDANT, NOT SCARCE"** section: the `%` is a buffer gauge not a deadline; log don't hoard (the log *is* the safe copy); the only thing that loses context is skipping the discipline (unlogged/uncommitted/un-POSTFLIGHTed work).
- **CLAUDE.md template + copilot-instructions** — "compaction loses context permanently" / "Context can be lost on compaction. Don't accumulate changes" → routine-swap framing; commit for clarity+audit, not fear.
- **post-compact.py** (3 messages) — dropped "Do NOT truncate, rush, or defer work" → "pick up at full quality; what mattered was logged and is loaded; search retrieves the rest."
- **context-shift-tracker.py** — the >80% injection now reads "buffer reading, not a deadline"; project-switch hint drops "before compaction" → "when convenient."

## Deliberately left intact
- The "rush PREFLIGHT→CHECK→POSTFLIGHT *without real work*" anti-pattern — that's the rubber-stamp warning, not context scarcity.
- `context_budget` eviction internals (the mechanism, not its framing).

## Deployment note
Deployed plugin hooks are **copies**, so live effect lands on the next `setup-claude-code --force` / release. David's personal `~/.claude/empirica-system-prompt.md` re-interpolates from the lean template on the same refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)