### PR TITLE
fix(sentinel): recovery-verb deadlock + doctor allowlist + worktree subagent signal

### DIFF
--- a/empirica/plugins/claude-code-integration/hooks/sentinel-gate.py
+++ b/empirica/plugins/claude-code-integration/hooks/sentinel-gate.py
@@ -438,6 +438,8 @@ EMPIRICA_TIER1_PREFIXES = (
     'empirica discover-goals', 'empirica list-identities',
     'empirica issue-list',
     'empirica docs-assess',  # Documentation assessment - read-only investigation tool
+    'empirica doctor',  # Read-only diagnostic — MUST stay allowed (recovery escape hatch)
+    'empirica diagnose',  # Read-only mesh/listener diagnostic — recovery escape hatch
     'empirica calibration-report',  # Calibration analysis - read-only
     'empirica compact-analysis',  # Compact event analysis - read-only
     'empirica commit-context',  # Per-commit artifact aggregator - read-only
@@ -1972,6 +1974,26 @@ def _noetic_firewall_check(tool_name: str, tool_input: dict, hook_input: dict) -
     return None
 
 
+def _in_linked_git_worktree() -> bool:
+    """True if CWD is inside a LINKED git worktree (vs the main checkout).
+
+    A linked worktree (`git worktree add`) marks its root with a `.git` *file*
+    (`gitdir: …/worktrees/…`), whereas the main checkout has a `.git` *directory*.
+    Pure filesystem stat — no subprocess — so it's cheap enough for the per-tool
+    PreToolUse path. Used as a worktree-aware subagent signal: isolation:worktree
+    subagents run here; the real practitioner runs in the main checkout.
+    """
+    try:
+        cwd = Path.cwd()
+        for d in [cwd, *cwd.parents]:
+            g = d / '.git'
+            if g.exists():
+                return g.is_file()  # file → linked worktree; dir → main checkout
+    except Exception:
+        pass
+    return False
+
+
 def _detect_subagent(claude_session_id: str) -> bool:
     """Detect if the current invocation is from a subagent.
 
@@ -2011,6 +2033,15 @@ def _detect_subagent(claude_session_id: str) -> bool:
         # No active_work file for this claude_session_id — likely a subagent
         # (or session-init failed / project initialized mid-session).
         #
+        # Worktree-aware signal (ecodex prop_3dih #3, David architectural flag):
+        # isolation:worktree subagents run in a LINKED git worktree where the
+        # active_work lookup above fails — without this they fall through and risk
+        # mis-detection as the PARENT (then get measured, polluting parent state).
+        # Safe: the real practitioner runs in the main checkout and has its
+        # active_work (Path 1), so only genuine subagents reach this Path-2 branch.
+        if _in_linked_git_worktree():
+            return True
+
         # TIGHTENED CHECK (fixes #68): Don't just check if active_session exists —
         # verify its session matches the current transaction. Stale active_session
         # files from other projects/sessions cause false positive subagent detection.
@@ -2127,6 +2158,31 @@ def _validate_check_record(cursor, session_id: str, current_transaction_id, pref
     Returns (know, uncertainty, decision, check_timestamp) on success,
     or ("deny", message) tuple on failure.
     """
+    # ── RECOVERY ESCAPE HATCH (ecodex prop_3dih #1, David-flagged) ──────────
+    # A firewall must NEVER gate its own escape hatch. Empirica's discipline /
+    # recovery verbs (check/postflight-submit, *-log, note, doctor) + noetic
+    # tools must ALWAYS pass — regardless of CHECK / rush / stuck state. The
+    # safe-command escapes below live only in the no-CHECK-row branch; without
+    # this hoist, a rushed assessment (short noetic + 0 artifacts) makes EVERY
+    # praxic call — INCLUDING the postflight that would clear it — deny "Rushed
+    # assessment", an unrecoverable deadlock. Covers both the no-CHECK-row and
+    # the has-CHECK-row (rush) paths.
+    if (
+        tool_name in NOETIC_TOOLS
+        or tool_name in NOETIC_MCP_CHROME
+        or tool_name in NOETIC_MCP_CORTEX
+        or _is_empirica_mcp_tool(tool_name)
+        or (
+            tool_name == 'Bash'
+            and tool_input
+            and (
+                is_safe_bash_command(tool_input)
+                or is_safe_empirica_command(tool_input.get('command', ''))
+            )
+        )
+    ):
+        return None
+
     if current_transaction_id:
         cursor.execute("""
             SELECT know, uncertainty, reflex_data, timestamp

--- a/tests/test_sentinel_recovery_escape.py
+++ b/tests/test_sentinel_recovery_escape.py
@@ -1,0 +1,97 @@
+"""Regression: the sentinel firewall must never gate its own escape hatch.
+
+Two David-flagged bugs (ecodex prop_3dih), both in sentinel-gate.py:
+
+1) CRITICAL deadlock — a rushed assessment (short noetic + 0 artifacts) made
+   the rush-guard deny EVERY praxic Bash call, INCLUDING the postflight /
+   check-submit / doctor needed to clear it. The safe-command escape lived only
+   in the no-CHECK-row branch; the has-CHECK-row (rush) branch denied
+   unconditionally. Fix: hoist the recovery escape to the TOP of
+   _validate_check_record so recovery verbs always pass, in any state.
+
+2) `empirica doctor` was not allow-listed at all → blocked when needed most.
+
+This locks both so the deadlock can't return.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_HOOK = (
+    Path(__file__).resolve().parent.parent
+    / "empirica/plugins/claude-code-integration/hooks/sentinel-gate.py"
+)
+
+
+def _load_hook():
+    spec = importlib.util.spec_from_file_location("sentinel_gate_under_test", _HOOK)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+sg = _load_hook()
+
+
+# --- #2: doctor/diagnose are recovery verbs and must be allow-listed --------- #
+@pytest.mark.parametrize("cmd", ["empirica doctor", "empirica diagnose"])
+def test_diagnostic_recovery_verbs_allow_listed(cmd):
+    assert sg.is_safe_empirica_command(cmd) is True
+
+
+# --- #1: recovery verbs escape the rush-guard regardless of CHECK state ------ #
+# The escape is hoisted ABOVE any cursor use, so passing cursor=None proves the
+# command short-circuits to allow (None) without ever reaching the rush/deny
+# logic. A genuinely praxic command would instead touch the cursor (and here
+# raise), so "returns None cleanly" == "escaped the gate".
+@pytest.mark.parametrize("command", [
+    "empirica postflight-submit -",
+    "empirica check-submit -",
+    "empirica doctor",
+    "empirica finding-log --finding x",
+    'empirica note "x"',
+])
+def test_recovery_verb_escapes_rush_guard(command):
+    result = sg._validate_check_record(
+        None, "sess", None, 0,
+        tool_input={"command": command}, tool_name="Bash",
+    )
+    assert result is None, f"{command!r} should escape the gate (allow), got {result!r}"
+
+
+def test_noetic_tool_escapes_rush_guard():
+    result = sg._validate_check_record(
+        None, "sess", None, 0, tool_input={}, tool_name="Read",
+    )
+    assert result is None
+
+
+def test_non_recovery_bash_is_not_escaped_by_the_hatch():
+    # A non-safe praxic command must NOT short-circuit via the escape — it falls
+    # through to the real logic, which calls cursor.execute(); with cursor=None
+    # that raises AttributeError. If the escape were over-broad it would instead
+    # return None. So the raise proves the command reached the real gate.
+    with pytest.raises(AttributeError):
+        sg._validate_check_record(
+            None, "sess", "tx1", 0,
+            tool_input={"command": "rm -rf /tmp/whatever"}, tool_name="Bash",
+        )
+
+
+# --- #3: worktree-aware subagent signal -------------------------------------- #
+def test_linked_worktree_detected_by_git_file(tmp_path, monkeypatch):
+    # Linked worktree: .git is a FILE.
+    (tmp_path / ".git").write_text("gitdir: /repo/.git/worktrees/wt1\n")
+    monkeypatch.chdir(tmp_path)
+    assert sg._in_linked_git_worktree() is True
+
+
+def test_main_checkout_not_flagged_as_worktree(tmp_path, monkeypatch):
+    # Main checkout: .git is a DIRECTORY.
+    (tmp_path / ".git").mkdir()
+    monkeypatch.chdir(tmp_path)
+    assert sg._in_linked_git_worktree() is False


### PR DESCRIPTION
Two David-flagged firewall bugs (surfaced by **ecodex**, prop_3dih). I hit milder variants of both this session.

## #1 — CRITICAL: deadlock on recovery commands

`_validate_check_record`'s safe-command escape (noetic / safe-bash / safe-empirica) lived **only in the no-CHECK-row branch**. With a CHECK row present but the assessment rushed (short noetic + 0 artifacts), the function skips straight to the unconditional `"Rushed assessment"` deny — it never re-checks whether the current command is a recovery verb.

**Result:** `postflight-submit` / `check-submit` / `doctor` all get denied in the rushed state → the firewall blocks the exact commands needed to clear it → **unrecoverable via shell**.

**Fix:** hoist the recovery escape to the **top** of `_validate_check_record` so it covers both the no-CHECK and rushed-CHECK paths. *A firewall must never gate its own escape hatch.* Also: `empirica doctor` and `diagnose` were **not allow-listed at all** → added to TIER1.

## #3 — subagent measurement leak

`_detect_subagent`'s Path-2 (active_work missing) could miss an `isolation:worktree` subagent → mis-detected as the **parent** and measured, polluting parent transaction state. (Confirmed live: the `d0c2308` dangling commit was a worktree subagent tagged with the parent session_id.)

**Fix:** `_in_linked_git_worktree()` — a cheap `.git`-is-a-file stat — as a Path-2 confirmation. Safe: the real practitioner runs in the main checkout and hits Path 1, so only genuine subagents reach Path 2.

## Verification

`tests/test_sentinel_recovery_escape.py` — **11 cases**: recovery verbs escape the rush-guard (proven with `cursor=None` — the escape is above any cursor use); a non-recovery command falls through to the real gate; `doctor`/`diagnose` allow-listed; worktree file-vs-dir detection. ruff clean. **Deployed live** via `setup-claude-code --force` (verified the global hook carries all three changes).

ecodex offered to test from their side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)