### PR TITLE
feat(postflight): persist work_type + phase_tool_counts into reflex_data

### DIFF
--- a/empirica/cli/command_handlers/_workflow_postflight.py
+++ b/empirica/cli/command_handlers/_workflow_postflight.py
@@ -1537,6 +1537,13 @@ def handle_postflight_submit_command(args):
                     "deltas": deltas, "trajectory_issues": trajectory_issues,
                     "transaction_id": tx_info["transaction_id"],
                     "tool_call_count": tx_info["tool_call_count"],
+                    # Persisted for the next PREFLIGHT's prior-tx feedback + the
+                    # retrospective gate: work_type (mechanical-exemption) and
+                    # phase_tool_counts (praxic_tool_calls = the "was there
+                    # substantive praxic activity" signal). Both come from the
+                    # already-loaded tx_info — no git read, no reordering.
+                    "work_type": tx_info["work_type"],
+                    "phase_tool_counts": tx_info["phase_tool_counts"],
                     "avg_turns_at_start": tx_info["avg_turns"],
                     "context_shifts": tx_info["context_shifts"] if tx_info["context_shifts"].get('unsolicited_prompts', 0) > 0 else None,
                     "entity_context": tx_info["entity_context"] or None,


### PR DESCRIPTION
Part B of the retrospective soft-gate. The POSTFLIGHT `reflex_data` blob carried `retrospective.artifact_counts` but **not** `work_type` or any praxic signal — so the (just-revived) prior-tx feedback and the upcoming seam-gate couldn't tell "was this substantive work" or "is this a mechanical work_type to exempt".

Both values are already in the loaded `tx_info` at the checkpoint write, so this is a clean 2-field addition — **no git read, no reordering, no new tx-file race** (the earlier-feared obstacles all dissolved once I found `praxic_tool_calls` already tracked in `phase_tool_counts`):
- `work_type` → mechanical/release exemption signal.
- `phase_tool_counts` (`noetic_tool_calls` / `praxic_tool_calls`) → `praxic_tool_calls` is the "was there substantive praxic activity" signal.

## Verified end-to-end (live)
This PR's own POSTFLIGHT ran the new code; querying the resulting `reflex_data`:
```
work_type: 'code'
phase_tool_counts: {'noetic_tool_calls': 2, 'praxic_tool_calls': 4}
```
Both were absent before. 221 postflight tests pass — no regression.

Part C (the seam-gate) reads these.

🤖 Generated with [Claude Code](https://claude.com/claude-code)