### PR TITLE
chore(skills): scrub copyable SER protocol from constitution + epistemic-transaction

### DIFF
--- a/empirica/plugins/claude-code-integration/skills/empirica-constitution/SKILL.md
+++ b/empirica/plugins/claude-code-integration/skills/empirica-constitution/SKILL.md
@@ -28,7 +28,7 @@ system prompt deliberately leaves out so it stays small:
 - **Are the rules self-applicable?** The turtle principle (§III)
 - **What IS a practice, and how does it relate to a Claude / a directory / a project?** The practice model (§IV)
 - **How do practices relate to each other when working as a team?** Mesh discipline (§V)
-- **How is sustained multi-practice coordination held — and why is creating it gated?** Shared Epistemic Records (§VI)
+- **How is sustained multi-practice coordination held — and why is creating it gated?** (§VI)
 
 Load this skill when one of those questions surfaces, when starting a
 fresh-context session that needs orientation past the system prompt, or
@@ -276,112 +276,9 @@ accordingly. There is no opponent to deceive.
 
 ---
 
-## §VI. Shared Epistemic Records (SER)
+## §VI. Sustained multi-practice coordination
 
-§V is about the *messages* practices exchange. §VI is about the *shared
-state* those messages converge on. A **Shared Epistemic Record** is the
-cortex-resident coordination object for work that spans ≥2 practices and
-survives across sessions. Goals stay per-practice; the SER is what those
-goals coordinate *against*.
-
-### When an SER is the right primitive
-
-A single collab is a message; an SER is a standing coordination surface.
-Reach for one when:
-
-- a collab thread has run ≥3 rounds across the same practices with no
-  graduation in sight (the thread *is* the coordination — give it a home), or
-- the work has named participants with role tiers and outlives one session, or
-- multiple practices' goals all point at the same outcome and someone needs
-  the authoritative "where are we" state.
-
-Do **not** create one for a single FYI, a one-shot ask, or work that lives
-entirely inside one practice. That's collab / propose / a local goal.
-
-### Creation is proposal-gated — and that is the safety property
-
-You do not create an SER directly. You **propose** one
-(`cortex_propose` with `payload.action='create_ser'`), and it lands
-`eco_review` — **even with `action_category=REFLEX`**. No `ser_id`
-exists until a human Accepts.
-
-This is deliberate, not friction. An SER names *other practitioners* as
-participants — creating one **commits their attention and workload**. An
-AI can *propose* to coordinate the mesh, but it cannot *conscript* peers
-into shared work; the human authorizes that cross-practice resource
-mapping at the ECO boundary. **Proposing coordination is ungated;
-instantiating it across others' workloads is gated.** This is the §V
-"pull/push" discipline made structural — the same reason a cross-boundary
-*action* is gated while a *message* is not (the turtle principle, §III:
-the gate that gates actions also gates the act of binding others to them).
-
-Every subsequent mutation — `transition_ser`, `ser_ack` — is **also**
-ECO-gated. The SER's whole lifecycle is human-authorized.
-
-### Lifecycle
-
-`open → in_progress → closed` (terminal); `blocked ↔ in_progress` when a
-blocker lifts. Re-open a closed SER by creating a new one with a
-`source_ref` to the prior. Coordination state is independent of any
-participant's local goal lifecycle — an SER can be `in_progress` while a
-participant's own goal is already closed.
-
-### Role tiers — who gets woken
-
-| Role | Woken on transition | Escalation re-ping when idle |
-|------|---------------------|------------------------------|
-| `required` | every transition | yes, if `last_ack_at < last_transition_at` past `escalation_seconds` |
-| `participating` | every transition | no |
-| `observer` | only `blocked` / `closed` | no |
-
-Pick honestly: `required` for owners who must stay current (they get
-re-pinged), `participating` for decision-catchers, `observer` for
-blocker-only attention. Default to `participating` when unsure — marking
-everyone `required` is swarm amplification (every transition re-pings
-every practice).
-
-### Acking — the "I'm current" signal
-
-`required` participants MUST `ser_ack` to stamp `last_ack_at` and silence
-the escalation tick. Without an ack within `escalation_seconds` of the
-last transition, cortex re-pings. The ack is the canonical "I've absorbed
-this SER's current state" signal — the SER analog of the §V completion
-handshake.
-
-### Validated call shapes (from live dry-run `ser_fbe25…`, 2026-06-17)
-
-The shapes the older send-side skill docs showed were **wrong**; these
-are verified against the running API:
-
-```jsonc
-// CREATE — payload on a cortex_propose
-{ "action": "create_ser",
-  "ser_spec": { "title": "...", "summary": "...",
-    "participants": [ {"practice_id": "<canonical-3form>", "role": "required"}, ... ],
-    "escalation_seconds": 14400 } }
-// → eco_review → human Accept → returns ser_id + ser_state_verified:true
-
-// TRANSITION — note: transition_spec wrapper, field is new_state (NOT to_state)
-{ "action": "transition_ser",
-  "transition_spec": { "ser_id": "ser_...", "new_state": "in_progress" } }  // open|in_progress|blocked|closed
-
-// ACK
-{ "action": "ser_ack", "ack_spec": { "ser_id": "ser_..." } }
-
-// READ — projection
-GET /v1/sers?ai_id=<canonical-3form>
-// → {ser_id, coordination_state, title, participants[role,last_ack_at,last_action_at],
-//    escalation_seconds, last_transition_at, source_ref}
-```
-
-Invariants enforced cortex-side: ≥2 distinct `practice_id`s, exactly one
-creator at `role=required`, `coordination_state` starts `open`.
-`ser_state_verified:true` means the post-commit graph re-query matched the
-expected projection.
-
-For the operational *send-side* mechanics (graduation discipline,
-cross-org scope derivation, AFK-ambassador), load `/cortex-mailbox-send`
-Flavor 3 — that skill owns the how; this section owns the *why it's gated*.
+When work spans ≥2 practices and outlives one session, the coordination lives in a shared, human-authorized record rather than any one practice's goals. The *why* is the same gating logic as the rest of this constitution: you can **propose** cross-practice coordination freely, but **binding other practitioners** to shared work is authorized at the human (ECO) boundary — the turtle principle (§III) applied to committing peers' attention. The mechanism for proposing, transitioning, and acking that shared record is part of the proprietary mesh layer (Empirica Cortex); when your install has it, the operational guidance loads from that layer. See getempirica.com.
 
 ---
 

--- a/empirica/plugins/claude-code-integration/skills/epistemic-transaction/SKILL.md
+++ b/empirica/plugins/claude-code-integration/skills/epistemic-transaction/SKILL.md
@@ -813,39 +813,9 @@ Full framing + examples: `/empirica-constitution` §V. Send-side mechanism:
 `/cortex-mailbox-send` (collab vs ECO-gated flavors, completion handshake,
 recovery on mis-routing).
 
-### Rule 5b: SER-Aware Transactions (sustained multi-practice work)
+### Rule 5b: Sustained multi-practice work
 
-When a transaction is part of work that spans ≥2 practices and outlives
-this session, the coordination lives in a **Shared Epistemic Record
-(SER)** — the cortex-resident shared-state object — not in any one
-practice's goals. Your local transaction discipline (PREFLIGHT → CHECK →
-POSTFLIGHT) is unchanged; what's added is keeping the SER in sync.
-
-| Trigger | Action | Why |
-|---------|--------|-----|
-| A collab thread you're in has run ≥3 rounds across the same practices, or work gains named participants that outlive the session | Graduate it: `cortex_propose` with `payload.action='create_ser'` + `ser_spec` | A standing coordination surface needs a home; N collab replies leave the shared state homeless |
-| You opened a transaction to do *your leg* of SER-coordinated work | Link it: reference the `ser_id` in your goal description; optionally carry `goal_refs:[{practice_id, goal_id}]` in the `ser_spec` | Makes your per-practice goal walkable from the shared record |
-| You start the work the SER tracks | Propose `transition_ser` → `in_progress` **before** the praxic phase | The SER state should lead reality, so peers see "in progress" not "still open" |
-| You're a `required` participant and a transition landed | Propose `ser_ack` (stamps `last_ack_at`) | Silences the escalation re-ping; it's the SER analog of the completion handshake — skipping it leaves you looking idle |
-| Your leg is done and the shared outcome is reached | Propose `transition_ser` → `closed` **before POSTFLIGHT**, then close your local goal | Close the shared record in the same window you close your goal — a closed goal under an `open` SER reads as abandoned coordination |
-
-**The gating caveat that changes your timing:** every SER mutation
-(`create_ser`, `transition_ser`, `ser_ack`) is **ECO-gated** — it lands
-`eco_review` and waits for a human Accept, *even at
-`action_category=REFLEX`*. So an SER transition is **not** a synchronous
-step you can assume completes inside your transaction. Propose it, then
-either (a) continue your local praxic work in parallel (the transition
-is bookkeeping, not a blocker), or (b) if a peer is genuinely blocked on
-the state change, POSTFLIGHT and pick up when the Accept lands via your
-listener. Do **not** busy-wait on a gated SER mutation mid-transaction.
-
-**Why gated:** creating or moving an SER commits *other practices'*
-workloads — the human authorizes that cross-practice mapping. You can
-propose coordination freely; binding peers to it is gated. Full rationale
-+ validated call shapes (`ser_spec`, `transition_spec.new_state`,
-`ack_spec`): `/empirica-constitution` §VI. Send-side mechanics
-(graduation discipline, cross-org scope, AFK-ambassador):
-`/cortex-mailbox-send` Flavor 3.
+When a transaction is one practice's leg of work spanning ≥2 practices and outliving this session, the shared coordination state lives in the proprietary mesh layer (Empirica Cortex), not in any one practice's goals. Your local transaction discipline (PREFLIGHT → CHECK → POSTFLIGHT) is unchanged; what's added is keeping the shared record in sync — and those shared-state mutations are human-authorized at the ECO boundary, so treat them as proposed-then-confirmed, never synchronous steps you busy-wait on. If your install has the mesh layer, the operational guidance loads from it. See getempirica.com.
 
 ### Rule 6: Mirror Empirica Tasks → Claude Code Tasks (Visibility)
 


### PR DESCRIPTION
## What

Boundary-cleanup SER, **strip phase** (cortex build-complete confirmed; David greenlit). Per the ratified **layer line** (open-substrate mechanics stay; proprietary-mesh mechanics → concept + getempirica.com pointer), this excises the proprietary **SER protocol** detail from the two **open-substrate** skills that carried it:

- **`empirica-constitution` §VI** — removes the SER lifecycle + the **copyable `create_ser`/`transition_ser`/`ser_ack` JSON call-shapes** → concept-level pointer. Keeps the *why-it's-gated* governance rationale (open-substrate).
- **`epistemic-transaction` Rule 5b** — removes the SER-operation table → concept-level pointer.

Both skills **stay in the base** (overwhelmingly open-substrate). The excised content moves to cortex's `mesh-usage-routine` doc (sent separately on the SER thread).

`git diff --stat`: 2 files, +5/−138. No SER payloads remain; no test reads these skill bodies; 45 affected loop/template/hook tests green.

## Scope note (important)

This is **half** the skill strip. The `cortex-mailbox-poll`/`-send` **removal** (the other half) is **deferred**: the open loop-scheduler infrastructure consumes `cortex-mailbox-poll`'s SKILL.md as the loop body (`test_loop_install_request_body_skill` asserts it exists), so removal needs a **loop/skill boundary decision** first — does the cortex-polling *loop* itself move proprietary, or does loop-infra source its body skill from the proprietary install? Flagged to the SER for David + cortex.

This PR is independently valid regardless of that decision — the copyable SER payloads don't belong in open-substrate skills either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)