### PR TITLE
fix(seat): session-init mesh backfill (#7 layer B) + correct stale tenant-metadata endpoint

### DIFF
--- a/empirica/cli/command_handlers/setup_claude_code.py
+++ b/empirica/cli/command_handlers/setup_claude_code.py
@@ -946,14 +946,14 @@ def _fetch_tenant_metadata(
     api_key: str,
     timeout: float = 10.0,
 ) -> dict | None:
-    """GET `{cortex_url}/v1/tenant/me` and pull {org_id, tenant_slug, mesh_id_prefix}.
+    """GET `{cortex_url}/v1/users/me` and pull {org_id, tenant_slug, mesh_id_prefix}.
 
     Returns the three fields on 2xx, None on HTTP error / network failure /
     malformed JSON. Mirrors the Bearer-auth + urllib pattern used by
     projects_commands._post_project — kept inline to avoid an import cycle
     with the bulk-register handler.
     """
-    url = f"{cortex_url.rstrip('/')}/v1/tenant/me"
+    url = f"{cortex_url.rstrip('/')}/v1/users/me"
     req = urllib.request.Request(
         url,
         method="GET",
@@ -1045,7 +1045,7 @@ def _resolve_and_persist_tenant_metadata(
 ) -> dict | None:
     """Resolve {org_id, tenant_slug, mesh_id_prefix} and merge into project.yaml.
 
-    Precedence per field: CLI flag > REST `/v1/tenant/me` > unset.
+    Precedence per field: CLI flag > REST `/v1/users/me` > unset.
     REST is skipped entirely when all three flags are supplied.
     When REST is needed but cortex creds are missing, we no-op silently.
 
@@ -1450,7 +1450,7 @@ def handle_setup_claude_code_command(args):
             creds_state = _run_credentials_wizard(creds_state, output_format)
 
         # Stage 6.6: Tenant metadata resolution (cortex Phase 1 mesh — prop_jc5f4h5).
-        # Fetch org_id/tenant_slug/mesh_id_prefix from /v1/tenant/me and merge
+        # Fetch org_id/tenant_slug/mesh_id_prefix from /v1/users/me and merge
         # into .empirica/project.yaml so per-AI session bootstraps can compose
         # the three ai_id forms (short/tenant/mesh) without a cortex round-trip
         # every time. Flags --org-id / --tenant-slug / --mesh-id-prefix

--- a/empirica/cli/parsers/onboarding_parsers.py
+++ b/empirica/cli/parsers/onboarding_parsers.py
@@ -53,23 +53,23 @@ Run this after 'brew install empirica' or 'pip install empirica'.
         help='Skip installing the persistent listener service '
              '(systemd-user / launchd). Use when you want session-only Monitor.'
     )
-    # Tenant metadata escape hatches — override the cortex /v1/tenant/me fetch
+    # Tenant metadata escape hatches — override the cortex /v1/users/me fetch
     # field-by-field. Useful when running setup-claude-code without cortex
     # creds, or pre-baking tenant identity into a fleet image.
     setup_cc_parser.add_argument(
         '--org-id',
         default=None,
-        help='Override tenant org_id (skip cortex /v1/tenant/me fetch for this field)'
+        help='Override tenant org_id (skip cortex /v1/users/me fetch for this field)'
     )
     setup_cc_parser.add_argument(
         '--tenant-slug',
         default=None,
-        help='Override tenant_slug (skip cortex /v1/tenant/me fetch for this field)'
+        help='Override tenant_slug (skip cortex /v1/users/me fetch for this field)'
     )
     setup_cc_parser.add_argument(
         '--mesh-id-prefix',
         default=None,
-        help='Override mesh_id_prefix (skip cortex /v1/tenant/me fetch for this field)'
+        help='Override mesh_id_prefix (skip cortex /v1/users/me fetch for this field)'
     )
     setup_cc_parser.add_argument(
         '--skip-claude-md',

--- a/empirica/config/project_config_loader.py
+++ b/empirica/config/project_config_loader.py
@@ -242,7 +242,7 @@ def compose_ai_id_forms(
 
     Mirrors cortex.tenant.compose_ai_id_forms — kept local so empirica doesn't
     take a runtime dependency on the cortex package. Trusts `mesh_id_prefix`
-    as cortex returns it (via /v1/tenant/me or cortex_session_init) rather
+    as cortex returns it (via /v1/users/me or cortex_session_init) rather
     than recomputing it, so we don't drift if cortex changes its slug rule.
 
     Forms (progressively qualified — pick the narrowest that disambiguates):
@@ -267,7 +267,7 @@ def compose_canonical_seat(*, mesh_id_prefix: str, ai_id: str) -> str | None:
     the older mesh-addressing convention — do not use those for `seat`.
 
     `mesh_id_prefix` is the `<org>.<tenant>` prefix cortex returns in
-    session_init / `/v1/tenant/me` (e.g. `empirica.david`); `ai_id` is the
+    session_init / `/v1/users/me` (e.g. `empirica.david`); `ai_id` is the
     project's canonical basename (e.g. `empirica`). Result:
     `empirica.david.empirica`.
 

--- a/empirica/plugins/claude-code-integration/hooks/session-init.py
+++ b/empirica/plugins/claude-code-integration/hooks/session-init.py
@@ -491,6 +491,80 @@ def _heal_session_project_id_at_init(session_id: str, project_root: str | None) 
               file=sys.stderr)
 
 
+def _heal_mesh_metadata_at_init(project_root: str | None) -> None:
+    """Backfill mesh tenant metadata into .empirica/project.yaml at session-init.
+
+    Projects init'd before the strict-canonical seat era have an ``ai_id`` but
+    none of {org_id, tenant_slug, mesh_id_prefix, canonical_seat}. Without
+    ``canonical_seat``, ``cortex_session_init`` cannot pick a seat for a
+    multi-practice api_key (returns ``multi_project_no_seat``) and every mesh
+    send must hand-compose ``source_claude``. This self-heals it: resolve the
+    tenant metadata from cortex's ``/v1/tenant/me`` and persist it — which also
+    composes the strict canonical 3-form seat (``org.tenant.project``) via
+    ``compose_canonical_seat``.
+
+    Read-only against cortex (a GET) — it never passes a ``seat`` to
+    session_init, so it cannot trip the seat-param anti-spoof path. That
+    (passing the composed seat) is the separate, cortex-phased Phase 2.
+
+    Idempotent — the ``canonical_seat`` fast-path returns BEFORE any network
+    call or heavy import, so the steady-state cost is a single yaml read.
+    Non-fatal — degrades silently when cortex creds are absent (offline /
+    un-onboarded) and never blocks session boot.
+    """
+    if not project_root:
+        return
+    try:
+        import yaml
+        project_yaml = Path(project_root) / '.empirica' / 'project.yaml'
+        if not project_yaml.exists():
+            return
+        cfg = yaml.safe_load(project_yaml.read_text()) or {}
+        if not isinstance(cfg, dict):
+            return
+        # Idempotent fast-path: already seated → no import, no network.
+        if cfg.get('canonical_seat'):
+            return
+        ai_id = cfg.get('ai_id')
+        if not ai_id:
+            return  # nothing to compose a seat from — leave alone, never guess
+
+        # Backfill needed — resolve cortex creds.
+        from empirica.config.credentials_loader import get_credentials_loader
+        loader = get_credentials_loader()
+        loader.reload()
+        cortex_cfg = loader.get_cortex_config()
+        cortex_url = cortex_cfg.get('url')
+        api_key = cortex_cfg.get('api_key')
+        if not (cortex_url and api_key):
+            return  # offline / un-onboarded — silent no-op
+
+        # Reuse setup-claude-code's REST + persist helpers (persist composes
+        # canonical_seat). Lazy-imported only on the unhealed path.
+        from empirica.cli.command_handlers.setup_claude_code import (
+            _fetch_tenant_metadata,
+            _persist_tenant_metadata,
+        )
+        metadata = _fetch_tenant_metadata(cortex_url, api_key)
+        if not metadata or not metadata.get('mesh_id_prefix'):
+            return  # can't compose a seat without the prefix — leave alone
+
+        wrote = _persist_tenant_metadata(Path(project_root), **metadata)
+        if wrote:
+            from empirica.config.project_config_loader import compose_canonical_seat
+            seat = compose_canonical_seat(
+                mesh_id_prefix=metadata['mesh_id_prefix'], ai_id=ai_id,
+            )
+            print(
+                f"session-init: backfilled project.yaml mesh metadata "
+                f"(canonical_seat={seat})",
+                file=sys.stderr,
+            )
+    except Exception as e:
+        print(f"session-init: mesh metadata backfill skipped "
+              f"({type(e).__name__}: {e})", file=sys.stderr)
+
+
 def create_session_and_bootstrap(ai_id: str, project_id: str | None = None) -> dict:
     """Create session + run bootstrap in sequence.
 
@@ -527,6 +601,12 @@ def create_session_and_bootstrap(ai_id: str, project_id: str | None = None) -> d
         # Step 1d: Heal .empirica/project.yaml ai_id if it's a stripped-prefix
         # legacy value (pre-strict-canonical era, 1.11.x). Idempotent.
         _heal_project_yaml_ai_id_at_init(os.environ.get('PWD') or os.getcwd())
+
+        # Step 1e: Backfill mesh tenant metadata (canonical_seat etc.) for
+        # ai_id-only project.yamls so cortex_session_init can seat a
+        # multi-practice api_key. Idempotent + cortex-read-only (no seat is
+        # passed here — that's the cortex-gated Phase 2).
+        _heal_mesh_metadata_at_init(os.environ.get('PWD') or os.getcwd())
 
         # Step 2: Run bootstrap
         bootstrap_data, project_context = _run_bootstrap(session_id, env)

--- a/empirica/plugins/claude-code-integration/hooks/session-init.py
+++ b/empirica/plugins/claude-code-integration/hooks/session-init.py
@@ -499,7 +499,7 @@ def _heal_mesh_metadata_at_init(project_root: str | None) -> None:
     ``canonical_seat``, ``cortex_session_init`` cannot pick a seat for a
     multi-practice api_key (returns ``multi_project_no_seat``) and every mesh
     send must hand-compose ``source_claude``. This self-heals it: resolve the
-    tenant metadata from cortex's ``/v1/tenant/me`` and persist it — which also
+    tenant metadata from cortex's ``/v1/users/me`` and persist it — which also
     composes the strict canonical 3-form seat (``org.tenant.project``) via
     ``compose_canonical_seat``.
 

--- a/tests/test_session_init_mesh_backfill.py
+++ b/tests/test_session_init_mesh_backfill.py
@@ -1,0 +1,210 @@
+"""Tests for _heal_mesh_metadata_at_init in the session-init hook.
+
+Closes the seat gap (goal #7): projects init'd before the strict-canonical
+seat era have an ``ai_id`` but no {org_id, tenant_slug, mesh_id_prefix,
+canonical_seat}, so ``cortex_session_init`` returns ``multi_project_no_seat``
+for a multi-practice api_key. This hook step backfills the mesh metadata from
+cortex's ``/v1/tenant/me`` at session-init, persisting the strict canonical
+3-form seat.
+
+Read-only against cortex (a GET); it never passes a ``seat`` to session_init
+(that is the separate, cortex-gated Phase 2). Idempotent + non-fatal.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import yaml
+
+HOOK_PATH = (
+    Path(__file__).parent.parent
+    / "empirica" / "plugins" / "claude-code-integration"
+    / "hooks" / "session-init.py"
+)
+
+
+def _load_hook_module():
+    """Import the session-init.py hook as a module despite the dash in the name."""
+    spec = importlib.util.spec_from_file_location("session_init_hook", HOOK_PATH)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    plugin_lib = HOOK_PATH.parent.parent / "lib"
+    sys.path.insert(0, str(plugin_lib))
+    try:
+        spec.loader.exec_module(mod)
+    finally:
+        sys.path.remove(str(plugin_lib))
+    return mod
+
+
+class _FakeLoader:
+    """Stand-in for the credentials loader — returns a fixed cortex config."""
+
+    def __init__(self, cfg: dict):
+        self._cfg = cfg
+
+    def reload(self) -> None:
+        pass
+
+    def get_cortex_config(self) -> dict:
+        return self._cfg
+
+
+def _make_project_yaml(project_root: Path, fields: dict) -> Path:
+    (project_root / ".empirica").mkdir(parents=True)
+    yaml_path = project_root / ".empirica" / "project.yaml"
+    yaml_path.write_text(yaml.safe_dump(fields, sort_keys=False))
+    return yaml_path
+
+
+def _patch_creds(monkeypatch, cfg: dict) -> None:
+    monkeypatch.setattr(
+        "empirica.config.credentials_loader.get_credentials_loader",
+        lambda: _FakeLoader(cfg),
+    )
+
+
+def _patch_fetch(monkeypatch, result, calls: list | None = None):
+    """Patch setup_claude_code._fetch_tenant_metadata to return `result`.
+
+    If `calls` is provided, each invocation appends to it (call-count assert).
+    """
+    def _fake(cortex_url, api_key):
+        if calls is not None:
+            calls.append((cortex_url, api_key))
+        return result
+    monkeypatch.setattr(
+        "empirica.cli.command_handlers.setup_claude_code._fetch_tenant_metadata",
+        _fake,
+    )
+    return calls
+
+
+_META = {
+    "org_id": "org-empirica",
+    "tenant_slug": "david",
+    "mesh_id_prefix": "empirica.david",
+}
+
+
+def test_backfills_when_ai_id_only(tmp_path, monkeypatch, capsys):
+    """ai_id-only yaml + creds + REST → canonical_seat + mesh fields written."""
+    mod = _load_hook_module()
+    proj = tmp_path / "empirica"
+    _make_project_yaml(proj, {"version": "2.0", "name": "Empirica", "ai_id": "empirica"})
+    _patch_creds(monkeypatch, {"url": "https://cortex.test", "api_key": "k"})
+    _patch_fetch(monkeypatch, dict(_META))
+
+    mod._heal_mesh_metadata_at_init(str(proj))
+
+    cfg = yaml.safe_load((proj / ".empirica" / "project.yaml").read_text())
+    assert cfg["canonical_seat"] == "empirica.david.empirica"
+    assert cfg["mesh_id_prefix"] == "empirica.david"
+    assert cfg["org_id"] == "org-empirica"
+    assert cfg["tenant_slug"] == "david"
+    # ai_id and other fields preserved
+    assert cfg["ai_id"] == "empirica"
+    assert cfg["name"] == "Empirica"
+    err = capsys.readouterr().err
+    assert "backfilled" in err
+    assert "empirica.david.empirica" in err
+
+
+def test_idempotent_when_canonical_seat_present(tmp_path, monkeypatch, capsys):
+    """Already-seated yaml → no REST call, unchanged (fast-path before network)."""
+    mod = _load_hook_module()
+    proj = tmp_path / "empirica"
+    _make_project_yaml(proj, {
+        "ai_id": "empirica", "canonical_seat": "empirica.david.empirica",
+    })
+    _patch_creds(monkeypatch, {"url": "https://cortex.test", "api_key": "k"})
+    calls: list = []
+    _patch_fetch(monkeypatch, dict(_META), calls)
+
+    mod._heal_mesh_metadata_at_init(str(proj))
+
+    assert calls == []  # fast-path returned before any fetch
+    cfg = yaml.safe_load((proj / ".empirica" / "project.yaml").read_text())
+    assert cfg["canonical_seat"] == "empirica.david.empirica"
+    assert "backfilled" not in capsys.readouterr().err
+
+
+def test_second_call_is_noop_after_backfill(tmp_path, monkeypatch):
+    """Backfill then re-run → second run hits the idempotent fast-path."""
+    mod = _load_hook_module()
+    proj = tmp_path / "empirica"
+    _make_project_yaml(proj, {"ai_id": "empirica"})
+    _patch_creds(monkeypatch, {"url": "https://cortex.test", "api_key": "k"})
+    calls: list = []
+    _patch_fetch(monkeypatch, dict(_META), calls)
+
+    mod._heal_mesh_metadata_at_init(str(proj))   # writes seat
+    mod._heal_mesh_metadata_at_init(str(proj))   # should not fetch again
+
+    assert len(calls) == 1  # only the first run reached the network
+
+
+def test_no_op_when_no_creds(tmp_path, monkeypatch, capsys):
+    """No cortex creds → silent no-op, no REST call, yaml unchanged."""
+    mod = _load_hook_module()
+    proj = tmp_path / "empirica"
+    _make_project_yaml(proj, {"ai_id": "empirica"})
+    _patch_creds(monkeypatch, {})  # no url/api_key
+    calls: list = []
+    _patch_fetch(monkeypatch, dict(_META), calls)
+
+    mod._heal_mesh_metadata_at_init(str(proj))
+
+    assert calls == []
+    cfg = yaml.safe_load((proj / ".empirica" / "project.yaml").read_text())
+    assert "canonical_seat" not in cfg
+    assert "Traceback" not in capsys.readouterr().err
+
+
+def test_no_op_when_no_ai_id(tmp_path, monkeypatch):
+    """yaml without ai_id → leave alone, never guess a seat."""
+    mod = _load_hook_module()
+    proj = tmp_path / "empirica"
+    _make_project_yaml(proj, {"version": "2.0", "name": "no-ai"})
+    _patch_creds(monkeypatch, {"url": "https://cortex.test", "api_key": "k"})
+    calls: list = []
+    _patch_fetch(monkeypatch, dict(_META), calls)
+
+    mod._heal_mesh_metadata_at_init(str(proj))
+
+    assert calls == []
+    cfg = yaml.safe_load((proj / ".empirica" / "project.yaml").read_text())
+    assert "canonical_seat" not in cfg
+
+
+def test_no_op_when_fetch_lacks_prefix(tmp_path, monkeypatch):
+    """REST returns no mesh_id_prefix → can't compose a seat, leave alone."""
+    mod = _load_hook_module()
+    proj = tmp_path / "empirica"
+    _make_project_yaml(proj, {"ai_id": "empirica"})
+    _patch_creds(monkeypatch, {"url": "https://cortex.test", "api_key": "k"})
+    _patch_fetch(monkeypatch, {"org_id": "org-empirica", "tenant_slug": "david",
+                               "mesh_id_prefix": None})
+
+    mod._heal_mesh_metadata_at_init(str(proj))
+
+    cfg = yaml.safe_load((proj / ".empirica" / "project.yaml").read_text())
+    assert "canonical_seat" not in cfg
+
+
+def test_no_op_when_no_project_yaml(tmp_path, capsys):
+    """Missing project.yaml → silent, non-fatal."""
+    mod = _load_hook_module()
+    mod._heal_mesh_metadata_at_init(str(tmp_path / "no-such-project"))
+    assert "Traceback" not in capsys.readouterr().err
+
+
+def test_no_op_with_empty_project_root(capsys):
+    """None / empty project_root → silent, non-fatal."""
+    mod = _load_hook_module()
+    mod._heal_mesh_metadata_at_init(None)
+    mod._heal_mesh_metadata_at_init("")
+    assert "Traceback" not in capsys.readouterr().err

--- a/tests/test_session_init_mesh_backfill.py
+++ b/tests/test_session_init_mesh_backfill.py
@@ -4,7 +4,7 @@ Closes the seat gap (goal #7): projects init'd before the strict-canonical
 seat era have an ``ai_id`` but no {org_id, tenant_slug, mesh_id_prefix,
 canonical_seat}, so ``cortex_session_init`` returns ``multi_project_no_seat``
 for a multi-practice api_key. This hook step backfills the mesh metadata from
-cortex's ``/v1/tenant/me`` at session-init, persisting the strict canonical
+cortex's ``/v1/users/me`` at session-init, persisting the strict canonical
 3-form seat.
 
 Read-only against cortex (a GET); it never passes a ``seat`` to session_init

--- a/tests/test_setup_claude_code_tenant_metadata.py
+++ b/tests/test_setup_claude_code_tenant_metadata.py
@@ -94,13 +94,13 @@ def test_fetch_strips_trailing_slash_on_cortex_url():
     with patch("urllib.request.urlopen", side_effect=fake_urlopen):
         _fetch_tenant_metadata("https://cortex.example.com/", "ctx_test")
 
-    assert captured["url"] == "https://cortex.example.com/v1/tenant/me"
+    assert captured["url"] == "https://cortex.example.com/v1/users/me"
     assert captured["auth"] == "Bearer ctx_test"
 
 
 def test_fetch_http_error_returns_none():
     err = urllib.error.HTTPError(
-        url="https://cortex/v1/tenant/me", code=401,
+        url="https://cortex/v1/users/me", code=401,
         msg="Unauthorized", hdrs=None, fp=io.BytesIO(b""),  # type: ignore[arg-type]
     )
     with patch("urllib.request.urlopen", side_effect=err):


### PR DESCRIPTION
## What
Closes the `multi_project_no_seat` gap (goal #7) so `cortex_session_init` can seat a multi-practice api_key.

**Two commits, two layers:**
1. **`_heal_mesh_metadata_at_init`** — an idempotent, non-fatal session-init heal step that backfills `{org_id, tenant_slug, mesh_id_prefix, canonical_seat}` into `project.yaml` for projects predating the strict-canonical seat era. Reuses `compose_canonical_seat` + the existing persist helper; matches the established `_heal_*_at_init` pattern. Read-only against cortex — never passes a `seat` to session_init (that's the separate, cortex-gated Phase 2).
2. **Endpoint correction** `/v1/tenant/me` → `/v1/users/me` — the tenant-metadata fetch targeted an endpoint that 404s on prod. Per cortex's contract clarification, `/v1/tenant/me` never existed; `/v1/users/me` is canonical (same shape, in-prod). This also fixes a **pre-existing bug**: the already-shipped seat-persist feature was a prod no-op for the same reason, since both consumers reuse `_fetch_tenant_metadata`.

## Verification
- 8 new tests (backfill, idempotency, no-creds / no-ai_id / no-prefix / missing-yaml graceful no-ops)
- Live: `_fetch_tenant_metadata` returns `{org_id: org-empirica, tenant_slug: david, mesh_id_prefix: empirica.david}` from real `/v1/users/me`
- E2E: layer B backfills a fresh ai_id-only yaml through the real endpoint → `canonical_seat=empirica.david.empirica`
- ruff + pyright clean on all 4 changed files

## Out of scope
Layer C (empirica/daemons *passing* the composed seat to `cortex_session_init`) remains cortex-phased — not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)