### PR TITLE
fix(sql): revive 5 silently-dead queries (column renames) found by the schema guard

### DIFF
--- a/empirica/api/serve_app.py
+++ b/empirica/api/serve_app.py
@@ -582,35 +582,35 @@ def _store_artifacts(artifacts: list[ArtifactPayload]) -> dict:
         try:
             if atype == "finding":
                 db.adapter.execute(
-                    "INSERT INTO project_findings (id, project_id, session_id, finding, impact, created_at) "
+                    "INSERT INTO project_findings (id, project_id, session_id, finding, impact, created_timestamp) "
                     "VALUES (?, ?, ?, ?, ?, ?)",
                     (artifact_id, "extension-import", None,
                      content, meta.get("impact", 0.5), now),
                 )
             elif atype == "decision":
                 db.adapter.execute(
-                    "INSERT INTO project_findings (id, project_id, session_id, finding, impact, created_at) "
+                    "INSERT INTO project_findings (id, project_id, session_id, finding, impact, created_timestamp) "
                     "VALUES (?, ?, ?, ?, ?, ?)",
                     (artifact_id, "extension-import", None,
                      f"[decision] {content}", meta.get("impact", 0.5), now),
                 )
             elif atype == "dead_end":
                 db.adapter.execute(
-                    "INSERT INTO project_dead_ends (id, project_id, session_id, approach, why_failed, created_at) "
+                    "INSERT INTO project_dead_ends (id, project_id, session_id, approach, why_failed, created_timestamp) "
                     "VALUES (?, ?, ?, ?, ?, ?)",
                     (artifact_id, "extension-import", None,
                      content, meta.get("whyFailed", ""), now),
                 )
             elif atype == "mistake":
                 db.adapter.execute(
-                    "INSERT INTO mistakes_made (id, project_id, session_id, mistake, why_wrong, prevention, created_at) "
+                    "INSERT INTO mistakes_made (id, project_id, session_id, mistake, why_wrong, prevention, created_timestamp) "
                     "VALUES (?, ?, ?, ?, ?, ?, ?)",
                     (artifact_id, "extension-import", None,
                      content, meta.get("whyFailed", ""), meta.get("prevention", ""), now),
                 )
             elif atype == "unknown":
                 db.adapter.execute(
-                    "INSERT INTO project_unknowns (id, project_id, session_id, unknown, created_at) "
+                    "INSERT INTO project_unknowns (id, project_id, session_id, unknown, created_timestamp) "
                     "VALUES (?, ?, ?, ?, ?)",
                     (artifact_id, "extension-import", None,
                      content, now),

--- a/empirica/cli/command_handlers/graph_commands.py
+++ b/empirica/cli/command_handlers/graph_commands.py
@@ -673,7 +673,7 @@ def handle_resolve_artifacts_command(args):  # noqa: C901 — batch dispatcher f
                     cursor = db.conn.cursor()
                     cursor.execute(
                         "UPDATE project_unknowns SET is_resolved = 1, resolved_by = ?, "
-                        "resolved_timestamp = datetime('now') WHERE unknown_id LIKE ?",
+                        "resolved_timestamp = datetime('now') WHERE id LIKE ?",
                         (resolution, f"{artifact_id}%"),
                     )
                     if cursor.rowcount > 0:

--- a/empirica/core/issue_capture.py
+++ b/empirica/core/issue_capture.py
@@ -339,7 +339,7 @@ class AutoIssueCaptureService:
             # Update issue_category field
             cursor.execute("""
                 UPDATE auto_captured_issues
-                SET issue_category = ?
+                SET category = ?
                 WHERE id = ?
             """, (issue_type, issue_id))
 

--- a/empirica/plugins/claude-code-integration/hooks/post-compact.py
+++ b/empirica/plugins/claude-code-integration/hooks/post-compact.py
@@ -737,11 +737,11 @@ def _load_dynamic_context(session_id: str, ai_id: str, pre_snapshot: dict) -> di
         context["pending_subtasks"] = []
         for goal in context["active_goals"]:
             cursor.execute("""
-                SELECT id, description, status, importance, created_timestamp
+                SELECT id, description, status, epistemic_importance, created_timestamp
                 FROM subtasks
                 WHERE goal_id = ? AND status != 'completed'
                 ORDER BY
-                    CASE importance
+                    CASE epistemic_importance
                         WHEN 'critical' THEN 1
                         WHEN 'high' THEN 2
                         WHEN 'medium' THEN 3

--- a/empirica/plugins/claude-code-integration/hooks/sentinel-gate.py
+++ b/empirica/plugins/claude-code-integration/hooks/sentinel-gate.py
@@ -2176,12 +2176,12 @@ def _validate_check_record(cursor, session_id: str, current_transaction_id, pref
         if noetic_duration < min_duration:
             cursor.execute("""
                 SELECT COUNT(*) FROM project_findings
-                WHERE session_id = ? AND timestamp > ? AND timestamp < ?
+                WHERE session_id = ? AND created_timestamp > ? AND created_timestamp < ?
             """, (session_id, preflight_ts, check_ts))
             findings = cursor.fetchone()[0]
             cursor.execute("""
                 SELECT COUNT(*) FROM project_unknowns
-                WHERE session_id = ? AND timestamp > ? AND timestamp < ?
+                WHERE session_id = ? AND created_timestamp > ? AND created_timestamp < ?
             """, (session_id, preflight_ts, check_ts))
             unknowns = cursor.fetchone()[0]
             if findings == 0 and unknowns == 0:

--- a/tests/test_sql_schema_references.py
+++ b/tests/test_sql_schema_references.py
@@ -272,14 +272,9 @@ def _missing_symbol(message: str) -> str:
 # the violations are listed here in the open, tracked, and CI-guarded against
 # regrowth. Fix-tracking goal: "SQL schema-reference audit — fix the 17 dead queries".
 _KNOWN_VIOLATIONS: frozenset[tuple[str, str]] = frozenset({
-    ("empirica/api/serve_app.py", "created_at"),
-    ("empirica/core/issue_capture.py", "issue_category"),
-    ("empirica/plugins/claude-code-integration/hooks/sentinel-gate.py", "timestamp"),
-    ("empirica/plugins/claude-code-integration/hooks/post-compact.py", "importance"),
     ("empirica/core/post_test/calibration_insights.py", "calibration_score"),
     ("empirica/core/sentinel/orchestrator.py", "scope_breadth"),
     ("empirica/cli/command_handlers/docs_commands.py", "project_id"),
-    ("empirica/cli/command_handlers/graph_commands.py", "unknown_id"),
     ("empirica/cli/command_handlers/agent_commands.py", "vectors_json"),
     ("empirica/cli/command_handlers/_workflow_preflight.py", "project_id"),
     ("empirica/cli/command_handlers/_workflow_preflight.py", "updated_at"),


### PR DESCRIPTION
Category-A of the 17 the schema-reference guard (#130) surfaced — pure column-name mismatches, verified via PRAGMA, swallowed by broad excepts so the features were silently dead.

- **serve_app.py ×5** — `created_at` → `created_timestamp`. The daemon's artifact-import has been silently failing on finding/dead-end/mistake/unknown inserts. **Restored.**
- **issue_capture.py** — `issue_category` → `category` (read path already used `category`).
- **sentinel-gate.py ×2** — `timestamp` → `created_timestamp` (REAL epoch, matches comparands).
- **post-compact.py** — subtasks `importance` → `epistemic_importance`.
- **graph_commands.py** — `unknown_id` → `id` (the PK).

Each removed from `_KNOWN_VIOLATIONS` (ratchet 17→7). Guard green; 24 focused tests pass.

The remaining 7 are **behaviour-revival restructures in core paths** (not renames) — fully analysed + specified in the tracking goal/finding, deferred for careful per-bug fixing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)