### PR TITLE
feat(module): module.yaml manifest schema + validator + `empirica module validate`

### DIFF
--- a/docs/human/developers/CLI_COMMANDS_UNIFIED.md
+++ b/docs/human/developers/CLI_COMMANDS_UNIFIED.md
@@ -23,8 +23,8 @@
 > dictionary, then running this script.
 
 **Framework version:** 1.12.4
-**Generated:** 2026-06-22 16:23:47 UTC
-**Total commands:** 245 (across 26 categories)
+**Generated:** 2026-06-23 13:46:29 UTC
+**Total commands:** 246 (across 26 categories)
 
 For the most up-to-date detail on any single command, prefer
 `empirica <command> --help` — the generator extracts the same `help`
@@ -5009,6 +5009,24 @@ View conversation thread
 - `--channel` — optional
   Filter by channel (optional)
 - `--output` — optional · type=`choice` · choices={human, json} · default=`json`
+
+#### `empirica module`
+
+Practice-module manifest tooling (validate; fetch/provision land in later legs)
+
+**Subcommands:**
+
+##### `empirica module validate`
+
+Validate a module.yaml manifest (structural; fail-fast before install)
+
+**Arguments:**
+
+- `path` — **required**
+  Path to the module.yaml to validate
+- `--output` — optional · type=`choice` · choices={json, text} · default=`json`
+  Output format (default: json)
+
 
 #### `empirica performance`
 

--- a/empirica/cli/cli_core.py
+++ b/empirica/cli/cli_core.py
@@ -170,6 +170,7 @@ from .command_handlers.message_commands import (
     handle_message_send_command,
     handle_message_thread_command,
 )
+from .command_handlers.module_commands import handle_module_group_command
 from .command_handlers.persona_commands import (
     handle_persona_find_command,
     handle_persona_list_command,
@@ -218,6 +219,7 @@ from .parsers import (
     add_memory_parsers,
     add_mesh_parsers,
     add_message_parsers,
+    add_module_parsers,
     add_monitor_parsers,
     add_notify_parsers,
     add_onboarding_parsers,
@@ -309,6 +311,7 @@ def create_argument_parser():
     add_release_parsers(subparsers)
     add_lesson_parsers(subparsers)
     add_onboarding_parsers(subparsers)
+    add_module_parsers(subparsers)
     add_trajectory_parsers(subparsers)
     add_concept_graph_parsers(subparsers)
     add_mcp_parsers(subparsers)
@@ -661,6 +664,7 @@ def main(args=None):
             # Cockpit (proposal: PROPOSAL_SENTINEL_LOOP_TUI.md)
             "sentinel": handle_sentinel_group_command,
             "loop": handle_loop_group_command,
+            "module": handle_module_group_command,
             "listener": handle_listener_group_command,
             "mailbox": handle_mailbox_group_command,
             "instance": handle_instance_group_command,

--- a/empirica/cli/command_handlers/__init__.py
+++ b/empirica/cli/command_handlers/__init__.py
@@ -151,6 +151,7 @@ from .lesson_commands import (
     handle_lesson_stats_command,
 )
 from .mcp_commands import handle_mcp_list_tools_command
+from .module_commands import handle_module_group_command
 from .monitor_commands import (
     handle_assess_state_command,
     handle_calibration_dispute_command,
@@ -388,6 +389,7 @@ __all__ = [  # noqa: RUF022
     "handle_log_artifacts_command",
     # Loop / sentinel group dispatchers — re-exported for cli_core wildcard import
     "handle_loop_group_command",
+    "handle_module_group_command",
     "handle_mco_load_command",
     # MCP inspection (lifecycle owned by harness mcp.json — 5 commands retired 2026-06-03)
     "handle_mcp_list_tools_command",

--- a/empirica/cli/command_handlers/module_commands.py
+++ b/empirica/cli/command_handlers/module_commands.py
@@ -1,0 +1,50 @@
+"""Command handlers for the ``empirica module`` group (practice-module system).
+
+Currently surfaces ``validate``. The group dispatcher mirrors the ``loop``
+group pattern (``handle_loop_group_command``) so ``fetch`` / ``provision`` slot
+in as additional ``_MODULE_DISPATCH`` entries in later legs.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+
+def handle_module_validate_command(args) -> int:
+    """Validate a ``module.yaml`` and report. Exit 0 on valid, 1 on invalid."""
+    from empirica.core.modules.manifest import validate_manifest_file
+
+    receipt = validate_manifest_file(args.path)
+
+    if getattr(args, "output", "json") == "json":
+        sys.stdout.write(json.dumps(receipt) + "\n")
+    elif receipt["ok"]:
+        m = receipt["manifest"]
+        sys.stdout.write(
+            f"ok: {receipt['path']} — module '{m.get('name')}' v{m.get('version')} ({m.get('visibility')}) valid\n"
+        )
+    else:
+        sys.stdout.write(f"INVALID: {receipt['path']}\n")
+        for err in receipt["errors"]:
+            sys.stdout.write(f"  - {err}\n")
+
+    return 0 if receipt["ok"] else 1
+
+
+_MODULE_DISPATCH = {
+    "validate": handle_module_validate_command,
+}
+
+
+def handle_module_group_command(args) -> int:
+    """Dispatch ``empirica module <action>`` to the matching handler."""
+    action = getattr(args, "module_action", None)
+    if not action:
+        sys.stdout.write("usage: empirica module <validate> [args...]\n")
+        return 2
+    handler = _MODULE_DISPATCH.get(action)
+    if handler is None:
+        sys.stdout.write(f"error: unknown module action: {action}\n")
+        return 2
+    return handler(args) or 0

--- a/empirica/cli/parsers/__init__.py
+++ b/empirica/cli/parsers/__init__.py
@@ -64,6 +64,7 @@ from .mcp_parsers import add_mcp_parsers
 from .memory_parsers import add_memory_parsers
 from .mesh_parsers import add_mesh_parsers
 from .message_parsers import add_message_parsers
+from .module_parsers import add_module_parsers
 from .monitor_parsers import add_monitor_parsers
 from .notify_parsers import add_notify_parsers
 from .onboarding_parsers import add_onboarding_parsers
@@ -108,6 +109,7 @@ __all__ = [
     "add_memory_parsers",
     "add_mesh_parsers",
     "add_message_parsers",
+    "add_module_parsers",
     "add_monitor_parsers",
     "add_notify_parsers",
     "add_onboarding_parsers",

--- a/empirica/cli/parsers/module_parsers.py
+++ b/empirica/cli/parsers/module_parsers.py
@@ -1,0 +1,29 @@
+"""Parsers for the ``empirica module`` command group (practice-module system).
+
+``validate`` ships first (the piece that unblocks practices writing their
+``module.yaml``). ``fetch`` (auth-gated artifact pull) and ``provision``
+(plugin-layer install) land in later legs of the module-build SER.
+"""
+
+from __future__ import annotations
+
+
+def add_module_parsers(subparsers):
+    """Register the ``module`` command group."""
+    module_root = subparsers.add_parser(
+        "module",
+        help="Practice-module manifest tooling (validate; fetch/provision land in later legs)",
+    )
+    module_subs = module_root.add_subparsers(dest="module_action", metavar="action")
+
+    validate = module_subs.add_parser(
+        "validate",
+        help="Validate a module.yaml manifest (structural; fail-fast before install)",
+    )
+    validate.add_argument("path", help="Path to the module.yaml to validate")
+    validate.add_argument(
+        "--output",
+        choices=("json", "text"),
+        default="json",
+        help="Output format (default: json)",
+    )

--- a/empirica/core/modules/__init__.py
+++ b/empirica/core/modules/__init__.py
@@ -1,0 +1,27 @@
+"""Empirica practice-module system.
+
+A practice-module bundles everything a practice needs to install as a
+mesh-coordinated practitioner. Installation is two layers over one shared
+declaration (``module.yaml``):
+
+- **seat layer** → autonomy's ``install_seat.py`` (the CLAUDE.md managed-block)
+- **plugin layer** → ``empirica module provision`` (skills/agents/automations/topics/env)
+
+This package holds the manifest schema + validator. The MIT core reads the
+manifest declaratively — it never imports a module's code to understand what
+the manifest would install.
+"""
+
+from empirica.core.modules.manifest import (
+    ManifestError,
+    ModuleManifest,
+    load_manifest,
+    validate_manifest_file,
+)
+
+__all__ = [
+    "ManifestError",
+    "ModuleManifest",
+    "load_manifest",
+    "validate_manifest_file",
+]

--- a/empirica/core/modules/manifest.py
+++ b/empirica/core/modules/manifest.py
@@ -1,0 +1,209 @@
+"""``module.yaml`` — the practice-module manifest schema, loader, and validator.
+
+A practice-module declares its install bill-of-materials in a ``module.yaml``
+under a top-level ``empirica_module:`` key. The MIT core reads it *declaratively*
+(pydantic models, no import of any module's code) to understand what the
+manifest would install across the two install layers:
+
+- **seat layer** → autonomy's ``install_seat.py`` (CLAUDE.md managed-block).
+  ``seat.import`` / ``seat.mode`` / top-level ``seat_name`` map onto the
+  ``--seat-import`` / ``--mode`` / ``--seat-name`` flags.
+- **plugin layer** → ``empirica module provision`` (skills/agents/automations,
+  ntfy topics, env presence checks).
+
+Distribution artifacts (``artifacts``) are fetched by ``empirica module fetch``
+as a pre-step before either layer runs (install_seat itself never fetches).
+
+Validation is structural and fail-fast: a malformed manifest is rejected with a
+precise error *before* any install action runs. ``extra="forbid"`` turns a
+mis-spelled key into a loud error rather than a silently-ignored field, and the
+``secrets_ref`` validator enforces the reference-only discipline (a raw key is
+rejected at the schema layer, not just by the downstream secrets-manager).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Literal
+
+import yaml
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator, model_validator
+
+# A secrets reference is a manager pointer, never a raw key: ``doppler://...``,
+# ``op://...``, ``vault://...`` (scheme://...) or ``env:VARNAME``. Anything that
+# does not match is treated as a raw secret and rejected.
+_SECRETS_REF_RE = re.compile(r"^(?:[a-z][a-z0-9+.\-]*://.+|env:[A-Za-z_][A-Za-z0-9_]*)$")
+
+_ROOT_KEY = "empirica_module"
+
+
+class ManifestError(Exception):
+    """Raised when a ``module.yaml`` is missing, unreadable, or invalid."""
+
+
+class Seat(BaseModel):
+    """Seat layer declaration → ``install_seat.py`` flags."""
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    import_: str = Field(
+        alias="import",
+        description="@import body doc (relative to the seat root) → install_seat --seat-import",
+    )
+    mode: Literal["inject", "dedicated"] = "inject"
+
+
+class Artifacts(BaseModel):
+    """Distribution artifacts → ``empirica module fetch`` (auth-gated pre-step)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    plugin_archive: str | None = Field(
+        default=None, description="Plugin archive name fetched from the auth-gated registry"
+    )
+    python_packages: list[str] = Field(
+        default_factory=list, description="Closed-source wheels from an auth-gated index"
+    )
+
+
+class Automation(BaseModel):
+    """A declared automation wired via ``empirica loop register`` (canonical catalog).
+
+    ``kind=listener`` → a long-running systemd-user *service* (``autostart`` +
+    ``restart_policy`` apply). ``kind=interval`` / ``kind=cron`` → a systemd-user
+    *timer*.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    kind: Literal["listener", "interval", "cron"]
+    command: str | None = None
+    interval: str | None = None
+    cron: str | None = None
+    autostart: bool = False
+    restart_policy: Literal["no", "on-failure", "always"] = "no"
+
+    @model_validator(mode="after")
+    def _kind_requires_field(self) -> Automation:
+        if self.kind == "listener" and not self.command:
+            raise ValueError(f"automation {self.name!r}: kind=listener requires 'command'")
+        if self.kind == "interval" and not self.interval:
+            raise ValueError(f"automation {self.name!r}: kind=interval requires 'interval'")
+        if self.kind == "cron" and not self.cron:
+            raise ValueError(f"automation {self.name!r}: kind=cron requires 'cron'")
+        return self
+
+
+class Provides(BaseModel):
+    """Plugin-layer payload → ``empirica module provision``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    skills: list[str] = Field(default_factory=list)
+    agents: list[str] = Field(default_factory=list)
+    hooks: list[str] = Field(default_factory=list)
+    automations: list[Automation] = Field(default_factory=list)
+
+
+class RequiresRuntime(BaseModel):
+    """Runtime requirements — presence-validated at install, never raw-held.
+
+    ``env`` names are presence-checked only (the value is never read into the
+    provisioner). ``topics`` are registered via the cortex admin ntfy ACL.
+    ``secrets_ref`` is a single manager reference both install layers resolve.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    env: list[str] = Field(default_factory=list)
+    topics: list[str] = Field(default_factory=list)
+    secrets_ref: str | None = None
+
+    @field_validator("secrets_ref")
+    @classmethod
+    def _ref_only(cls, v: str | None) -> str | None:
+        if v is not None and not _SECRETS_REF_RE.match(v):
+            raise ValueError(
+                "secrets_ref must be a manager REFERENCE (e.g. doppler://, op://, "
+                "vault://, env:VARNAME), never a raw key"
+            )
+        return v
+
+
+class Requires(BaseModel):
+    """Compatibility constraints checked before install."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    empirica_core: str | None = None
+    cortex_api: str | None = None
+
+
+class ModuleManifest(BaseModel):
+    """The ``empirica_module:`` block of a ``module.yaml``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(description="Plugin/module id (drops into ~/.claude/plugins/local/<name>/)")
+    seat_name: str = Field(description="Canonical seat id → install_seat --seat-name")
+    version: str
+    visibility: Literal["public", "private", "enterprise"] = "private"
+    requires: Requires = Field(default_factory=Requires)
+    seat: Seat
+    artifacts: Artifacts = Field(default_factory=Artifacts)
+    provides: Provides = Field(default_factory=Provides)
+    requires_runtime: RequiresRuntime = Field(default_factory=RequiresRuntime)
+
+
+def _format_errors(exc: ValidationError) -> list[str]:
+    """Render pydantic errors as flat, human-readable ``path: message`` strings."""
+    out: list[str] = []
+    for err in exc.errors():
+        loc = ".".join(str(p) for p in err["loc"]) or "<root>"
+        out.append(f"{loc}: {err['msg']}")
+    return out
+
+
+def load_manifest(path: str | Path) -> ModuleManifest:
+    """Load + validate a ``module.yaml``. Raises ``ManifestError`` on any problem.
+
+    The file must contain a top-level ``empirica_module:`` mapping.
+    """
+    p = Path(path)
+    if not p.exists():
+        raise ManifestError(f"manifest not found: {p}")
+    try:
+        raw = yaml.safe_load(p.read_text())
+    except yaml.YAMLError as e:
+        raise ManifestError(f"invalid YAML in {p}: {e}") from e
+    if not isinstance(raw, dict) or _ROOT_KEY not in raw:
+        raise ManifestError(f"{p}: missing top-level '{_ROOT_KEY}:' key")
+    body = raw[_ROOT_KEY]
+    if not isinstance(body, dict):
+        raise ManifestError(f"{p}: '{_ROOT_KEY}' must be a mapping")
+    try:
+        return ModuleManifest.model_validate(body)
+    except ValidationError as e:
+        raise ManifestError("; ".join(_format_errors(e))) from e
+
+
+def validate_manifest_file(path: str | Path) -> dict:
+    """Validate a ``module.yaml`` and return a CLI-friendly receipt.
+
+    Returns ``{ok, path, errors, manifest}`` — ``manifest`` is the normalized
+    dict on success, ``errors`` the list of ``path: message`` strings on failure.
+    Never raises for a validation problem (the receipt carries it).
+    """
+    p = Path(path)
+    try:
+        manifest = load_manifest(p)
+    except ManifestError as e:
+        return {"ok": False, "path": str(p), "errors": [str(e)], "manifest": None}
+    return {
+        "ok": True,
+        "path": str(p),
+        "errors": [],
+        "manifest": manifest.model_dump(by_alias=True),
+    }

--- a/tests/test_module_manifest.py
+++ b/tests/test_module_manifest.py
@@ -1,0 +1,213 @@
+"""Tests for the practice-module manifest (``module.yaml``) schema + validator.
+
+Covers: full valid load, the top-level ``empirica_module:`` requirement,
+required-field + unknown-key (extra=forbid) rejection, the reference-only
+``secrets_ref`` discipline, automation kind↔field consistency, the
+``validate_manifest_file`` receipt shape, and the ``empirica module validate``
+CLI exit codes.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+import yaml
+
+from empirica.cli.command_handlers.module_commands import handle_module_validate_command
+from empirica.core.modules.manifest import (
+    ManifestError,
+    load_manifest,
+    validate_manifest_file,
+)
+
+
+def _valid_manifest() -> dict:
+    return {
+        "empirica_module": {
+            "name": "outreach",
+            "seat_name": "empirica-outreach",
+            "version": "0.4.0",
+            "visibility": "private",
+            "requires": {"empirica_core": ">=1.11.6", "cortex_api": ">=v1"},
+            "seat": {"import": "docs/OUTREACH_SEAT.md", "mode": "inject"},
+            "artifacts": {
+                "plugin_archive": "outreach-0.4.0-plugin.tar.gz",
+                "python_packages": ["empirica-outreach==0.4.0"],
+            },
+            "provides": {
+                "skills": ["devto", "voice-analyze", "brain-classifier"],
+                "agents": ["outreach-search", "outreach-scout"],
+                "automations": [
+                    {
+                        "name": "outreach-outbox-dispatcher",
+                        "kind": "listener",
+                        "command": "outreach dispatch-listen --instance empirica-outreach",
+                        "autostart": True,
+                        "restart_policy": "on-failure",
+                    }
+                ],
+            },
+            "requires_runtime": {
+                "env": ["DEVTO_API_KEY", "ZERNIO_API_KEY"],
+                "topics": ["empirica-outreach-dispatch"],
+                "secrets_ref": "doppler://empirica/outreach",
+            },
+        }
+    }
+
+
+def _write(tmp_path, data: dict):
+    p = tmp_path / "module.yaml"
+    p.write_text(yaml.safe_dump(data))
+    return p
+
+
+# ── happy path ──────────────────────────────────────────────────────────
+
+
+def test_valid_manifest_loads(tmp_path):
+    m = load_manifest(_write(tmp_path, _valid_manifest()))
+    assert m.name == "outreach"
+    assert m.seat_name == "empirica-outreach"
+    assert m.seat.import_ == "docs/OUTREACH_SEAT.md"  # alias 'import'
+    assert m.seat.mode == "inject"
+    assert m.provides.automations[0].kind == "listener"
+    assert m.requires_runtime.secrets_ref == "doppler://empirica/outreach"
+
+
+def test_round_trips_import_alias(tmp_path):
+    receipt = validate_manifest_file(_write(tmp_path, _valid_manifest()))
+    assert receipt["ok"] is True
+    # by_alias dump re-emits 'import', not 'import_'
+    assert receipt["manifest"]["seat"]["import"] == "docs/OUTREACH_SEAT.md"
+
+
+def test_minimal_manifest_defaults(tmp_path):
+    data = {
+        "empirica_module": {
+            "name": "x",
+            "seat_name": "empirica-x",
+            "version": "0.1.0",
+            "seat": {"import": "docs/X_SEAT.md"},
+        }
+    }
+    m = load_manifest(_write(tmp_path, data))
+    assert m.visibility == "private"  # default
+    assert m.seat.mode == "inject"  # default
+    assert m.provides.skills == [] and m.requires_runtime.env == []
+
+
+# ── structural rejection ────────────────────────────────────────────────
+
+
+def test_missing_root_key(tmp_path):
+    p = tmp_path / "module.yaml"
+    p.write_text(yaml.safe_dump({"name": "x"}))
+    with pytest.raises(ManifestError, match="empirica_module"):
+        load_manifest(p)
+
+
+def test_missing_required_field(tmp_path):
+    data = _valid_manifest()
+    del data["empirica_module"]["seat"]["import"]
+    receipt = validate_manifest_file(_write(tmp_path, data))
+    assert receipt["ok"] is False
+    assert any("seat.import" in e for e in receipt["errors"])
+
+
+def test_unknown_key_rejected(tmp_path):
+    data = _valid_manifest()
+    data["empirica_module"]["provides"]["skils"] = ["typo"]  # misspelled
+    receipt = validate_manifest_file(_write(tmp_path, data))
+    assert receipt["ok"] is False
+    assert any("skils" in e or "extra" in e.lower() for e in receipt["errors"])
+
+
+def test_missing_file(tmp_path):
+    receipt = validate_manifest_file(tmp_path / "nope.yaml")
+    assert receipt["ok"] is False
+    assert any("not found" in e for e in receipt["errors"])
+
+
+def test_invalid_yaml(tmp_path):
+    p = tmp_path / "module.yaml"
+    p.write_text("empirica_module: {name: x, : broken")
+    receipt = validate_manifest_file(p)
+    assert receipt["ok"] is False
+
+
+# ── reference-only secrets discipline ───────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "ref",
+    ["doppler://empirica/outreach", "op://vault/item", "vault://secret/data", "env:ZERNIO_API_KEY"],
+)
+def test_secrets_ref_accepts_references(tmp_path, ref):
+    data = _valid_manifest()
+    data["empirica_module"]["requires_runtime"]["secrets_ref"] = ref
+    assert validate_manifest_file(_write(tmp_path, data))["ok"] is True
+
+
+@pytest.mark.parametrize("raw", ["sk-abc123raw", "ZERNIO_KEY=topsecret", "just-a-string"])
+def test_secrets_ref_rejects_raw_keys(tmp_path, raw):
+    data = _valid_manifest()
+    data["empirica_module"]["requires_runtime"]["secrets_ref"] = raw
+    receipt = validate_manifest_file(_write(tmp_path, data))
+    assert receipt["ok"] is False
+    assert any("secrets_ref" in e for e in receipt["errors"])
+
+
+# ── automation kind↔field consistency ───────────────────────────────────
+
+
+def test_listener_requires_command(tmp_path):
+    data = _valid_manifest()
+    del data["empirica_module"]["provides"]["automations"][0]["command"]
+    receipt = validate_manifest_file(_write(tmp_path, data))
+    assert receipt["ok"] is False
+    assert any("command" in e for e in receipt["errors"])
+
+
+def test_interval_requires_interval(tmp_path):
+    data = _valid_manifest()
+    data["empirica_module"]["provides"]["automations"] = [
+        {"name": "poller", "kind": "interval"}  # missing interval
+    ]
+    receipt = validate_manifest_file(_write(tmp_path, data))
+    assert receipt["ok"] is False
+    assert any("interval" in e for e in receipt["errors"])
+
+
+def test_interval_automation_valid(tmp_path):
+    data = _valid_manifest()
+    data["empirica_module"]["provides"]["automations"] = [{"name": "poller", "kind": "interval", "interval": "5m"}]
+    assert validate_manifest_file(_write(tmp_path, data))["ok"] is True
+
+
+# ── CLI handler ─────────────────────────────────────────────────────────
+
+
+def test_cli_validate_exit_0_on_valid(tmp_path, capsys):
+    p = _write(tmp_path, _valid_manifest())
+    rc = handle_module_validate_command(SimpleNamespace(path=str(p), output="json"))
+    out = json.loads(capsys.readouterr().out)
+    assert rc == 0 and out["ok"] is True
+
+
+def test_cli_validate_exit_1_on_invalid(tmp_path, capsys):
+    data = _valid_manifest()
+    del data["empirica_module"]["version"]
+    p = _write(tmp_path, data)
+    rc = handle_module_validate_command(SimpleNamespace(path=str(p), output="json"))
+    out = json.loads(capsys.readouterr().out)
+    assert rc == 1 and out["ok"] is False
+
+
+def test_cli_validate_text_output(tmp_path, capsys):
+    p = _write(tmp_path, _valid_manifest())
+    rc = handle_module_validate_command(SimpleNamespace(path=str(p), output="text"))
+    text = capsys.readouterr().out
+    assert rc == 0 and "outreach" in text and "valid" in text


### PR DESCRIPTION
## What

First leg of the installable practice-module system: the **`module.yaml` manifest schema + validator** and the `empirica module validate` CLI verb.

A practice-module declares its install bill-of-materials in a `module.yaml` under a top-level `empirica_module:` key. The MIT core reads it **declaratively** — pydantic models, no import of any module's code — to understand what the manifest would install across the two install layers:

- **seat layer** → the CLAUDE.md managed-block (`seat.import` / `seat.mode` / `seat_name` map to seat-install flags)
- **plugin layer** → skills / agents / automations / ntfy topics / env (a later `module provision`)

Distribution `artifacts` are a fetch pre-step (a later `module fetch`); the seat installer itself never fetches.

## Why fail-fast validation

A malformed manifest is rejected with a precise `path: message` error **before** any install action runs:
- `extra="forbid"` turns a mis-spelled key into a loud error instead of a silently-ignored field
- the `secrets_ref` validator enforces **reference-only** (`doppler://`, `op://`, `vault://`, `env:VARNAME`) — a raw key is rejected at the schema layer, not just by the downstream secrets-manager
- automation `kind` ↔ field consistency (`listener`→`command`, `interval`→`interval`, `cron`→`cron`)

## Surface

- `empirica/core/modules/manifest.py` — `ModuleManifest` schema + `load_manifest` + `validate_manifest_file`
- `empirica module validate <path>` — `--output json|text`, exit 1 on invalid
- `empirica/core/modules/__init__.py`, `module_parsers.py`, `module_commands.py` + cli_core/parsers/handlers wiring

## Tests

- 21 new tests (`tests/test_module_manifest.py`) — happy path, missing root key, required-field + unknown-key rejection, reference-only secrets, automation consistency, CLI exit codes
- ruff clean; CLI-contract parity green (266 passed)

`fetch` (auth-gated artifact pull) and `provision` (plugin-layer install) follow in subsequent PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)