### PR TITLE
feat(note): scratchpad note-to-self (CLI + MCP) + note-aware soft-gate

### DIFF
--- a/empirica-mcp/empirica_mcp/server.py
+++ b/empirica-mcp/empirica_mcp/server.py
@@ -139,6 +139,18 @@ TOOL_REGISTRY: dict[str, dict] = {
         "desc": "Log a finding (what was learned). Use source_ids to link to epistemic sources, visibility to opt into cross-project sharing, epistemic_source to tag provenance.",
         "list_params": ["source_ids"],
     },
+    "note": {
+        "cli": "note",
+        "params": {"tag": "--tag", "session_id": "--session-id", "project_id": "--project-id"},
+        "positional": "text",
+        "required": ["text"],
+        "desc": "Jot a quick note-to-self (scratchpad) while in flow — for things to "
+                "check on after the current work. Faster + lower-friction than a full "
+                "finding/decision: pure metadata, NOT shared, NOT embedded. Notes are "
+                "transaction-scoped, survive context compaction, and surface at "
+                "POSTFLIGHT for triage. Optional tag: followup | doubt | idea. "
+                "Review/clear via CLI: empirica note --list / --clear.",
+    },
     "unknown_log": {
         "cli": "unknown-log",
         "params": {"unknown": "--unknown", "session_id": "--session-id",

--- a/empirica/cli/cli_core.py
+++ b/empirica/cli/cli_core.py
@@ -335,7 +335,7 @@ _HELP_CATEGORIES = {
     'session': ['session-create', 'sessions-list', 'sessions-show', 'sessions-export', 'sessions-resume', 'session-snapshot', 'memory-compact', 'transaction-adopt'],
     'workflow': ['preflight-submit', 'check', 'check-submit', 'postflight-submit'],
     'goals': ['goals-create', 'goals-list', 'goals-search', 'goals-complete', 'goals-claim', 'goals-add-task', 'goals-add-dependency', 'goals-complete-task', 'goals-get-tasks', 'goals-progress', 'goals-discover', 'goals-ready', 'goals-resume', 'goals-mark-stale', 'goals-get-stale', 'goals-refresh'],
-    'logging': ['finding-log', 'unknown-log', 'unknown-list', 'unknown-resolve', 'deadend-log', 'assumption-log', 'decision-log', 'mistake-log', 'mistake-query', 'source-add', 'source-list', 'sources-map', 'sources-reconcile', 'source-archive', 'act-log', 'investigate-log', 'log-artifacts', 'resolve-artifacts', 'delete-artifacts', 'epistemics-list', 'epistemics-show', 'noetic-batch'],
+    'logging': ['finding-log', 'unknown-log', 'unknown-list', 'unknown-resolve', 'deadend-log', 'assumption-log', 'decision-log', 'mistake-log', 'mistake-query', 'note', 'source-add', 'source-list', 'sources-map', 'sources-reconcile', 'source-archive', 'act-log', 'investigate-log', 'log-artifacts', 'resolve-artifacts', 'delete-artifacts', 'epistemics-list', 'epistemics-show', 'noetic-batch'],
     'project': ['project-init', 'project-update', 'project-create', 'project-list', 'project-switch', 'project-bootstrap', 'project-handoff', 'project-search', 'project-embed', 'code-embed', 'doc-check', 'bootstrap-context', 'practice-context', 'projects-sync', 'projects-discover', 'projects-list', 'projects-bulk-register', 'projects-unregister'],
     'workspace': ['workspace-init', 'workspace-map', 'workspace-list', 'workspace-overview', 'workspace-search', 'engagement-focus', 'ecosystem-check', 'save', 'history', 'entity-list', 'entity-show', 'entity-walk', 'entity-search'],
     'checkpoint': ['checkpoint-create', 'checkpoint-load', 'checkpoint-list', 'checkpoint-diff', 'checkpoint-sign', 'checkpoint-verify', 'checkpoint-signatures'],
@@ -617,6 +617,7 @@ def main(args=None):
             'daemon-grants-list': handle_daemon_grants_list_command,
 
             # Finding/unknown/deadend/assumption/decision logging
+            'note': handle_note_command,
             'finding-log': handle_finding_log_command,
             'unknown-log': handle_unknown_log_command,
             'unknown-resolve': handle_unknown_resolve_command,

--- a/empirica/cli/command_handlers/__init__.py
+++ b/empirica/cli/command_handlers/__init__.py
@@ -164,6 +164,7 @@ from .monitor_commands import (
     handle_workflow_patterns_command,
 )
 from .noetic_batch_commands import handle_noetic_batch_command
+from .note_commands import handle_note_command
 from .notify_commands import (
     handle_notify_backends_command,
     handle_notify_config_command,
@@ -334,6 +335,7 @@ __all__ = [  # noqa: RUF022
     'handle_epistemics_stats_command',
     'handle_epp_activate_command',
     'handle_finding_log_command',
+    'handle_note_command',
     'handle_forgejo_publish_command',
     'handle_goals_activate_command',    # Activate planned goal → in_progress
     'handle_goals_add_dependency_command',

--- a/empirica/cli/command_handlers/_workflow_preflight.py
+++ b/empirica/cli/command_handlers/_workflow_preflight.py
@@ -474,7 +474,33 @@ def _feedback_compute_calibration_trend(cursor, ai_id, project_id):
 # calibration anyway). Extend deliberately.
 _RETROSPECTIVE_GATE_EXEMPT_WORK_TYPES = frozenset({'release'})
 
-def _feedback_compute_retrospective_gate(pf_meta, retrospective_reason):
+def _feedback_count_untriaged_notes(cursor, session_id, pf_meta):
+    """Count untriaged scratchpad notes for the previous transaction.
+
+    Scoped to pf_meta's transaction_id (the transaction that just POSTFLIGHTed)
+    when available, else the session. Tolerates the notes table not existing on
+    older DBs. Returns 0 on any error.
+    """
+    try:
+        prev_tx = (pf_meta or {}).get('transaction_id')
+        if prev_tx:
+            row = cursor.execute(
+                "SELECT COUNT(*) FROM notes WHERE session_id = ? AND "
+                "transaction_id = ? AND triaged = 0",
+                (session_id, prev_tx),
+            ).fetchone()
+        else:
+            row = cursor.execute(
+                "SELECT COUNT(*) FROM notes WHERE session_id = ? AND triaged = 0",
+                (session_id,),
+            ).fetchone()
+        return row[0] if row else 0
+    except Exception:
+        return 0
+
+
+def _feedback_compute_retrospective_gate(pf_meta, retrospective_reason,
+                                         untriaged_note_count=0):
     """The retrospective soft-gate (Piece 2, Part C).
 
     A breather between transactions. Fires at PREFLIGHT ONLY on the narrow,
@@ -482,6 +508,11 @@ def _feedback_compute_retrospective_gate(pf_meta, retrospective_reason):
     calls but logged ZERO epistemic artifacts, on a non-mechanical work_type.
     That combination means real work happened with nothing recorded — invisible
     to grounded calibration.
+
+    Note-aware: scratchpad notes-to-self earn partial credit (intent WAS
+    captured, just not yet structured). With notes present the gate softens to
+    "promote your notes"; with 0 artifacts AND 0 notes it is the strongest
+    "logged literally nothing" signal.
 
     Deliberately NOT generic PREFLIGHT nagging (a prior decision rejected that):
     the trigger is specific, it is SOFT (a response field, never a hard block),
@@ -512,6 +543,7 @@ def _feedback_compute_retrospective_gate(pf_meta, retrospective_reason):
     if praxic_calls <= 0 or artifact_total > 0:
         return None
 
+    note_count = untriaged_note_count or 0
     gate = {
         "trigger": (
             f"Previous transaction made {praxic_calls} praxic tool call(s) "
@@ -520,12 +552,24 @@ def _feedback_compute_retrospective_gate(pf_meta, retrospective_reason):
             "invisible to grounded calibration."
         ),
         "soft": True,
+        # Notes earn partial credit: 0 artifacts + 0 notes is the strongest
+        # "logged literally nothing" signal; notes mean intent was captured.
+        "severity": "strong" if note_count == 0 else "soft",
+        "untriaged_note_count": note_count,
         "env_toggle": "Set EMPIRICA_RETROSPECTIVE_GATE=false to disable.",
     }
     if retrospective_reason:
         gate["acknowledged"] = True
         gate["retrospective_reason"] = retrospective_reason
         gate["breather"] = "Acknowledged — proceeding. Reason recorded."
+    elif note_count > 0:
+        gate["acknowledged"] = False
+        gate["breather"] = (
+            f"You left {note_count} untriaged note(s)-to-self last transaction "
+            "but logged 0 structured artifacts. Promote the keepers to "
+            "findings/decisions/goals (then `empirica note --clear`), or pass "
+            "retrospective_reason to acknowledge."
+        )
     else:
         gate["acknowledged"] = False
         gate["breather"] = (
@@ -577,8 +621,13 @@ def _preflight_collect_behavioral_feedback(db, session_id, ai_id, project_id,
                 previous_transaction_feedback = {}
             previous_transaction_feedback["calibration_trend"] = trend
 
-        # 4. Retrospective soft-gate — breather on real-work-zero-artifacts
-        gate = _feedback_compute_retrospective_gate(pf_meta, retrospective_reason)
+        # 4. Retrospective soft-gate — breather on real-work-zero-artifacts.
+        #    Note-aware: count the prior transaction's untriaged notes (partial
+        #    credit — intent captured even if not yet structured).
+        note_count = _feedback_count_untriaged_notes(cursor, session_id, pf_meta)
+        gate = _feedback_compute_retrospective_gate(
+            pf_meta, retrospective_reason, untriaged_note_count=note_count
+        )
         if gate:
             if previous_transaction_feedback is None:
                 previous_transaction_feedback = {}

--- a/empirica/cli/command_handlers/_workflow_shared.py
+++ b/empirica/cli/command_handlers/_workflow_shared.py
@@ -596,12 +596,48 @@ def _build_retrospective(session_id: str, transaction_id: str | None) -> dict:
             pass
 
         _maybe_add_deferred_proposals_note(cursor, session_id, retro)
+        _maybe_add_untriaged_notes(cursor, session_id, transaction_id, retro)
 
         db.close()
         return retro
     except Exception as e:
         logger.debug(f"Retrospective feedback failed (non-fatal): {e}")
         return {}
+
+
+def _maybe_add_untriaged_notes(cursor, session_id: str, transaction_id, retro: dict) -> None:
+    """Surface scratchpad notes-to-self for triage at the retrospective.
+
+    The POSTFLIGHT review moment: untriaged notes from this transaction (or the
+    session, if no transaction) are surfaced so the AI can promote them to
+    artifacts/goals or discard them (then `empirica note --clear`). Scoped,
+    metadata-only, non-fatal. Tolerates the table not existing on older DBs.
+    """
+    try:
+        if transaction_id:
+            rows = cursor.execute(
+                "SELECT text, tag FROM notes WHERE session_id = ? AND "
+                "transaction_id = ? AND triaged = 0 ORDER BY created_at",
+                (session_id, transaction_id),
+            ).fetchall()
+        else:
+            rows = cursor.execute(
+                "SELECT text, tag FROM notes WHERE session_id = ? AND "
+                "triaged = 0 ORDER BY created_at",
+                (session_id,),
+            ).fetchall()
+        if not rows:
+            return
+        retro["untriaged_notes"] = [
+            {"text": r[0], "tag": r[1]} for r in rows
+        ]
+        retro["untriaged_notes_hint"] = (
+            f"{len(rows)} untriaged note(s)-to-self from this transaction. "
+            "Promote any worth keeping to a finding/decision/goal, then "
+            "`empirica note --clear`."
+        )
+    except Exception:
+        pass  # notes table may not exist on older DBs — non-fatal
 
 
 def _maybe_add_deferred_proposals_note(cursor, session_id: str, retro: dict) -> None:

--- a/empirica/cli/command_handlers/note_commands.py
+++ b/empirica/cli/command_handlers/note_commands.py
@@ -1,0 +1,145 @@
+"""Note command — fast scratchpad / note-to-self.
+
+Low-friction, transaction-scoped jottings captured mid-flow and reviewed at the
+POSTFLIGHT retrospective. The complement to the structured ``*-log`` artifacts:
+capture now, classify later. Pure metadata — NOT shared, NOT embedded in Qdrant,
+NOT written to git notes. The durability win (survives context compaction) is
+why these live in sessions.db rather than in-context.
+
+Usage:
+    empirica note "static query should stay static, not f-string"
+    empirica note "ask cortex if gap1 overlaps R3" --tag followup
+    empirica note --list      # review untriaged notes (the retrospective moment)
+    empirica note --clear     # mark this transaction's notes triaged
+"""
+
+from __future__ import annotations
+
+import json
+import time
+import uuid
+
+from .artifact_log_commands import _resolve_artifact_context
+
+_NOTES_DDL = """
+    CREATE TABLE IF NOT EXISTS notes (
+        note_id TEXT PRIMARY KEY,
+        session_id TEXT NOT NULL,
+        transaction_id TEXT,
+        project_id TEXT,
+        ai_id TEXT,
+        text TEXT NOT NULL,
+        tag TEXT,
+        created_at REAL NOT NULL,
+        triaged INTEGER DEFAULT 0
+    )
+"""
+
+
+def handle_note_command(args) -> dict | int | None:
+    """Add a note-to-self, or review/clear with --list / --clear."""
+    db = None
+    try:
+        ctx = _resolve_artifact_context(None, args, required_fields=None)
+        db = ctx["db"]
+        conn = db.conn
+        output_format = ctx["output_format"]
+
+        # Self-heal: older DBs predate the schema addition.
+        conn.execute(_NOTES_DDL)
+
+        if getattr(args, "list", False):
+            return _list_notes(conn, ctx, output_format)
+        if getattr(args, "clear", False):
+            return _clear_notes(conn, ctx, output_format)
+
+        text = getattr(args, "text", None) or getattr(args, "text_flag", None)
+        if not text:
+            msg = 'note text required — e.g. empirica note "..." (or --list / --clear)'
+            if output_format == "json":
+                print(json.dumps({"ok": False, "error": msg}))
+                return None
+            print(f"❌ {msg}")
+            return 1
+
+        tag = getattr(args, "tag", None)
+        note_id = str(uuid.uuid4())
+        conn.execute(
+            "INSERT INTO notes (note_id, session_id, transaction_id, project_id, "
+            "ai_id, text, tag, created_at, triaged) VALUES (?,?,?,?,?,?,?,?,0)",
+            (
+                note_id, ctx["session_id"], ctx["transaction_id"],
+                ctx["project_id"], ctx["ai_id"], text, tag, time.time(),
+            ),
+        )
+        conn.commit()
+
+        if output_format == "json":
+            print(json.dumps({
+                "ok": True, "note_id": note_id, "tag": tag,
+                "transaction_id": ctx["transaction_id"],
+            }))
+            return None
+        print(f"📝 Noted{f' [{tag}]' if tag else ''}: {text}")
+        print("   (surfaces at POSTFLIGHT for triage)")
+        return None
+    except Exception as e:
+        if (db is None or getattr(args, "output", "human") == "json"):
+            print(json.dumps({"ok": False, "error": str(e)}))
+        else:
+            print(f"❌ Failed to record note: {e}")
+        return 1
+    finally:
+        if db is not None:
+            db.close()
+
+
+def _query_untriaged(conn, ctx):
+    """Untriaged notes for the active transaction (or whole session if none)."""
+    if ctx["transaction_id"]:
+        rows = conn.execute(
+            "SELECT note_id, text, tag, created_at FROM notes "
+            "WHERE session_id = ? AND transaction_id = ? AND triaged = 0 "
+            "ORDER BY created_at",
+            (ctx["session_id"], ctx["transaction_id"]),
+        ).fetchall()
+    else:
+        rows = conn.execute(
+            "SELECT note_id, text, tag, created_at FROM notes "
+            "WHERE session_id = ? AND triaged = 0 ORDER BY created_at",
+            (ctx["session_id"],),
+        ).fetchall()
+    return rows
+
+
+def _list_notes(conn, ctx, output_format) -> dict | int | None:
+    rows = _query_untriaged(conn, ctx)
+    notes = [
+        {"note_id": r[0], "text": r[1], "tag": r[2], "created_at": r[3]}
+        for r in rows
+    ]
+    if output_format == "json":
+        print(json.dumps({"ok": True, "count": len(notes), "notes": notes}))
+        return None
+    if not notes:
+        print("📝 No untriaged notes.")
+        return None
+    print(f"📝 {len(notes)} untriaged note(s):")
+    for n in notes:
+        tag = f" [{n['tag']}]" if n["tag"] else ""
+        print(f"   • {n['text']}{tag}")
+    print("   → promote to artifacts/goals, then `empirica note --clear`.")
+    return None
+
+
+def _clear_notes(conn, ctx, output_format) -> dict | int | None:
+    rows = _query_untriaged(conn, ctx)
+    ids = [r[0] for r in rows]
+    for note_id in ids:
+        conn.execute("UPDATE notes SET triaged = 1 WHERE note_id = ?", (note_id,))
+    conn.commit()
+    if output_format == "json":
+        print(json.dumps({"ok": True, "cleared": len(ids)}))
+        return None
+    print(f"📝 Cleared {len(ids)} note(s) (marked triaged).")
+    return None

--- a/empirica/cli/parsers/checkpoint_parsers.py
+++ b/empirica/cli/parsers/checkpoint_parsers.py
@@ -675,6 +675,27 @@ def add_checkpoint_parsers(subparsers):
     finding_log_parser.add_argument('--output', choices=['human', 'json'], default='human', help='Output format')
     finding_log_parser.add_argument('--verbose', action='store_true', help='Show detailed operation info')
 
+    # Note command — fast scratchpad / note-to-self
+    note_parser = subparsers.add_parser(
+        'note',
+        help=(
+            'Jot a quick note-to-self while in flow — a scratchpad for things '
+            'to check on after the current work. Faster + lower-friction than a '
+            'full finding/decision: pure metadata, NOT shared, NOT embedded. '
+            'Notes are transaction-scoped and surface at POSTFLIGHT for triage '
+            '(promote to an artifact/goal, or discard). They survive context '
+            'compaction. Use --list to review, --clear to mark triaged.'
+        ),
+    )
+    note_parser.add_argument('text', nargs='?', help='The note text (positional, the common case)')
+    note_parser.add_argument('--text', dest='text_flag', help='The note text (flag form, for MCP/scripts)')
+    note_parser.add_argument('--tag', help='Optional free-form tag (suggested: followup | doubt | idea)')
+    note_parser.add_argument('--list', action='store_true', help='List untriaged notes for the current transaction/session')
+    note_parser.add_argument('--clear', action='store_true', help='Mark the current transaction/session notes as triaged')
+    note_parser.add_argument('--session-id', required=False, help='Session UUID')
+    note_parser.add_argument('--project-id', required=False, help='Project UUID')
+    note_parser.add_argument('--output', choices=['human', 'json'], default='human', help='Output format')
+
     # Unknown log command
     unknown_log_parser = subparsers.add_parser(
         'unknown-log',

--- a/empirica/data/schema/epistemic_schema.py
+++ b/empirica/data/schema/epistemic_schema.py
@@ -99,4 +99,26 @@ SCHEMAS = [
                 )
     """,
 
+    # Schema 4 — scratchpad notes (note-to-self)
+    #
+    # Low-friction, transaction-scoped jottings captured mid-flow and reviewed
+    # at the POSTFLIGHT retrospective. Pure metadata: NOT shared, NOT embedded
+    # in Qdrant, NOT written to git notes. `triaged` flips to 1 once the note
+    # has been promoted to an artifact/goal or consciously discarded.
+    """
+    CREATE TABLE IF NOT EXISTS notes (
+                    note_id TEXT PRIMARY KEY,
+                    session_id TEXT NOT NULL,
+                    transaction_id TEXT,
+                    project_id TEXT,
+                    ai_id TEXT,
+                    text TEXT NOT NULL,
+                    tag TEXT,
+                    created_at REAL NOT NULL,
+                    triaged INTEGER DEFAULT 0,
+
+                    FOREIGN KEY (session_id) REFERENCES sessions(session_id)
+                )
+    """,
+
 ]

--- a/empirica/plugins/claude-code-integration/hooks/sentinel-gate.py
+++ b/empirica/plugins/claude-code-integration/hooks/sentinel-gate.py
@@ -473,6 +473,7 @@ EMPIRICA_TIER2_PREFIXES = (
     'empirica preflight-submit', 'empirica check-submit', 'empirica postflight-submit',
     'empirica finding-log', 'empirica unknown-log', 'empirica deadend-log',
     'empirica mistake-log', 'empirica log-mistake',
+    'empirica note',  # Scratchpad note-to-self (metadata-only, ungated like *-log)
     'empirica log-artifacts', 'empirica resolve-artifacts', 'empirica delete-artifacts',  # Batch artifact operations
     'empirica goals-create', 'empirica goal-create', 'empirica gc',  # Goal create + aliases
     'empirica goals-complete', 'empirica goal-complete',  # Goal complete + alias

--- a/tests/test_note_command.py
+++ b/tests/test_note_command.py
@@ -1,0 +1,91 @@
+"""Tests for the `empirica note` scratchpad.
+
+Covers the storage/query logic and the POSTFLIGHT retrospective surfacing
+directly (no full session needed): notes are transaction-scoped, triage-aware,
+and degrade safely when the table is absent on older DBs.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+
+from empirica.cli.command_handlers import note_commands as nc
+from empirica.cli.command_handlers._workflow_shared import _maybe_add_untriaged_notes
+from empirica.data.schema.epistemic_schema import SCHEMAS
+
+
+def _conn():
+    conn = sqlite3.connect(":memory:")
+    conn.execute(nc._NOTES_DDL)
+    return conn
+
+
+def _add(conn, text, session_id="s1", transaction_id="t1", tag=None, triaged=0):
+    conn.execute(
+        "INSERT INTO notes (note_id, session_id, transaction_id, project_id, "
+        "ai_id, text, tag, created_at, triaged) VALUES (?,?,?,?,?,?,?,?,?)",
+        (text, session_id, transaction_id, "p", "a", text, tag, time.time(), triaged),
+    )
+    conn.commit()
+
+
+def _ctx(session_id="s1", transaction_id="t1"):
+    return {"session_id": session_id, "transaction_id": transaction_id}
+
+
+# --- schema ---------------------------------------------------------------- #
+def test_notes_table_in_schema():
+    assert any("CREATE TABLE IF NOT EXISTS notes" in s for s in SCHEMAS)
+
+
+# --- query logic ----------------------------------------------------------- #
+def test_query_untriaged_scoped_to_transaction():
+    conn = _conn()
+    _add(conn, "a", transaction_id="t1")
+    _add(conn, "b", transaction_id="t1")
+    _add(conn, "c", transaction_id="t2")           # other transaction
+    _add(conn, "d", transaction_id="t1", triaged=1)  # already triaged
+    rows = nc._query_untriaged(conn, _ctx(transaction_id="t1"))
+    texts = sorted(r[1] for r in rows)
+    assert texts == ["a", "b"]
+
+
+def test_query_untriaged_session_scope_when_no_transaction():
+    conn = _conn()
+    _add(conn, "a", transaction_id="t1")
+    _add(conn, "b", transaction_id=None)
+    rows = nc._query_untriaged(conn, _ctx(transaction_id=None))
+    assert {r[1] for r in rows} == {"a", "b"}  # all untriaged for the session
+
+
+def test_clear_marks_triaged():
+    conn = _conn()
+    _add(conn, "a")
+    _add(conn, "b")
+    nc._clear_notes(conn, _ctx(), "json")
+    assert nc._query_untriaged(conn, _ctx()) == []
+
+
+# --- retrospective surfacing ----------------------------------------------- #
+def test_retrospective_surfaces_untriaged_notes():
+    conn = _conn()
+    _add(conn, "promote me", tag="followup")
+    retro: dict = {}
+    _maybe_add_untriaged_notes(conn.cursor(), "s1", "t1", retro)
+    assert retro["untriaged_notes"] == [{"text": "promote me", "tag": "followup"}]
+    assert "1 untriaged note" in retro["untriaged_notes_hint"]
+
+
+def test_retrospective_silent_when_none():
+    conn = _conn()
+    retro: dict = {}
+    _maybe_add_untriaged_notes(conn.cursor(), "s1", "t1", retro)
+    assert "untriaged_notes" not in retro
+
+
+def test_retrospective_tolerates_missing_table():
+    conn = sqlite3.connect(":memory:")  # no notes table
+    retro: dict = {}
+    _maybe_add_untriaged_notes(conn.cursor(), "s1", "t1", retro)  # must not raise
+    assert retro == {}

--- a/tests/test_retrospective_gate.py
+++ b/tests/test_retrospective_gate.py
@@ -84,6 +84,22 @@ def test_env_toggle_disables(monkeypatch):
     assert _feedback_compute_retrospective_gate(_pf_meta(), None) is None
 
 
+def test_zero_artifacts_zero_notes_is_strong():
+    gate = _feedback_compute_retrospective_gate(_pf_meta(), None, untriaged_note_count=0)
+    assert gate is not None
+    assert gate["severity"] == "strong"
+    assert gate["untriaged_note_count"] == 0
+    assert "finding-log" in gate["breather"]  # "log something" wording
+
+
+def test_notes_present_softens_to_promote():
+    gate = _feedback_compute_retrospective_gate(_pf_meta(), None, untriaged_note_count=3)
+    assert gate is not None
+    assert gate["severity"] == "soft"
+    assert gate["untriaged_note_count"] == 3
+    assert "Promote" in gate["breather"]  # "promote your notes" wording
+
+
 def test_no_pf_meta_is_safe():
     assert _feedback_compute_retrospective_gate(None, None) is None
 


### PR DESCRIPTION
## What

A low-friction **scratchpad** for jotting notes-to-self mid-flow, reviewed at the POSTFLIGHT retrospective. Fills the gap between full artifact-logging (friction) and holding-in-context (lost at compaction) — the complement to `*-log`: **capture now, classify later.** (David's idea, greenlit 2026-06-21.)

```
empirica note "static query should stay static, not f-string"   # add
empirica note "ask cortex if gap1 overlaps R3" --tag followup    # add + tag
empirica note --list      # review untriaged (the retrospective moment)
empirica note --clear     # mark this transaction's notes triaged
```

## Design

| Aspect | Choice |
|---|---|
| **Storage** | `notes` table in `sessions.db` (schema add, `CREATE TABLE IF NOT EXISTS`, self-heals older DBs). Keyed by `session_id` + `transaction_id`. |
| **Metadata-only** | NOT shared, NOT embedded in Qdrant, NOT in git notes — per "fast, simple, not shared". |
| **Why DB not flat-file** | Durability across **context compaction** is the whole AI-specific value; a note that evaporates on compact defeats the purpose. |
| **Ungated** | `empirica note` in sentinel-gate TIER2; `mcp__empirica__*` already always-allowed → never trips the noetic firewall (jot in any phase). |
| **MCP** | `note` tool in `empirica-mcp` `TOOL_REGISTRY` (positional text + tag), delegating to the CLI like the other thin wrappers. |
| **Surfacing** | POSTFLIGHT retrospective gains `untriaged_notes` + a triage hint. |

## Note-aware soft-gate ("softgate smarter")

The retrospective soft-gate (#133) now reads the prior transaction's untriaged note count:
- **Notes earn partial credit** — intent was captured, just not structured. With notes present the gate softens to *"promote your notes"* (`severity=soft`).
- **0 artifacts AND 0 notes** is the strongest *"logged literally nothing"* signal (`severity=strong`).
- Trigger unchanged (praxic>0 + 0 artifacts + non-mechanical); only severity + wording adapt. Carrot (note) and stick (gate) reinforce each other.

## Verification

- `tests/test_note_command.py` — 7 cases (storage, transaction-scoping, clear, retrospective surfacing, table-absent-safe).
- `tests/test_retrospective_gate.py` — +2 note-aware cases.
- **21 gate+note+regression tests pass**; `ruff` + `pyright` clean; live CLI (`note`/`--list`/`--clear`/JSON) + MCP command-build smoke-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)