### PR TITLE
docs(note): surface the note scratchpad in system-prompt + skill

### DIFF
--- a/empirica/plugins/claude-code-integration/skills/epistemic-transaction/SKILL.md
+++ b/empirica/plugins/claude-code-integration/skills/epistemic-transaction/SKILL.md
@@ -754,10 +754,22 @@ transaction should capture what was relevant:
 | Made an error | `mistake-log` |
 | Discovered something | `finding-log` |
 | Hit an open question | `unknown-log` |
+| Noticed something to revisit, but not worth a full artifact mid-flow | `note "..."` (scratchpad) |
 
 **Why:** Single-type artifact logging (only findings) leaves calibration
 gaps ungrounded. The retrospective breadth_note will flag this, but by then
 the measurement window is closing.
+
+**Scratchpad notes vs artifacts.** `empirica note "..."` is the low-friction
+middle ground between logging a full artifact (structured, embedded) and
+holding a thought in context (lost at compaction). Use it to jot a follow-up,
+doubt, or "check this later" *without* breaking stride to classify it. Notes
+are transaction-scoped, pure-metadata (not shared, not embedded), and surface
+at POSTFLIGHT under `untriaged_notes`. At the retrospective, triage them:
+`note --list` → promote the keepers to a finding/decision/goal → `note --clear`.
+Capture now, classify later. (The retrospective soft-gate is note-aware — real
+praxic work with zero artifacts *and* zero notes is the strongest "logged
+nothing" signal.)
 
 ### Rule 4: Close Artifacts Before POSTFLIGHT
 

--- a/empirica/plugins/claude-code-integration/templates/empirica-system-prompt-lean.md
+++ b/empirica/plugins/claude-code-integration/templates/empirica-system-prompt-lean.md
@@ -329,6 +329,7 @@ empirica postflight-submit -         # Closes transaction
 empirica finding-log --finding "..." --impact 0.7
 empirica unknown-log --unknown "..."
 empirica deadend-log --approach "..." --why-failed "..."
+empirica note "..." [--tag followup|doubt|idea]   # fast scratchpad note-to-self (triaged at POSTFLIGHT)
 empirica goals-create --objective "..."
 empirica goals-complete --goal-id <ID> --reason "..."
 empirica project-search --task "..." --global
@@ -387,6 +388,7 @@ Infer epistemic actions from conversation naturally:
 | Approach failed | `deadend-log` |
 | Error made | `mistake-log` |
 | Choice point | `decision-log` |
+| Something to check on later, but not worth a full artifact yet (a doubt, a follow-up, "this smells off", "ask peer X") | `empirica note "..."` (optionally `--tag followup\|doubt\|idea`) — a fast scratchpad note-to-self. Pure metadata, not shared, survives compaction; surfaces at POSTFLIGHT for triage (`note --list`, then promote to an artifact/goal or `note --clear`). Capture now, classify later. |
 | External material cited (URL, doc, paper, transcript) | `source-add` then link via `sourced_from` in `log-artifacts` |
 | Logging ≥3 related artifacts in one breath, or any artifact with edges to others | `log-artifacts -` (one batch with `nodes` + `edges` JSON) instead of N individual `*-log` calls |
 | Closing several open unknowns / verifying assumptions at once (typically pre-POSTFLIGHT cleanup) | `resolve-artifacts -` batch JSON, not N individual `unknown-resolve` calls |


### PR DESCRIPTION
## What

Makes AIs aware of `empirica note` (shipped in #135) so it actually gets used.

- **System-prompt template** (`empirica-system-prompt-lean.md`) — the always-loaded layer, chosen deliberately so `note` is top-of-mind for constant mid-flow use rather than lazy-loaded behind a skill:
  - COLLABORATIVE MODE signal-table row: *"something to check on later, not worth a full artifact yet"* → `empirica note "..."`
  - CORE COMMANDS quick-reference line
- **`epistemic-transaction` skill** — a "scratchpad notes vs artifacts" explainer + artifact-logging table row. Covers capture-now-classify-later, transaction scoping, POSTFLIGHT `untriaged_notes` triage, and the note-aware soft-gate.

Markdown-only. MCP coverage already shipped in #135.

🤖 Generated with [Claude Code](https://claude.com/claude-code)