### PR TITLE
feat(preflight): retrospective soft-gate — breather on real-work-zero-artifacts

### DIFF
--- a/empirica/cli/command_handlers/_workflow_preflight.py
+++ b/empirica/cli/command_handlers/_workflow_preflight.py
@@ -58,6 +58,7 @@ def _preflight_parse_and_validate(args):
         criticality = getattr(validated, 'criticality', None)
         predicted_check_outcomes = getattr(validated, 'predicted_check_outcomes', None)
         voice = getattr(validated, 'voice', None)
+        retrospective_reason = getattr(validated, 'retrospective_reason', None)
     else:
         session_id = args.session_id
         vectors = parse_json_safely(args.vectors) if isinstance(args.vectors, str) else args.vectors
@@ -69,6 +70,7 @@ def _preflight_parse_and_validate(args):
         criticality = None
         predicted_check_outcomes = None
         voice = getattr(args, 'voice', None)
+        retrospective_reason = getattr(args, 'retrospective_reason', None)
 
         if not session_id or not vectors:
             print(json.dumps({
@@ -103,6 +105,7 @@ def _preflight_parse_and_validate(args):
         "criticality": criticality,
         "predicted_check_outcomes": predicted_check_outcomes,
         "voice": voice,
+        "retrospective_reason": retrospective_reason,
         "output_format": output_format,
     }
 
@@ -466,7 +469,77 @@ def _feedback_compute_calibration_trend(cursor, ai_id, project_id):
     except Exception:
         return None
 
-def _preflight_collect_behavioral_feedback(db, session_id, ai_id, project_id):
+# Work types where zero artifacts is expected, not a discipline gap. `release`
+# is a scripted mechanical pipeline (all evidence is excluded from its
+# calibration anyway). Extend deliberately.
+_RETROSPECTIVE_GATE_EXEMPT_WORK_TYPES = frozenset({'release'})
+
+def _feedback_compute_retrospective_gate(pf_meta, retrospective_reason):
+    """The retrospective soft-gate (Piece 2, Part C).
+
+    A breather between transactions. Fires at PREFLIGHT ONLY on the narrow,
+    high-signal pattern: the previous transaction made substantive praxic tool
+    calls but logged ZERO epistemic artifacts, on a non-mechanical work_type.
+    That combination means real work happened with nothing recorded — invisible
+    to grounded calibration.
+
+    Deliberately NOT generic PREFLIGHT nagging (a prior decision rejected that):
+    the trigger is specific, it is SOFT (a response field, never a hard block),
+    it is env-toggleable (EMPIRICA_RETROSPECTIVE_GATE=false), and it is cleared
+    either by logging the missed artifacts or by passing `retrospective_reason`
+    in this PREFLIGHT to acknowledge.
+
+    Returns a gate dict, or None when it should not fire.
+    """
+    if os.environ.get('EMPIRICA_RETROSPECTIVE_GATE', 'true').lower() != 'true':
+        return None
+    if not pf_meta:
+        return None
+
+    work_type = pf_meta.get('work_type')
+    # Unknown work_type can't be judged; exempt mechanical pipelines.
+    if not work_type or work_type in _RETROSPECTIVE_GATE_EXEMPT_WORK_TYPES:
+        return None
+
+    phase_tool_counts = pf_meta.get('phase_tool_counts') or {}
+    praxic_calls = phase_tool_counts.get('praxic_tool_calls', 0) or 0
+
+    retro = pf_meta.get('retrospective') or {}
+    counts = retro.get('artifact_counts') or {}
+    artifact_total = sum(v for v in counts.values() if isinstance(v, (int, float)))
+
+    # The high-signal pattern: real praxic activity, nothing logged.
+    if praxic_calls <= 0 or artifact_total > 0:
+        return None
+
+    gate = {
+        "trigger": (
+            f"Previous transaction made {praxic_calls} praxic tool call(s) "
+            f"(work_type={work_type}) but logged 0 epistemic artifacts. "
+            "Substantive work with no findings/decisions/dead-ends/mistakes is "
+            "invisible to grounded calibration."
+        ),
+        "soft": True,
+        "env_toggle": "Set EMPIRICA_RETROSPECTIVE_GATE=false to disable.",
+    }
+    if retrospective_reason:
+        gate["acknowledged"] = True
+        gate["retrospective_reason"] = retrospective_reason
+        gate["breather"] = "Acknowledged — proceeding. Reason recorded."
+    else:
+        gate["acknowledged"] = False
+        gate["breather"] = (
+            "Take a breather before continuing: log what the last transaction "
+            "learned — a finding, decision, dead-end, or mistake (empirica "
+            "finding-log / decision-log / deadend-log / mistake-log); they "
+            "attach to the prior transaction. If there was genuinely nothing "
+            "to record, pass retrospective_reason in this PREFLIGHT to "
+            "acknowledge and clear."
+        )
+    return gate
+
+def _preflight_collect_behavioral_feedback(db, session_id, ai_id, project_id,
+                                           retrospective_reason=None):
     """Pull discipline observations from last POSTFLIGHT.
 
     Vectors are beliefs about epistemic state -- deterministic services inform
@@ -503,6 +576,13 @@ def _preflight_collect_behavioral_feedback(db, session_id, ai_id, project_id):
             if previous_transaction_feedback is None:
                 previous_transaction_feedback = {}
             previous_transaction_feedback["calibration_trend"] = trend
+
+        # 4. Retrospective soft-gate — breather on real-work-zero-artifacts
+        gate = _feedback_compute_retrospective_gate(pf_meta, retrospective_reason)
+        if gate:
+            if previous_transaction_feedback is None:
+                previous_transaction_feedback = {}
+            previous_transaction_feedback["retrospective_gate"] = gate
 
         if previous_transaction_feedback:
             previous_transaction_feedback["note"] = (
@@ -696,7 +776,8 @@ def handle_preflight_submit_command(args):
 
             # Stage 8: Collect behavioral feedback from last transaction
             previous_transaction_feedback = _preflight_collect_behavioral_feedback(
-                db, session_id, cal["ai_id"], cal["project_id"]
+                db, session_id, cal["ai_id"], cal["project_id"],
+                retrospective_reason=parsed.get("retrospective_reason"),
             )
 
             # Stage 9: Retrieve patterns for task context

--- a/empirica/cli/validation.py
+++ b/empirica/cli/validation.py
@@ -139,6 +139,19 @@ class PreflightInput(BaseModel):
         ),
         pattern="^[a-z][a-z0-9_-]*$",
     )
+    retrospective_reason: str | None = Field(
+        default=None,
+        max_length=2000,
+        description=(
+            "Acknowledgment that clears the retrospective soft-gate. The gate "
+            "fires at PREFLIGHT when the previous transaction made substantive "
+            "praxic tool calls but logged 0 epistemic artifacts (on a "
+            "non-mechanical work_type). Provide a one-line reason why nothing "
+            "was logged (e.g. 'pure mechanical rename, no decisions') to "
+            "acknowledge and proceed — or instead log the missed artifacts, "
+            "which clears the gate on the next transaction's POSTFLIGHT."
+        ),
+    )
 
     @field_validator('session_id')
     @classmethod

--- a/tests/test_retrospective_gate.py
+++ b/tests/test_retrospective_gate.py
@@ -1,0 +1,97 @@
+"""Retrospective soft-gate (Piece 2, Part C) — the breather predicate.
+
+The gate fires at PREFLIGHT when the PREVIOUS transaction made substantive
+praxic tool calls but logged ZERO epistemic artifacts on a non-mechanical
+work_type — real work with nothing recorded, invisible to grounded calibration.
+
+It is deliberately narrow (not generic PREFLIGHT nagging), SOFT (a response
+field, never a hard block), env-toggleable, and clearable via
+`retrospective_reason`. These tests lock that behavior down.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from empirica.cli.command_handlers._workflow_preflight import (
+    _feedback_compute_retrospective_gate,
+)
+
+
+def _pf_meta(work_type="code", praxic_calls=5, artifact_counts=None):
+    """Build a previous-POSTFLIGHT reflex_data blob (pf_meta) for the gate."""
+    if artifact_counts is None:
+        artifact_counts = {
+            "findings": 0,
+            "decisions": 0,
+            "unknowns": 0,
+            "dead_ends": 0,
+            "mistakes": 0,
+            "assumptions": 0,
+        }
+    return {
+        "work_type": work_type,
+        "phase_tool_counts": {"praxic_tool_calls": praxic_calls},
+        "retrospective": {"artifact_counts": artifact_counts},
+    }
+
+
+@pytest.fixture(autouse=True)
+def _gate_enabled(monkeypatch):
+    # Default-on so each test controls the toggle explicitly.
+    monkeypatch.setenv("EMPIRICA_RETROSPECTIVE_GATE", "true")
+
+
+def test_fires_on_real_work_zero_artifacts():
+    gate = _feedback_compute_retrospective_gate(_pf_meta(), None)
+    assert gate is not None
+    assert gate["soft"] is True
+    assert gate["acknowledged"] is False
+    assert "0 epistemic artifacts" in gate["trigger"]
+    assert "breather" in gate
+
+
+def test_cleared_by_retrospective_reason():
+    gate = _feedback_compute_retrospective_gate(_pf_meta(), "pure mechanical rename, no decisions to record")
+    assert gate is not None
+    assert gate["acknowledged"] is True
+    assert gate["retrospective_reason"] == "pure mechanical rename, no decisions to record"
+    assert gate["breather"] == "Acknowledged — proceeding. Reason recorded."
+
+
+def test_no_fire_when_artifacts_logged():
+    meta = _pf_meta(artifact_counts={"findings": 2, "decisions": 1})
+    assert _feedback_compute_retrospective_gate(meta, None) is None
+
+
+def test_no_fire_when_no_praxic_activity():
+    # Noetic-only transaction (investigation) — zero artifacts is not the
+    # high-signal pattern when no praxic work happened.
+    assert _feedback_compute_retrospective_gate(_pf_meta(praxic_calls=0), None) is None
+
+
+def test_exempt_mechanical_work_type_release():
+    assert _feedback_compute_retrospective_gate(_pf_meta(work_type="release"), None) is None
+
+
+def test_no_fire_on_unknown_work_type():
+    # work_type=None can't be judged (older POSTFLIGHTs before Part B).
+    assert _feedback_compute_retrospective_gate(_pf_meta(work_type=None), None) is None
+
+
+def test_env_toggle_disables(monkeypatch):
+    monkeypatch.setenv("EMPIRICA_RETROSPECTIVE_GATE", "false")
+    assert _feedback_compute_retrospective_gate(_pf_meta(), None) is None
+
+
+def test_no_pf_meta_is_safe():
+    assert _feedback_compute_retrospective_gate(None, None) is None
+
+
+def test_missing_subkeys_dont_crash():
+    # A malformed/partial pf_meta must degrade to "no gate", never raise.
+    assert _feedback_compute_retrospective_gate({"work_type": "code"}, None) is None
+    assert (
+        _feedback_compute_retrospective_gate({"work_type": "code", "phase_tool_counts": {"praxic_tool_calls": 3}}, None)
+        is not None
+    )  # no retrospective → artifact_total 0 → fires


### PR DESCRIPTION
## What

**Piece 2, Part C** of the discipline-hardening work — the "breather between transactions" David asked for. Parts A+B already persist `work_type` + `phase_tool_counts.praxic_tool_calls` into the POSTFLIGHT `reflex_data`; this is the seam-gate that reads them back at the next PREFLIGHT.

## When it fires

ONLY on the narrow, high-signal pattern: the previous transaction made **substantive praxic tool calls but logged ZERO epistemic artifacts**, on a **non-mechanical work_type**. That combination means real work happened with nothing recorded — invisible to grounded calibration.

This is deliberately **not** generic PREFLIGHT nagging — a prior decision explicitly rejected that ("Retrospective feedback at POSTFLIGHT is less annoying than prospective nagging at PREFLIGHT"). The reconciliation is a *calibrated escalation*, not a blanket nudge:

| Property | Behavior |
|---|---|
| **Soft** | A `retrospective_gate` field on `previous_transaction_feedback` — never a hard block. The Sentinel CHECK gate is unchanged. |
| **Narrow** | `praxic_calls > 0` AND `0 artifacts` AND `work_type ∉ {release}`. Unknown work_type (older POSTFLIGHTs) never fires. |
| **Toggleable** | `EMPIRICA_RETROSPECTIVE_GATE=false` disables it. |
| **Clearable** | Pass `retrospective_reason` in the PREFLIGHT to acknowledge (echoed back, `acknowledged=true`), or just log the missed artifacts — that clears it on the next POSTFLIGHT. |

## Implementation

- `validation.py`: new optional `retrospective_reason` field on `PreflightInput`.
- `_workflow_preflight.py`: `_feedback_compute_retrospective_gate(pf_meta, retrospective_reason)` predicate (degrades to `None` on any missing subkey — never raises); wired into `_preflight_collect_behavioral_feedback` step 4; `retrospective_reason` threaded parse → handler → collector.
- `tests/test_retrospective_gate.py`: 9 cases — fires, cleared-by-reason, no-fire-on-artifacts, no-fire-no-praxic, release-exempt, unknown-work-type, env-disabled, None-safe, partial-meta-safe.

## Verification

`ruff check` clean, `pyright` clean (source), 12 tests pass (9 new + 3 preflight-feedback regression). Functional-only diff (98 lines) — no cosmetic reformatting churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)