### PR TITLE
fix(preflight): read prior-tx retrospective from reflex_data, not the dead meta column

### DIFF
--- a/empirica/cli/command_handlers/_workflow_preflight.py
+++ b/empirica/cli/command_handlers/_workflow_preflight.py
@@ -359,7 +359,7 @@ def _feedback_extract_retrospective(cursor, session_id):
     Returns (feedback_dict, pf_meta) or (None, None) if no retrospective found.
     """
     cursor.execute("""
-        SELECT meta FROM reflexes
+        SELECT reflex_data FROM reflexes
         WHERE session_id = ? AND phase = 'POSTFLIGHT'
         ORDER BY timestamp DESC LIMIT 1
     """, (session_id,))

--- a/tests/test_preflight_feedback_column.py
+++ b/tests/test_preflight_feedback_column.py
@@ -1,0 +1,70 @@
+"""Regression: PREFLIGHT prior-transaction feedback must read the right column.
+
+The behavioral-feedback feature persists the POSTFLIGHT retrospective into the
+`reflexes.reflex_data` JSON blob, but `_feedback_extract_retrospective` was
+querying a non-existent `meta` column — so the query errored, got swallowed by
+the caller's try/except, and the feature silently returned `None` on every
+PREFLIGHT. This locks the column name so the regression can't return.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+
+from empirica.cli.command_handlers._workflow_preflight import (
+    _feedback_extract_retrospective,
+)
+
+
+def _reflexes_db() -> sqlite3.Connection:
+    # Minimal schema: just the columns the extractor touches. Crucially there is
+    # NO `meta` column — so a query against `meta` raises OperationalError and
+    # the test fails, exactly as the bug would.
+    conn = sqlite3.connect(":memory:")
+    conn.execute(
+        "CREATE TABLE reflexes (session_id TEXT, phase TEXT, timestamp REAL, reflex_data TEXT)"
+    )
+    return conn
+
+
+def test_feedback_extracted_from_reflex_data_column():
+    conn = _reflexes_db()
+    retro = {
+        "artifact_counts": {
+            "findings": 1, "decisions": 1, "unknowns": 0,
+            "dead_ends": 0, "mistakes": 0, "assumptions": 0,
+        },
+        "sources_discipline_note": "2 artifacts logged with 0 source_refs.",
+    }
+    conn.execute(
+        "INSERT INTO reflexes (session_id, phase, timestamp, reflex_data) VALUES (?,?,?,?)",
+        ("s1", "POSTFLIGHT", 1.0, json.dumps({"retrospective": retro})),
+    )
+
+    feedback, pf_meta = _feedback_extract_retrospective(conn.cursor(), "s1")
+
+    # Was None for the whole life of the bug (wrong column → swallowed error).
+    assert feedback is not None
+    assert feedback["artifact_gaps"] == ["unknowns", "dead_ends", "mistakes", "assumptions"]
+    assert "sources_discipline_warning" in feedback
+    assert pf_meta["retrospective"]["artifact_counts"]["findings"] == 1
+
+
+def test_feedback_none_when_no_postflight_row():
+    conn = _reflexes_db()
+    feedback, pf_meta = _feedback_extract_retrospective(conn.cursor(), "s1")
+    assert feedback is None and pf_meta is None
+
+
+def test_feedback_picks_latest_postflight():
+    conn = _reflexes_db()
+    for ts, n in ((1.0, 0), (2.0, 3)):
+        rd = {"retrospective": {"artifact_counts": {"findings": n}}}
+        conn.execute(
+            "INSERT INTO reflexes (session_id, phase, timestamp, reflex_data) VALUES (?,?,?,?)",
+            ("s1", "POSTFLIGHT", ts, json.dumps(rd)),
+        )
+    _, pf_meta = _feedback_extract_retrospective(conn.cursor(), "s1")
+    # ORDER BY timestamp DESC LIMIT 1 → the ts=2.0 row.
+    assert pf_meta["retrospective"]["artifact_counts"]["findings"] == 3


### PR DESCRIPTION
Found while building the retrospective soft-gate: the prior-transaction **behavioral-feedback feature has been silently dead**.

The feature persists the POSTFLIGHT retrospective into `reflexes.reflex_data`, but `_feedback_extract_retrospective` queried a non-existent `meta` column → `OperationalError` → swallowed by the caller's try/except → `previous_transaction_feedback: null` on **every PREFLIGHT** (visible all this session).

## Fix
One line: `SELECT meta` → `SELECT reflex_data`. **Verified end-to-end against real stored data** — the extractor now returns artifact gaps, edge-density + sources-discipline warnings, and context-shift counts from the prior transaction (where it returned `None` before).

## Test
Regression test locks the column — its minimal in-memory table has **no `meta` column**, so reverting to `meta` fails the test. 3 new + 28 broader preflight/workflow tests pass.

## Follow-up (documented, next PR)
The retrospective soft-gate (Piece 2) depends on this read path. It also needs `work_type` + a praxic summary (commits/files) persisted into `reflex_data` — currently absent (work_type lost to the known postflight tx-file overwrite; git evidence computed *after* the checkpoint write). That persistence + the gate are the next transaction, scoped on these findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)