### PR TITLE
feat(plugin): auto-sync installed CC plugin on version drift (deploy-staleness fix)

### DIFF
--- a/docs/human/developers/CLI_COMMANDS_UNIFIED.md
+++ b/docs/human/developers/CLI_COMMANDS_UNIFIED.md
@@ -23,8 +23,8 @@
 > dictionary, then running this script.
 
 **Framework version:** 1.12.4
-**Generated:** 2026-06-22 16:23:47 UTC
-**Total commands:** 245 (across 26 categories)
+**Generated:** 2026-06-22 22:41:07 UTC
+**Total commands:** 246 (across 26 categories)
 
 For the most up-to-date detail on any single command, prefer
 `empirica <command> --help` — the generator extracts the same `help`
@@ -87,7 +87,7 @@ require `--session-id` (`project-bootstrap`, `sessions-show`,
 | [memory](#memory) | 6 | `memory-prime`, `memory-scope`, `memory-value`, … |
 | [vision](#vision) | 1 | `vision` |
 | [domains](#domains) | 4 | `domain-list`, `domain-show`, `domain-resolve`, … |
-| [setup](#setup) | 7 | `onboard`, `setup-claude-code`, `enp-setup`, … |
+| [setup](#setup) | 8 | `onboard`, `setup-claude-code`, `plugin-sync`, … |
 
 ---
 
@@ -4287,6 +4287,19 @@ Configure Claude Code integration (hooks, CLAUDE.md, MCP server)
   Output format (default: human)
 - `--verbose` — optional · flag
   Show detailed output
+
+#### `empirica plugin-sync`
+
+Re-sync the installed Claude Code plugin if it has drifted behind the running empirica version
+
+**Arguments:**
+
+- `--force` — optional · flag
+  Sync even if the version stamp matches
+- `--quiet` — optional · flag
+  Suppress the human status line (still exits non-zero on error)
+- `--output` — optional · type=`choice` · choices={human, json} · default=`human`
+  Output format
 
 #### `empirica enp-setup`
 

--- a/empirica/cli/cli_core.py
+++ b/empirica/cli/cli_core.py
@@ -507,7 +507,7 @@ _HELP_CATEGORIES = {
     "memory": ["memory-prime", "memory-scope", "memory-value", "pattern-check", "session-rollup", "memory-report"],
     "vision": ["vision"],
     "domains": ["domain-list", "domain-show", "domain-resolve", "domain-validate"],
-    "setup": ["onboard", "setup-claude-code", "enp-setup", "diagnose", "doctor", "release", "serve"],
+    "setup": ["onboard", "setup-claude-code", "plugin-sync", "enp-setup", "diagnose", "doctor", "release", "serve"],
 }
 
 
@@ -855,6 +855,7 @@ def main(args=None):
             # Onboarding commands
             "onboard": handle_onboard_command,
             "setup-claude-code": handle_setup_claude_code_command,
+            "plugin-sync": handle_plugin_sync_command,
             "enp-setup": handle_enp_setup_command,
             "diagnose": handle_diagnose_command,
             "doctor": handle_doctor_command,

--- a/empirica/cli/command_handlers/__init__.py
+++ b/empirica/cli/command_handlers/__init__.py
@@ -233,7 +233,7 @@ from .session_commands import (
     handle_transaction_adopt_command,
 )
 from .session_create import handle_session_create_command
-from .setup_claude_code import handle_setup_claude_code_command
+from .setup_claude_code import handle_plugin_sync_command, handle_setup_claude_code_command
 from .skill_commands import (
     handle_skill_extract_command,
     handle_skill_fetch_command,
@@ -470,6 +470,7 @@ __all__ = [  # noqa: RUF022
     "handle_sessions_show_command",
     "handle_sessions_show_command",
     "handle_setup_claude_code_command",
+    "handle_plugin_sync_command",
     "handle_skill_extract_command",
     "handle_skill_fetch_command",
     "handle_skill_suggest_command",

--- a/empirica/cli/command_handlers/setup_claude_code.py
+++ b/empirica/cli/command_handlers/setup_claude_code.py
@@ -30,6 +30,9 @@ logger = logging.getLogger(__name__)
 
 PLUGIN_NAME = "empirica"
 PLUGIN_VERSION = "1.12.4"
+# Written into the installed plugin dir; the empirica version its files came
+# from. Drives drift-sync (empirica plugin-sync / session-init auto-heal).
+PLUGIN_VERSION_STAMP = ".plugin-version"
 
 
 def _resolve_empirica_version() -> str:
@@ -684,6 +687,95 @@ def _install_plugin_files(source_dir, plugin_dir, output_format):
 
     if output_format != "json":
         print(f"   ✓ Plugin installed to {plugin_dir}")
+
+
+def _installed_plugin_dir() -> Path:
+    """The installed plugin location Claude Code loads hooks from."""
+    return Path.home() / ".claude" / "plugins" / "local" / PLUGIN_NAME
+
+
+def _read_plugin_version_stamp(plugin_dir: Path) -> str | None:
+    try:
+        return (plugin_dir / PLUGIN_VERSION_STAMP).read_text().strip() or None
+    except OSError:
+        return None
+
+
+def _write_plugin_version_stamp(plugin_dir: Path, version: str | None = None) -> None:
+    """Stamp the installed plugin with the empirica version its files came from."""
+    try:
+        (plugin_dir / PLUGIN_VERSION_STAMP).write_text((version or _resolve_empirica_version()).strip() + "\n")
+    except OSError:
+        pass
+
+
+def _sync_plugin_files_in_place(source_dir: Path, plugin_dir: Path) -> None:
+    """Overwrite installed plugin files from source IN PLACE (no rmtree), so it
+    is safe to run from a hook executing inside plugin_dir. Refreshes + adds
+    files; does NOT prune files removed from source (the full clean rebuild is
+    `setup-claude-code --force`, which rmtrees first)."""
+
+    def _ignore(_directory, files):
+        return [f for f in files if f in ("__pycache__", ".git", ".pyc")]
+
+    shutil.copytree(source_dir, plugin_dir, ignore=_ignore, dirs_exist_ok=True)
+    hooks_dir = plugin_dir / "hooks"
+    if hooks_dir.exists():
+        for h in list(hooks_dir.glob("*.py")) + list(hooks_dir.glob("*.sh")):
+            try:
+                h.chmod(0o755)
+            except OSError:
+                pass
+
+
+def handle_plugin_sync_command(args):
+    """Re-sync the installed CC plugin from the bundled package source when the
+    installed copy has drifted behind the running empirica version.
+
+    Closes the deploy-staleness gap: hook fixes land in the package on upgrade
+    but the installed ~/.claude copy only refreshes on a manual
+    setup-claude-code. session-init shells out to this at SessionStart so a pip
+    upgrade's hook fixes reach running CC sessions automatically (this is what
+    prevents the recovery-verb 'Rushed assessment' deadlock from a stale gate).
+
+    Default: sync only when the stamped version != running version. --force
+    always syncs. Lightweight (in-place overwrite, no interactive setup).
+    """
+    output = getattr(args, "output", "human")
+    force = getattr(args, "force", False)
+    quiet = getattr(args, "quiet", False)
+    version = _resolve_empirica_version()
+    plugin_dir = _installed_plugin_dir()
+    installed = _read_plugin_version_stamp(plugin_dir)
+
+    def _emit(result, rc=0):
+        if output == "json":
+            print(json.dumps(result))
+        elif not quiet:
+            if result.get("synced"):
+                print(f"🔄 empirica plugin synced {result.get('from') or '(unstamped)'} → {result['to']}")
+            elif result.get("ok"):
+                print(f"✓ empirica plugin current ({version})")
+        return rc
+
+    # No install present — nothing to sync (not an error: e.g. non-CC env).
+    if not plugin_dir.exists():
+        return _emit({"ok": True, "synced": False, "reason": "not_installed", "version": version})
+
+    if installed == version and version != "unknown" and not force:
+        return _emit({"ok": True, "synced": False, "reason": "current", "version": version})
+
+    source_dir = _get_plugin_source_dir()
+    if source_dir is None:
+        if output == "json":
+            print(json.dumps({"ok": False, "synced": False, "reason": "source_not_found", "version": version}))
+        elif not quiet:
+            print("⚠ empirica plugin source not found — run `empirica setup-claude-code --force`", file=sys.stderr)
+        return 1
+
+    _sync_plugin_files_in_place(source_dir, plugin_dir)
+    _write_plugin_version_stamp(plugin_dir, version)
+    return _emit({"ok": True, "synced": True, "from": installed, "to": version})
 
 
 def _install_claude_md(plugin_dir, claude_dir, output_format):
@@ -1535,6 +1627,7 @@ def handle_setup_claude_code_command(args):
 
         # Stage 2: Install plugin files
         _install_plugin_files(source_dir, plugin_dir, output_format)
+        _write_plugin_version_stamp(plugin_dir)  # drives drift-sync / session-init auto-heal
 
         # Stage 3: Install CLAUDE.md
         if not skip_claude_md:

--- a/empirica/cli/parsers/onboarding_parsers.py
+++ b/empirica/cli/parsers/onboarding_parsers.py
@@ -13,6 +13,24 @@ def add_onboarding_parsers(subparsers):
         help="AI identifier (optional, derives from project basename or .empirica/project.yaml)",
     )
 
+    # Plugin sync - re-sync the installed CC plugin when it drifts behind the
+    # running empirica version (closes the deploy-staleness gap that strands
+    # hook fixes in the package until a manual setup-claude-code --force).
+    plugin_sync_parser = subparsers.add_parser(
+        "plugin-sync",
+        help="Re-sync the installed Claude Code plugin if it has drifted behind the running empirica version",
+        description="Lightweight in-place re-copy of the bundled plugin files into "
+        "~/.claude/plugins/local/empirica/ when the installed copy's version stamp "
+        "differs from the running empirica version. Run automatically by session-init "
+        "at SessionStart so a pip upgrade's hook fixes reach running CC sessions without "
+        "a full setup-claude-code. Use --force to sync unconditionally.",
+    )
+    plugin_sync_parser.add_argument("--force", action="store_true", help="Sync even if the version stamp matches")
+    plugin_sync_parser.add_argument(
+        "--quiet", action="store_true", help="Suppress the human status line (still exits non-zero on error)"
+    )
+    plugin_sync_parser.add_argument("--output", choices=["human", "json"], default="human", help="Output format")
+
     # Setup Claude Code command - configure Claude Code integration
     setup_cc_parser = subparsers.add_parser(
         "setup-claude-code",

--- a/empirica/plugins/claude-code-integration/hooks/session-init.py
+++ b/empirica/plugins/claude-code-integration/hooks/session-init.py
@@ -1405,12 +1405,39 @@ EOF
 """
 
 
+def _auto_sync_plugin():
+    """Best-effort: heal a stale installed CC plugin so hook fixes from a pip
+    upgrade reach this session. Shells out to `empirica plugin-sync` (a no-op
+    when the installed version stamp already matches the running empirica).
+
+    This is what prevents the deploy-staleness deadlock class: without it, a
+    hook fix that lands in the package on upgrade doesn't reach
+    ~/.claude/plugins/local/empirica/ until a manual setup-claude-code --force,
+    so running CC sessions keep loading the stale gate. Never blocks session
+    start — short timeout, all failures swallowed.
+    """
+    try:
+        subprocess.run(
+            ["empirica", "plugin-sync", "--quiet"],
+            capture_output=True,
+            stdin=subprocess.DEVNULL,  # never consume the hook's JSON stdin
+            timeout=8,
+            check=False,
+        )
+    except Exception:
+        pass
+
+
 def main():
     """Main session init logic.
 
     Orchestrates: input parsing, project resolution, existing session detection
     (resume/adoption), new session creation, budget/dashboard init, and output.
     """
+    # Auto-heal a stale installed plugin (deploy-staleness gap) before the
+    # session work — so this session's hooks reflect the running empirica.
+    _auto_sync_plugin()
+
     hook_input = {}
     try:
         hook_input = json.loads(sys.stdin.read())

--- a/tests/test_plugin_sync.py
+++ b/tests/test_plugin_sync.py
@@ -1,0 +1,131 @@
+"""Tests for `empirica plugin-sync` — the deploy-staleness auto-heal.
+
+Closes the defect class behind the recovery-verb 'Rushed assessment' deadlock:
+hook fixes land in the package on upgrade but the installed ~/.claude plugin
+copy only refreshes on a manual setup-claude-code. plugin-sync re-syncs the
+installed copy when its version stamp drifts behind the running empirica, and
+session-init shells out to it at SessionStart.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from empirica.cli.command_handlers import setup_claude_code as scc
+
+
+@pytest.fixture
+def fake_source(tmp_path):
+    """A bundled-plugin source dir with a hooks/ file."""
+    src = tmp_path / "src" / "claude-code-integration"
+    (src / "hooks").mkdir(parents=True)
+    (src / "hooks" / "sentinel-gate.py").write_text("# v2 gate (fixed)\n")
+    (src / "plugin.json").write_text("{}\n")
+    return src
+
+
+@pytest.fixture
+def fake_install(tmp_path):
+    """An installed plugin dir with a STALE hook + no version stamp."""
+    inst = tmp_path / "install" / "empirica"
+    (inst / "hooks").mkdir(parents=True)
+    (inst / "hooks" / "sentinel-gate.py").write_text("# v1 gate (stale)\n")
+    return inst
+
+
+def _wire(monkeypatch, install_dir, source_dir, version="1.12.4"):
+    monkeypatch.setattr(scc, "_resolve_empirica_version", lambda: version)
+    monkeypatch.setattr(scc, "_installed_plugin_dir", lambda: install_dir)
+    monkeypatch.setattr(scc, "_get_plugin_source_dir", lambda: source_dir)
+
+
+def _run(output="json", **over):
+    args = SimpleNamespace(output=output, force=False, quiet=False)
+    for k, v in over.items():
+        setattr(args, k, v)
+    return scc.handle_plugin_sync_command(args)
+
+
+# ── drift → sync ─────────────────────────────────────────────────────────
+
+
+def test_drift_unstamped_install_syncs(monkeypatch, capsys, fake_install, fake_source):
+    """An install with no version stamp is treated as drift → re-synced."""
+    _wire(monkeypatch, fake_install, fake_source)
+    rc = _run()
+    out = json.loads(capsys.readouterr().out)
+    assert rc == 0 and out["synced"] is True and out["to"] == "1.12.4"
+    # the stale hook was overwritten with the fixed source version
+    assert (fake_install / "hooks" / "sentinel-gate.py").read_text() == "# v2 gate (fixed)\n"
+    # stamp written
+    assert (fake_install / scc.PLUGIN_VERSION_STAMP).read_text().strip() == "1.12.4"
+
+
+def test_drift_stale_stamp_syncs(monkeypatch, capsys, fake_install, fake_source):
+    (fake_install / scc.PLUGIN_VERSION_STAMP).write_text("1.11.2\n")  # behind
+    _wire(monkeypatch, fake_install, fake_source)
+    out = json.loads((_run(), capsys.readouterr().out)[1])
+    assert out["synced"] is True and out["from"] == "1.11.2" and out["to"] == "1.12.4"
+    assert (fake_install / "hooks" / "sentinel-gate.py").read_text() == "# v2 gate (fixed)\n"
+
+
+# ── no drift → no-op ─────────────────────────────────────────────────────
+
+
+def test_matching_stamp_is_noop(monkeypatch, capsys, fake_install, fake_source):
+    (fake_install / scc.PLUGIN_VERSION_STAMP).write_text("1.12.4\n")
+    _wire(monkeypatch, fake_install, fake_source)
+    out = json.loads((_run(), capsys.readouterr().out)[1])
+    assert out["synced"] is False and out["reason"] == "current"
+    # stale-marker file untouched (no copy happened)
+    assert (fake_install / "hooks" / "sentinel-gate.py").read_text() == "# v1 gate (stale)\n"
+
+
+def test_force_syncs_even_when_current(monkeypatch, capsys, fake_install, fake_source):
+    (fake_install / scc.PLUGIN_VERSION_STAMP).write_text("1.12.4\n")
+    _wire(monkeypatch, fake_install, fake_source)
+    out = json.loads((_run(force=True), capsys.readouterr().out)[1])
+    assert out["synced"] is True
+    assert (fake_install / "hooks" / "sentinel-gate.py").read_text() == "# v2 gate (fixed)\n"
+
+
+# ── safety / edge cases ──────────────────────────────────────────────────
+
+
+def test_no_install_is_not_an_error(monkeypatch, capsys, tmp_path, fake_source):
+    missing = tmp_path / "nope" / "empirica"
+    _wire(monkeypatch, missing, fake_source)
+    rc = _run()
+    out = json.loads(capsys.readouterr().out)
+    assert rc == 0 and out["ok"] is True and out["synced"] is False and out["reason"] == "not_installed"
+
+
+def test_missing_source_errors_without_clobber(monkeypatch, capsys, fake_install):
+    _wire(monkeypatch, fake_install, None)  # source not found
+    rc = _run()
+    out = json.loads(capsys.readouterr().out)
+    assert rc == 1 and out["ok"] is False and out["reason"] == "source_not_found"
+    # install left intact
+    assert (fake_install / "hooks" / "sentinel-gate.py").read_text() == "# v1 gate (stale)\n"
+
+
+def test_unknown_version_does_not_falsely_match(monkeypatch, capsys, fake_install, fake_source):
+    """If the running version can't be resolved ('unknown'), don't treat a
+    coincidental 'unknown' stamp as current — sync to be safe."""
+    (fake_install / scc.PLUGIN_VERSION_STAMP).write_text("unknown\n")
+    _wire(monkeypatch, fake_install, fake_source, version="unknown")
+    out = json.loads((_run(), capsys.readouterr().out)[1])
+    assert out["synced"] is True
+
+
+def test_sync_is_in_place_no_rmtree(monkeypatch, fake_install, fake_source):
+    """The sync overwrites in place — a user file alongside the plugin is not
+    wiped (only setup-claude-code --force does a full rmtree rebuild)."""
+    (fake_install / "user-local-note.txt").write_text("keep me\n")
+    _wire(monkeypatch, fake_install, fake_source)
+    _run()
+    assert (fake_install / "user-local-note.txt").read_text() == "keep me\n"
+    assert (fake_install / "hooks" / "sentinel-gate.py").read_text() == "# v2 gate (fixed)\n"


### PR DESCRIPTION
## What

Closes the **defect class behind the recovery-verb "Rushed assessment" deadlock** that both mesh-support and ecodex hit. Hook fixes land in the empirica package on upgrade, but the installed `~/.claude/plugins/local/empirica/` copy that running CC sessions actually load only refreshes on a manual `setup-claude-code --force`. So a fix-on-develop never reaches the deployed gate, and a stale gate rush-blocks the very recovery verbs (`check-submit`/`postflight`/`finding-log`) that clear a transaction → deadlock.

## Fix — three small pieces
- **`empirica plugin-sync [--force] [--quiet]`** — compares the installed `.plugin-version` stamp to the running empirica version and, on drift, re-copies the bundled plugin files **in place** (`copytree(dirs_exist_ok=True)`, **no rmtree** — safe to run from a hook executing inside the plugin dir). Reuses setup-claude-code's source/version helpers.
- **`setup-claude-code`** now writes the `.plugin-version` stamp on install.
- **`session-init`** shells out to `plugin-sync --quiet` at SessionStart (DEVNULL stdin so it can't consume the hook's JSON, 8s timeout, failures swallowed) → a pip upgrade's hook fixes **auto-heal into running CC sessions, no manual reinstall**.

Bootstraps from one `setup-claude-code --force` (which installs the drift-aware `session-init`); thereafter it self-heals. `plugin-sync` is a lightweight **subset** of setup-claude-code (plugin files + stamp only — no settings.json/mcp/creds/listener); the full clean rebuild stays `setup-claude-code --force` (which rmtrees).

## Tests
8 new (`tests/test_plugin_sync.py`): drift (unstamped + stale-stamp) / no-drift no-op / `--force` / not-installed-is-ok / missing-source-no-clobber / unknown-version-doesn't-falsely-match / in-place-no-rmtree-preserves-user-files. **264 regression green** (CLI contracts + all-cli-commands), ruff clean, CLI docs regenerated.

## Context
Durable preventative for the deploy-staleness arc resolved earlier today (mesh-support + ecodex deadlocks → root-caused as stale installed gate). Supersedes the ancient "plugin version not syncing on pip upgrade" goal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)