### PR TITLE
fix(project-id): route dead project.json resolvers through canonical resolver

### DIFF
--- a/empirica/cli/command_handlers/concept_graph_commands.py
+++ b/empirica/cli/command_handlers/concept_graph_commands.py
@@ -24,32 +24,29 @@ def _get_concept_graph():
 
 
 def _get_project_id(args):
-    """Get project ID from args or via unified context resolver."""
+    """Get project ID from args or via the canonical local resolver.
+
+    project.yaml is authoritative, sessions.db is the fallback (see
+    `_get_project_id_from_local_db`). Previously this read a non-existent
+    `.empirica/project.json` at both the resolved-path and CWD sites.
+    """
     if hasattr(args, 'project_id') and args.project_id:
         return args.project_id
 
-    # Try unified context resolver first
+    from empirica.utils.session_resolver import _get_project_id_from_local_db
+
+    # Prefer the unified context resolver's project path; else CWD.
+    project_path = None
     try:
         from empirica.utils.session_resolver import InstanceResolver as R
-        context = R.context()
-        project_path = context.get('project_path')
-        if project_path:
-            project_file = Path(project_path) / ".empirica" / "project.json"
-            if project_file.exists():
-                import json as json_mod
-                data = json_mod.loads(project_file.read_text())
-                return data.get("project_id")
+        project_path = R.context().get('project_path')
     except Exception:
         pass
 
-    # Fallback: Try reading from CWD .empirica/project.json
-    project_file = Path.cwd() / ".empirica" / "project.json"
-    if project_file.exists():
-        import json as json_mod
-        data = json_mod.loads(project_file.read_text())
-        return data.get("project_id")
-
-    return None
+    try:
+        return _get_project_id_from_local_db(Path(project_path) if project_path else Path.cwd())
+    except Exception:
+        return None
 
 
 def _get_db_path():

--- a/empirica/cli/command_handlers/docs_commands.py
+++ b/empirica/cli/command_handlers/docs_commands.py
@@ -1135,32 +1135,17 @@ class EpistemicDocsAgent:
         return refs[:5]  # Limit results
 
     def _detect_project_id(self) -> str | None:
-        """Detect project ID from sessions.db (authoritative) or .empirica config (fallback)."""
+        """Detect project ID via the canonical local resolver.
+
+        project.yaml is authoritative (the 1.12 project-identity design),
+        sessions.db is the fallback. See `_get_project_id_from_local_db`.
+        Previously this read a non-existent `.empirica/project.json`.
+        """
         try:
-            # Primary: sessions.db is authoritative
-            from empirica.utils.session_resolver import InstanceResolver as R
-            db_project_id = R.project_id_from_db(self.root)
-            if db_project_id:
-                return db_project_id
-
-            # Fallback: project.yaml for fresh projects
-            import yaml
-            project_yaml = self.root / ".empirica" / "project.yaml"
-            if project_yaml.exists():
-                with open(project_yaml) as f:
-                    data = yaml.safe_load(f)
-                    if data and data.get("project_id"):
-                        return data["project_id"]
-
-            # Fallback: Try .empirica/project.json
-            project_json = self.root / ".empirica" / "project.json"
-            if project_json.exists():
-                data = json.loads(project_json.read_text())
-                return data.get("project_id")
-
+            from empirica.utils.session_resolver import _get_project_id_from_local_db
+            return _get_project_id_from_local_db(self.root)
         except Exception:
-            pass
-        return None
+            return None
 
     def _extract_doc_sections(self, content: str) -> list[tuple[str, str]]:
         """Extract sections from markdown content by headers."""
@@ -1830,31 +1815,18 @@ class DocsExplainAgent:
         return self.root / "docs"
 
     def _detect_project_id(self) -> str | None:
-        """Detect project ID from .empirica config or database."""
-        try:
-            # Try reading from .empirica/project.json
-            project_file = self.root / ".empirica" / "project.json"
-            if project_file.exists():
-                import json
-                data = json.loads(project_file.read_text())
-                return data.get("project_id")
+        """Detect project ID via the canonical local resolver.
 
-            # Try querying database for project matching this path
-            from empirica.data.session_database import SessionDatabase
-            db = SessionDatabase()
-            cursor = db.conn.cursor()
-            cursor.execute("""
-                SELECT id FROM projects
-                WHERE name = ?
-                ORDER BY created_timestamp DESC LIMIT 1
-            """, (self.root.name,))
-            row = cursor.fetchone()
-            db.close()
-            if row:
-                return row[0]
+        project.yaml is authoritative (the 1.12 project-identity design),
+        sessions.db is the fallback. See `_get_project_id_from_local_db`.
+        Previously this read a non-existent `.empirica/project.json` as its
+        primary path (always dead), masking a broken projects-table fallback.
+        """
+        try:
+            from empirica.utils.session_resolver import _get_project_id_from_local_db
+            return _get_project_id_from_local_db(self.root)
         except Exception:
-            pass
-        return None
+            return None
 
     def _check_qdrant_available(self) -> bool:
         """Check if Qdrant is available for semantic search."""


### PR DESCRIPTION
## What

`.empirica/project.json` **does not exist** — the real file is `project.yaml` (David's catch). Three sites read the dead filename:

| Site | Bug |
|---|---|
| `docs_commands.py` `_detect_project_id` (method A) | dead `project.json` tail; also wrongly **sessions.db-first** (contradicts the yaml-authoritative design) |
| `docs_commands.py` `_detect_project_id` (method B) | `project.json` as the **primary** path — always dead, masking the broken projects-table fallback fixed in #132 |
| `concept_graph_commands.py` `_get_project_id` | `project.json` read at **both** the resolved-path and CWD sites |

## Fix

All three now route through the existing canonical **`_get_project_id_from_local_db(project_path)`** — `project.yaml` authoritative, `sessions.db` fallback (matches the 1.12 project-identity design). This:

- Kills all 3 dead `project.json` reads.
- **Unifies three divergent hand-rolled implementations** into one resolver.
- Supersedes #132's `docs_commands` workspace-projects-table query with the blessed path.
- Reduces the "hot spots read config directly instead of the resolver → UUID-mismatch cascades" debt (flagged by a conf-0.9 eidetic finding).

Rather than add a 4th/5th/6th hand-rolled `yaml.safe_load` (extending the very anti-pattern), it reuses the canonical resolver.

## Also

Regenerates `.empirica/project.yaml.example` from the stale **v1** shape (`project_id` as a name, `subjects`-with-`paths`) to the real **v2.0** schema (`ai_id`, `project_id` UUID, `type`/`domain`/`classification`, `evidence_profile`, etc.). The example is illustrative only — confirmed not consumed by any code.

## Verification

`ruff` clean, `pyright` clean, **187 related tests pass**, and live check confirms the resolver returns this repo's real UUID (`748a81a2-…`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)