### PR TITLE
feat(mcp): CLI-parity guard + fix param drift + curated cortex-free coverage

### DIFF
--- a/empirica-mcp/empirica_mcp/server.py
+++ b/empirica-mcp/empirica_mcp/server.py
@@ -13,8 +13,10 @@ Architecture:
 - Stateless: no session state in the server itself
 
 Version tracked via the empirica-mcp package metadata (see pyproject.toml).
-Last TOOL_REGISTRY re-verification against `empirica --help`: 2026-04-05
-(stale — see TOOL_REGISTRY refresh goal for the additions backlog).
+TOOL_REGISTRY flag-parity against the real CLI is now enforced automatically by
+tests/test_cli_parity.py (no more manual re-verification dates): it fails if any
+mapped --flag stops existing on its CLI subcommand, and a curated capability
+floor keeps core flags (--description, goal scope/status) exposed.
 """
 
 import argparse
@@ -133,7 +135,7 @@ TOOL_REGISTRY: dict[str, dict] = {
                    "goal_id": "--goal-id", "task_id": "--task-id", "project_id": "--project-id",
                    "subject": "--subject", "scope": "--scope",
                    "entity_type": "--entity-type", "entity_id": "--entity-id", "via": "--via",
-                   "source_ids": "--source",
+                   "source_ids": "--source", "description": "--description",
                    "visibility": "--visibility", "epistemic_source": "--epistemic-source"},
         "required": ["finding"],
         "desc": "Log a finding (what was learned). Use source_ids to link to epistemic sources, visibility to opt into cross-project sharing, epistemic_source to tag provenance.",
@@ -157,9 +159,11 @@ TOOL_REGISTRY: dict[str, dict] = {
                    "goal_id": "--goal-id", "task_id": "--task-id", "project_id": "--project-id",
                    "subject": "--subject", "scope": "--scope",
                    "entity_type": "--entity-type", "entity_id": "--entity-id", "via": "--via",
+                   "source_ids": "--source", "description": "--description",
                    "visibility": "--visibility", "epistemic_source": "--epistemic-source"},
         "required": ["unknown"],
-        "desc": "Log an unknown (what needs investigation)",
+        "desc": "Log an unknown (what needs investigation). Use description for a rich body.",
+        "list_params": ["source_ids"],
     },
     "deadend_log": {
         "cli": "deadend-log",
@@ -167,27 +171,35 @@ TOOL_REGISTRY: dict[str, dict] = {
                    "goal_id": "--goal-id", "task_id": "--task-id", "project_id": "--project-id",
                    "subject": "--subject", "scope": "--scope",
                    "entity_type": "--entity-type", "entity_id": "--entity-id", "via": "--via",
+                   "source_ids": "--source", "description": "--description",
                    "visibility": "--visibility", "epistemic_source": "--epistemic-source"},
         "required": ["approach", "why_failed"],
-        "desc": "Log a dead-end (approach that didn't work)",
+        "desc": "Log a dead-end (approach that didn't work). Use description for a rich body.",
+        "list_params": ["source_ids"],
     },
     "mistake_log": {
         "cli": "mistake-log",
         "params": {"mistake": "--mistake", "why_wrong": "--why-wrong", "prevention": "--prevention",
                    "session_id": "--session-id", "goal_id": "--goal-id", "project_id": "--project-id",
                    "scope": "--scope", "entity_type": "--entity-type", "entity_id": "--entity-id",
+                   "cost_estimate": "--cost-estimate", "root_cause_vector": "--root-cause-vector",
+                   "source_ids": "--source", "description": "--description",
                    "visibility": "--visibility", "epistemic_source": "--epistemic-source"},
         "required": ["mistake", "why_wrong", "prevention"],
-        "desc": "Log a mistake (error to avoid in future)",
+        "desc": "Log a mistake (error to avoid in future). cost_estimate + root_cause_vector "
+                "capture severity + which vector misfired; description for a rich body.",
+        "list_params": ["source_ids"],
     },
     "assumption_log": {
         "cli": "assumption-log",
         "params": {"assumption": "--assumption", "confidence": "--confidence", "domain": "--domain",
                    "session_id": "--session-id", "goal_id": "--goal-id", "project_id": "--project-id",
                    "entity_type": "--entity-type", "entity_id": "--entity-id", "via": "--via",
+                   "source_ids": "--source", "description": "--description",
                    "visibility": "--visibility", "epistemic_source": "--epistemic-source"},
         "required": ["assumption"],
-        "desc": "Log an unverified assumption with confidence level",
+        "desc": "Log an unverified assumption with confidence level. description for a rich body.",
+        "list_params": ["source_ids"],
     },
     "decision_log": {
         "cli": "decision-log",
@@ -195,11 +207,14 @@ TOOL_REGISTRY: dict[str, dict] = {
                    "reversibility": "--reversibility", "confidence": "--confidence", "domain": "--domain",
                    "session_id": "--session-id", "goal_id": "--goal-id", "project_id": "--project-id",
                    "entity_type": "--entity-type", "entity_id": "--entity-id", "via": "--via",
-                   "evidence_refs": "--evidence",
+                   "evidence_refs": "--evidence", "evidence_from": "--evidence-from",
+                   "source_ids": "--source", "description": "--description",
                    "visibility": "--visibility", "epistemic_source": "--epistemic-source"},
         "required": ["choice", "rationale"],
-        "desc": "Log a decision with rationale. Use evidence_refs to link to supporting findings.",
-        "list_params": ["evidence_refs"],
+        "desc": "Log a decision with rationale. Use evidence_refs/evidence_from to link "
+                "supporting findings, source_ids for external sources, description for a rich "
+                "markdown body.",
+        "list_params": ["evidence_refs", "evidence_from", "source_ids"],
     },
     "source_add": {
         "cli": "source-add",
@@ -207,6 +222,32 @@ TOOL_REGISTRY: dict[str, dict] = {
                    "description": "--description", "session_id": "--session-id"},
         "required": ["title", "source_type"],
         "desc": "Add an epistemic source reference",
+    },
+    # --- Read-side logging queries (curated coverage; all local, no cortex) ---
+    "source_list": {
+        "cli": "source-list",
+        "params": {"project_id": "--project-id", "type": "--type",
+                   "direction": "--direction", "include_archived": "--include-archived"},
+        "required": [],
+        "desc": "List epistemic sources for the project (filter by type/direction).",
+    },
+    "mistake_query": {
+        "cli": "mistake-query",
+        "params": {"session_id": "--session-id", "goal_id": "--goal-id", "limit": "--limit"},
+        "required": [],
+        "desc": "Query logged mistakes (lessons to avoid repeating).",
+    },
+    "epistemics_list": {
+        "cli": "epistemics-list",
+        "params": {"session_id": "--session-id"},
+        "required": [],
+        "desc": "List epistemic artifacts for a session.",
+    },
+    "epistemics_show": {
+        "cli": "epistemics-show",
+        "params": {"session_id": "--session-id", "phase": "--phase"},
+        "required": [],
+        "desc": "Show epistemic artifact detail for a session (optionally by phase).",
     },
 
     # --- Batch artifact graph (parity with Cortex MCP cortex_log_artifacts/resolve/delete) ---
@@ -282,9 +323,15 @@ TOOL_REGISTRY: dict[str, dict] = {
     # --- Goals ---
     "goals_create": {
         "cli": "goals-create",
-        "params": {"objective": "--objective", "session_id": "--session-id", "project_id": "--project-id"},
+        "params": {"objective": "--objective", "description": "--description",
+                   "session_id": "--session-id", "project_id": "--project-id",
+                   "scope_breadth": "--scope-breadth", "scope_duration": "--scope-duration",
+                   "scope_coordination": "--scope-coordination",
+                   "success_criteria": "--success-criteria",
+                   "estimated_complexity": "--estimated-complexity", "status": "--status"},
         "required": ["objective"],
-        "desc": "Create a new goal",
+        "desc": "Create a new goal. Use description for a rich markdown body (why/success "
+                "criteria/links), scope_* for sizing, status=planned to queue without starting.",
     },
     "goals_list": {
         "cli": "goals-list",
@@ -305,6 +352,44 @@ TOOL_REGISTRY: dict[str, dict] = {
                    "importance": "--importance"},
         "required": ["goal_id", "description"],
         "desc": "Add a task to a goal",
+    },
+    # --- Goal lifecycle (curated coverage; all local, no cortex dependency) ---
+    "goals_get_tasks": {
+        "cli": "goals-get-tasks",
+        "params": {"goal_id": "--goal-id"},
+        "required": ["goal_id"],
+        "desc": "List the tasks of a goal with their status/evidence.",
+    },
+    "goals_discover": {
+        "cli": "goals-discover",
+        "params": {"from_ai_id": "--from-ai-id", "session_id": "--session-id"},
+        "required": [],
+        "desc": "Semantic search for goals across sessions (local Qdrant).",
+    },
+    "goals_activate": {
+        "cli": "goals-activate",
+        "params": {"goal_id": "--goal-id"},
+        "required": ["goal_id"],
+        "desc": "Activate a planned goal (planned → in_progress).",
+    },
+    "goals_refresh": {
+        "cli": "goals-refresh",
+        "params": {"goal_id": "--goal-id"},
+        "required": ["goal_id"],
+        "desc": "Mark a stale goal back to in_progress (e.g. after regaining context).",
+    },
+    "goals_mark_stale": {
+        "cli": "goals-mark-stale",
+        "params": {"session_id": "--session-id", "reason": "--reason"},
+        "required": [],
+        "desc": "Mark in-progress goals stale (e.g. at compaction).",
+    },
+    "goals_add_dependency": {
+        "cli": "goals-add-dependency",
+        "params": {"goal_id": "--goal-id", "depends_on": "--depends-on",
+                   "type": "--type", "description": "--description"},
+        "required": ["goal_id", "depends_on"],
+        "desc": "Declare a goal-to-goal dependency.",
     },
     "goals_complete_task": {
         "cli": "goals-complete-task",
@@ -772,9 +857,10 @@ TOOL_REGISTRY: dict[str, dict] = {
 # =============================================================================
 
 _NUMERIC_PARAMS = {"impact", "confidence", "estimated_complexity", "limit", "weeks", "count",
-                   "max_age", "deadline", "wait_timeout", "ttl"}
+                   "max_age", "deadline", "wait_timeout", "ttl",
+                   "scope_breadth", "scope_duration", "scope_coordination", "cost_estimate"}
 _BOOLEAN_PARAMS = {"grounded", "trajectory", "completed", "resolved", "all", "planning_only",
-                   "turtle", "cost", "health", "wait", "dry_run", "force"}
+                   "turtle", "cost", "health", "wait", "dry_run", "force", "include_archived"}
 _ENUM_PARAMS = {
     "reversibility": ["exploratory", "committal", "forced"],
     "scope": ["session", "project", "both"],

--- a/empirica-mcp/tests/test_cli_parity.py
+++ b/empirica-mcp/tests/test_cli_parity.py
@@ -1,0 +1,131 @@
+"""Parity guard: every MCP tool's CLI mapping must match the real CLI.
+
+The Empirica MCP server is a thin wrapper that shells out to the `empirica`
+CLI (needed for Desktop/Chat AIs that can't run bash). Its `TOOL_REGISTRY`
+maps each tool to a `cli` subcommand + `params` (mcp-arg → --flag). That map
+is hand-maintained and silently drifts as the CLI evolves: a renamed/removed
+flag still listed in the registry is accepted by the MCP schema but REJECTED
+by argparse at call time — a silent capability loss (e.g. `--description` was
+added to every *-log command but never surfaced via MCP; `goals_create`
+exposed 3 of 16 flags).
+
+This guard introspects the REAL argparse parser (`create_argument_parser`) and
+asserts, for every registry entry:
+
+  A. its `cli` subcommand exists, and
+  B. every mapped `--flag` is a real option on that subcommand.
+
+It is the MCP analogue of the SQL schema-reference guard: catch the drift class
+deterministically instead of by 77-day-stale manual re-verification.
+
+NOT checked here: coverage gaps (CLI commands with no MCP tool) — that's a
+curation decision, not a correctness bug.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import pytest
+from empirica_mcp.server import TOOL_REGISTRY
+
+from empirica.cli.cli_core import create_argument_parser
+
+
+def _subcommand_choices() -> dict[str, argparse.ArgumentParser]:
+    parser = create_argument_parser()
+    for action in parser._actions:
+        if isinstance(action, argparse._SubParsersAction):
+            return action.choices
+    raise AssertionError("no subparsers found on the empirica argument parser")
+
+
+def _flags_of(subparser: argparse.ArgumentParser) -> set[str]:
+    """All option strings (--flag / -f) accepted by a subparser."""
+    flags: set[str] = set()
+    for action in subparser._actions:
+        flags.update(action.option_strings)
+    return flags
+
+
+_CHOICES = _subcommand_choices()
+
+
+# Allow-list for known, deliberate divergences (ratchet). Keep empty; add a
+# (tool, flag) tuple ONLY with a comment justifying why the flag legitimately
+# has no CLI counterpart.
+_KNOWN_FLAG_DIVERGENCES: frozenset[tuple[str, str]] = frozenset()
+
+
+def _registry_items():
+    return sorted(TOOL_REGISTRY.items())
+
+
+@pytest.mark.parametrize("tool_name,entry", _registry_items())
+def test_mcp_tool_cli_exists(tool_name, entry):
+    """A — every registry entry's cli subcommand exists."""
+    cli = entry["cli"]
+    first = cli.split()[0]  # multi-token clis like "listener on" → top subcommand
+    assert first in _CHOICES, (
+        f"MCP tool '{tool_name}' targets `empirica {cli}` but '{first}' is not a "
+        f"CLI subcommand. The command was renamed or removed — update or drop "
+        f"the registry entry."
+    )
+
+
+@pytest.mark.parametrize("tool_name,entry", _registry_items())
+def test_mcp_tool_flags_exist_in_cli(tool_name, entry):
+    """B — every mapped --flag is a real option on the CLI subcommand."""
+    cli = entry["cli"]
+    tokens = cli.split()
+    # Multi-token clis (e.g. "listener on") resolve flags on a nested subparser
+    # whose introspection is brittle; the param-drift bug class lives in the
+    # single-verb logging/goal tools, so we flag-check those and assert only
+    # subcommand existence for multi-token ones (covered by test A).
+    if len(tokens) != 1:
+        pytest.skip(f"multi-token cli '{cli}' — flag-checked at the CLI layer")
+    sub = _CHOICES.get(tokens[0])
+    if sub is None:
+        pytest.skip("subcommand existence is asserted by test_mcp_tool_cli_exists")
+
+    valid = _flags_of(sub)
+    mapped = entry.get("params", {})
+    missing = [
+        flag for flag in mapped.values() if flag not in valid and (tool_name, flag) not in _KNOWN_FLAG_DIVERGENCES
+    ]
+    assert not missing, (
+        f"MCP tool '{tool_name}' (→ `empirica {cli}`) maps flag(s) {missing} that "
+        f"the CLI no longer accepts. argparse will reject them at call time — a "
+        f"silent capability loss. Fix the registry `params` to match the CLI, or "
+        f"add (tool, flag) to _KNOWN_FLAG_DIVERGENCES with justification."
+    )
+
+
+# Capability floor: flags a tool MUST expose (not just "may"). The registry
+# intentionally omits many CLI flags, but these are core capabilities whose
+# silent omission was the actual divergence bug — Desktop/Chat AIs writing
+# title-only artifacts and skeleton goals. This locks the fix so the gap can't
+# silently reopen when the registry is next edited.
+_REQUIRED_FLAGS: dict[str, set[str]] = {
+    "finding_log": {"--description"},
+    "unknown_log": {"--description"},
+    "deadend_log": {"--description"},
+    "assumption_log": {"--description"},
+    "decision_log": {"--description", "--source"},
+    "mistake_log": {"--description"},
+    "goals_create": {"--description", "--scope-breadth", "--status"},
+}
+
+
+@pytest.mark.parametrize("tool_name", sorted(_REQUIRED_FLAGS))
+def test_mcp_tool_exposes_required_capability_flags(tool_name):
+    """Curated capability floor — core flags must stay exposed via MCP."""
+    entry = TOOL_REGISTRY.get(tool_name)
+    assert entry is not None, f"expected tool '{tool_name}' in TOOL_REGISTRY"
+    exposed = set(entry.get("params", {}).values())
+    missing = sorted(_REQUIRED_FLAGS[tool_name] - exposed)
+    assert not missing, (
+        f"MCP tool '{tool_name}' must expose {missing} but doesn't. These are "
+        f"core capabilities (rich --description body, goal scope/status) — without "
+        f"them Desktop/Chat AIs silently lose them. Add to the registry `params`."
+    )


### PR DESCRIPTION
## What

The empirica MCP server wraps the CLI for Desktop/Chat AIs, but its hand-maintained `TOOL_REGISTRY` silently drifts (last manual re-verification was **77 days stale**). Your "check on the divergence" audit found **0 broken tools** but real **param drift** + coverage gaps. This fixes it *and* makes it self-maintaining.

## Parity guard (`empirica-mcp/tests/test_cli_parity.py`) — the durable fix

MCP analogue of the SQL schema-reference guard. Introspects the real argparse parser:
- **A** — every tool's `cli` subcommand must exist.
- **B** — every mapped `--flag` must be a real option on that subcommand (catches the silent argparse-rejection class deterministically).
- **Capability floor** — a curated `_REQUIRED_FLAGS` asserts core flags stay exposed (`--description` on all `*-log`, goal `--scope-breadth`/`--status`) so the gap can't silently reopen on the next edit.

No more stale "last verified" dates — drift now fails CI.

## Param-drift fixes (B)

Added the flags the CLI already had but MCP didn't expose:
- `--description` → all 5 `*-log` tools + `mistake_log`
- `--source` → unknown/deadend/assumption/decision_log; `--evidence-from` → decision_log
- `--cost-estimate` + `--root-cause-vector` → mistake_log
- `goals_create`: **3 → 11 flags** (`--description`, `--scope-*`, `--success-criteria`, `--estimated-complexity`, `--status`)
- Repeatable flags marked `list_params`; scope/cost typed numeric.

## Curated coverage (C) — cortex-free per your constraint

Added **local-only** tools: goal-lifecycle (`get-tasks`, `discover`, `activate`, `refresh`, `mark-stale`, `add-dependency`) + read-side logging queries (`source-list`, `mistake-query`, `epistemics-list/show`).

**Deliberately excluded** (your "don't duplicate cortex / don't require cortex"): `message-*`/`mailbox`/`bus` (duplicate the proprietary `mcp__cortex__*` surface + require cortex), and `source-archive` (best-effort cortex push).

## Verification

**157 parity tests + 586 MCP suite pass**; ruff clean. Live-verified CLI building: `finding-log … --source s1 --source s2 --description body`, `goals-create … --scope-breadth 0.5 --status planned`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)