### PR TITLE
fix(sql): revive 7 Category-B silently-dead static queries

### DIFF
--- a/empirica/cli/command_handlers/_workflow_preflight.py
+++ b/empirica/cli/command_handlers/_workflow_preflight.py
@@ -442,12 +442,15 @@ def _feedback_compute_calibration_trend(cursor, ai_id, project_id):
     if not project_id:
         return None
     try:
+        # grounded_verifications has no project_id column — join through sessions.
         cursor.execute("""
-            SELECT overall_calibration_score FROM grounded_verifications
-            WHERE ai_id = ? AND project_id = ?
-            AND overall_calibration_score IS NOT NULL
-            AND overall_calibration_score > 0
-            ORDER BY created_at DESC LIMIT 10
+            SELECT gv.overall_calibration_score
+            FROM grounded_verifications gv
+            JOIN sessions s ON gv.session_id = s.session_id
+            WHERE gv.ai_id = ? AND s.project_id = ?
+            AND gv.overall_calibration_score IS NOT NULL
+            AND gv.overall_calibration_score > 0
+            ORDER BY gv.created_at DESC LIMIT 10
         """, (ai_id, project_id))
         recent_scores = [r[0] for r in cursor.fetchall()]
         if len(recent_scores) < 3:
@@ -520,8 +523,9 @@ def _preflight_get_last_session_ts(db, project_id, session_id):
     """Get the last session timestamp for adaptive pattern retrieval depth."""
     try:
         cursor = db.conn.cursor()
+        # sessions has no updated_at column; start_time is the ISO-8601 row time.
         cursor.execute("""
-            SELECT MAX(updated_at) FROM sessions
+            SELECT MAX(start_time) FROM sessions
             WHERE project_id = ? AND session_id != ?
         """, (project_id, session_id))
         row = cursor.fetchone()

--- a/empirica/cli/command_handlers/agent_commands.py
+++ b/empirica/cli/command_handlers/agent_commands.py
@@ -52,14 +52,28 @@ def handle_agent_spawn_command(args) -> dict | int | None:
             try:
                 db = SessionDatabase()
                 cursor = db.conn.cursor()
+                # Vectors live in individual reflexes columns, not a JSON blob
+                # (reflex_data only holds prompt_summary/uncertainty_notes).
+                # Kept as a static query so the schema-reference guard validates it.
                 cursor.execute("""
-                    SELECT vectors_json FROM reflexes
+                    SELECT know, do, context, clarity, coherence, signal,
+                           density, state, change, completion, impact,
+                           uncertainty, engagement
+                    FROM reflexes
                     WHERE session_id = ? AND phase IN ('PREFLIGHT', 'POSTFLIGHT')
                     ORDER BY timestamp DESC LIMIT 1
                 """, (session_id,))
                 row = cursor.fetchone()
-                if row and row[0]:
-                    grounding = json.loads(row[0])
+                if row:
+                    vector_cols = [
+                        'know', 'do', 'context', 'clarity', 'coherence',
+                        'signal', 'density', 'state', 'change', 'completion',
+                        'impact', 'uncertainty', 'engagement',
+                    ]
+                    grounding = {
+                        col: row[i] for i, col in enumerate(vector_cols)
+                        if row[i] is not None
+                    }
                 db.close()
             except Exception:
                 pass

--- a/empirica/cli/command_handlers/docs_commands.py
+++ b/empirica/cli/command_handlers/docs_commands.py
@@ -1844,10 +1844,10 @@ class DocsExplainAgent:
             db = SessionDatabase()
             cursor = db.conn.cursor()
             cursor.execute("""
-                SELECT project_id FROM projects
-                WHERE root_path LIKE ? OR name = ?
+                SELECT id FROM projects
+                WHERE name = ?
                 ORDER BY created_timestamp DESC LIMIT 1
-            """, (f"%{self.root.name}%", self.root.name))
+            """, (self.root.name,))
             row = cursor.fetchone()
             db.close()
             if row:

--- a/empirica/cli/command_handlers/goal_commands.py
+++ b/empirica/cli/command_handlers/goal_commands.py
@@ -2743,21 +2743,24 @@ def _prune_test_pollution(cursor, project_id: str, dry_run: bool) -> list[dict]:
     #   suffix forms — '... test', 'No X test', 'Post-fix test', 'Invalid X test'
     # Suffix forms catch the throwaway names test runners and old
     # development phases leave behind.
+    # ai_id lives on sessions, not goals — LEFT JOIN so test-pollution goals
+    # with a NULL session_id still match on the objective patterns.
     cursor.execute(
-        "SELECT id, objective, ai_id FROM goals "
-        "WHERE is_completed = 0 "
-        "AND (project_id = ? OR project_id IS NULL) "
+        "SELECT g.id, g.objective, s.ai_id FROM goals g "
+        "LEFT JOIN sessions s ON g.session_id = s.session_id "
+        "WHERE g.is_completed = 0 "
+        "AND (g.project_id = ? OR g.project_id IS NULL) "
         "AND ("
-        "     objective LIKE 'Test %' OR objective LIKE 'test %' "
-        "     OR objective LIKE 'E2E test%' "
-        "     OR objective LIKE 'Final test%' "
-        "     OR objective LIKE 'Post-fix test%' "
-        "     OR objective LIKE 'Invalid % test%' "
-        "     OR objective LIKE 'No % test%' "
-        "     OR objective LIKE '% test goal%' "
-        "     OR objective LIKE '% test issue%' "
-        "     OR objective LIKE '%smoke test%' "
-        "     OR ai_id LIKE 'test-%' OR ai_id = 'test'"
+        "     g.objective LIKE 'Test %' OR g.objective LIKE 'test %' "
+        "     OR g.objective LIKE 'E2E test%' "
+        "     OR g.objective LIKE 'Final test%' "
+        "     OR g.objective LIKE 'Post-fix test%' "
+        "     OR g.objective LIKE 'Invalid % test%' "
+        "     OR g.objective LIKE 'No % test%' "
+        "     OR g.objective LIKE '% test goal%' "
+        "     OR g.objective LIKE '% test issue%' "
+        "     OR g.objective LIKE '%smoke test%' "
+        "     OR s.ai_id LIKE 'test-%' OR s.ai_id = 'test'"
         ")",
         (project_id,),
     )

--- a/empirica/core/post_test/calibration_insights.py
+++ b/empirica/core/post_test/calibration_insights.py
@@ -120,8 +120,8 @@ class CalibrationInsightsAnalyzer:
             cursor = self.db.conn.cursor()
             cursor.execute(
                 """SELECT verification_id, session_id, phase, evidence_count,
-                          grounded_coverage, calibration_score, gaps, metadata,
-                          created_at
+                          grounded_coverage, overall_calibration_score,
+                          calibration_gaps, created_at
                    FROM grounded_verifications
                    ORDER BY created_at DESC
                    LIMIT ?""",
@@ -137,12 +137,6 @@ class CalibrationInsightsAnalyzer:
                         gaps = json.loads(row[6])
                     except (json.JSONDecodeError, TypeError):
                         pass
-                metadata = {}
-                if row[7]:
-                    try:
-                        metadata = json.loads(row[7])
-                    except (json.JSONDecodeError, TypeError):
-                        pass
                 records.append({
                     'verification_id': row[0],
                     'session_id': row[1],
@@ -151,8 +145,7 @@ class CalibrationInsightsAnalyzer:
                     'grounded_coverage': row[4],
                     'calibration_score': row[5],
                     'gaps': gaps,
-                    'metadata': metadata,
-                    'created_at': row[8],
+                    'created_at': row[7],
                 })
             return records
         except Exception as e:

--- a/empirica/core/sentinel/orchestrator.py
+++ b/empirica/core/sentinel/orchestrator.py
@@ -1153,7 +1153,7 @@ class Sentinel:
         db = SessionDatabase()
         cursor = db.conn.cursor()
         cursor.execute(
-            "SELECT scope_breadth, scope_duration, scope_coordination FROM goals WHERE id = ?",
+            "SELECT scope FROM goals WHERE id = ?",
             (goal_id,)
         )
         row = cursor.fetchone()
@@ -1161,11 +1161,24 @@ class Sentinel:
 
         sentinel = cls(session_id=session_id)
 
-        if row:
+        # goals.scope is a JSON blob: {"breadth": .., "duration": .., "coordination": ..}
+        # (written by GoalRepository.create_goal). Parse defensively — legacy rows
+        # may hold a float/string instead of a dict.
+        scope_data: dict = {}
+        if row and row[0]:
+            import json
+            try:
+                parsed = json.loads(row[0])
+                if isinstance(parsed, dict):
+                    scope_data = parsed
+            except (json.JSONDecodeError, TypeError):
+                pass
+
+        if scope_data:
             sentinel.init_loop_tracking(
-                scope_breadth=row[0] or 0.5,
-                scope_duration=row[1] or 0.5,
-                scope_coordination=row[2] or 0.3
+                scope_breadth=scope_data.get('breadth') or 0.5,
+                scope_duration=scope_data.get('duration') or 0.5,
+                scope_coordination=scope_data.get('coordination') or 0.3
             )
 
         return sentinel

--- a/tests/test_sql_schema_references.py
+++ b/tests/test_sql_schema_references.py
@@ -271,15 +271,7 @@ def _missing_symbol(message: str) -> str:
 # its entry is removed. This shrinks toward empty — a ratchet, not a sweep:
 # the violations are listed here in the open, tracked, and CI-guarded against
 # regrowth. Fix-tracking goal: "SQL schema-reference audit — fix the 17 dead queries".
-_KNOWN_VIOLATIONS: frozenset[tuple[str, str]] = frozenset({
-    ("empirica/core/post_test/calibration_insights.py", "calibration_score"),
-    ("empirica/core/sentinel/orchestrator.py", "scope_breadth"),
-    ("empirica/cli/command_handlers/docs_commands.py", "project_id"),
-    ("empirica/cli/command_handlers/agent_commands.py", "vectors_json"),
-    ("empirica/cli/command_handlers/_workflow_preflight.py", "project_id"),
-    ("empirica/cli/command_handlers/_workflow_preflight.py", "updated_at"),
-    ("empirica/cli/command_handlers/goal_commands.py", "ai_id"),
-})
+_KNOWN_VIOLATIONS: frozenset[tuple[str, str]] = frozenset()
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## What

Fixes the 7 remaining **Category-B** dead static SQL queries flagged by the schema-reference guard (`tests/test_sql_schema_references.py`). Category-A (5 mechanical renames) shipped in #131; these are the core-path **behavior revivals** — each query named a column that doesn't exist, the `OperationalError` was swallowed by a broad `except`, and the feature silently no-op'd for an unknown duration.

Every fix was verified against the **real schema** (built via the production schema builders for `grounded_verifications` / `goals` / `projects` / `reflexes` / `sessions`), not from priors.

| Site | Bug | Fix |
|---|---|---|
| `calibration_insights._get_recent_verifications` | `calibration_score`, `gaps`, `metadata` | → `overall_calibration_score`, `calibration_gaps`; dropped `metadata` (no such column, key unused downstream); reindexed `created_at` |
| `orchestrator.from_goal` | `scope_breadth/duration/coordination` columns don't exist | read the `scope` JSON blob, parse `breadth/duration/coordination` |
| `docs_commands._detect_project_id` | `project_id` **and** `root_path` | `SELECT id`, drop dead `root_path LIKE` clause, match on `name` |
| `agent_commands` turtle grounding | `vectors_json` column doesn't exist; `reflex_data` has no `vectors` key | read individual vector columns (`know`…`engagement`), build grounding dict |
| `_workflow_preflight` calibration trend | `grounded_verifications` has no `project_id` | JOIN `sessions` on `session_id`, filter `s.project_id` |
| `_workflow_preflight` last-session-ts | `sessions` has no `updated_at` | `MAX(start_time)` (ISO-8601) |
| `goal_commands._prune_test_pollution` | `ai_id` lives on `sessions`, not `goals` | LEFT JOIN `sessions` (NULL-session goals still match objective patterns) |

## Two things session-verification caught (the spec wasn't ground truth)

1. **`agent_commands`** — the deferred spec said read `reflex_data.get('vectors')`. But `reflex_data` stores only `{prompt_summary, uncertainty_notes}` — there is no `vectors` key. The canonical vectors are the individual reflexes columns. The wrong spec would have produced an always-empty grounding, silently.
2. **`docs_commands`** — the guard flagged only `project_id`, but `root_path` was *also* dead. `EXPLAIN` halts at the first bad column, so a violation can mask a sibling behind it. Re-running the guard after each fix surfaces the next.

## Verification

- Guard: **0 known + 0 new violations** (was 7 known); `_KNOWN_VIOLATIONS` allowlist emptied. 523 static queries validated via `EXPLAIN`.
- `agent_commands` query kept **static** (not f-string) so the guard keeps validating it — future vector-column renames fail at test time instead of silently re-killing turtle grounding.
- `tests/test_preflight_feedback_column.py` + `tests/test_import_budget.py` pass; all 6 edited modules import; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)