### PR TITLE
feat(module): `module fetch` + `module provision` — the two install-layer executors (legs 2–3)

### DIFF
--- a/docs/human/developers/CLI_COMMANDS_UNIFIED.md
+++ b/docs/human/developers/CLI_COMMANDS_UNIFIED.md
@@ -23,7 +23,7 @@
 > dictionary, then running this script.
 
 **Framework version:** 1.12.4
-**Generated:** 2026-06-23 13:46:29 UTC
+**Generated:** 2026-06-23 14:45:52 UTC
 **Total commands:** 246 (across 26 categories)
 
 For the most up-to-date detail on any single command, prefer
@@ -5024,6 +5024,50 @@ Validate a module.yaml manifest (structural; fail-fast before install)
 
 - `path` — **required**
   Path to the module.yaml to validate
+- `--output` — optional · type=`choice` · choices={json, text} · default=`json`
+  Output format (default: json)
+
+
+##### `empirica module fetch`
+
+Stage a module's distribution artifacts (auth-gated pre-step before seat + provision)
+
+**Arguments:**
+
+- `path` — **required**
+  Path to the module.yaml
+- `--dry-run` — optional · flag
+  Compute the fetch plan; write nothing
+- `--registry` — optional
+  Plugin-archive registry base URL (default: $EMPIRICA_MODULE_REGISTRY)
+- `--index-url` — optional
+  pip index URL for python_packages (default: $EMPIRICA_MODULE_INDEX_URL)
+- `--staging-root` — optional
+  Override the staging root (default: ~/.empirica/module_staging)
+- `--output` — optional · type=`choice` · choices={json, text} · default=`json`
+  Output format (default: json)
+
+
+##### `empirica module provision`
+
+Plugin layer: place files, register automations, grant ntfy topics, check env
+
+**Arguments:**
+
+- `path` — **required**
+  Path to the module.yaml
+- `--dry-run` — optional · flag
+  Compute the provision plan; perform nothing
+- `--plugin-root` — optional
+  Override plugin root (default: ~/.claude/plugins/local)
+- `--staging-root` — optional
+  Staging root holding fetched artifacts
+- `--cortex-url` — optional
+  Cortex base URL for ntfy ACL grants (default: credentials.yaml)
+- `--org` — optional
+  Org slug for ntfy grant users (e.g. empirica); topics skip without it
+- `--tenant` — optional
+  Tenant slug for the subscriber grant user
 - `--output` — optional · type=`choice` · choices={json, text} · default=`json`
   Output format (default: json)
 

--- a/docs/human/developers/CLI_COMMANDS_UNIFIED.md
+++ b/docs/human/developers/CLI_COMMANDS_UNIFIED.md
@@ -23,8 +23,8 @@
 > dictionary, then running this script.
 
 **Framework version:** 1.12.4
-**Generated:** 2026-06-22 16:23:47 UTC
-**Total commands:** 245 (across 26 categories)
+**Generated:** 2026-06-23 13:46:29 UTC
+**Total commands:** 246 (across 26 categories)
 
 For the most up-to-date detail on any single command, prefer
 `empirica <command> --help` — the generator extracts the same `help`
@@ -5009,6 +5009,24 @@ View conversation thread
 - `--channel` — optional
   Filter by channel (optional)
 - `--output` — optional · type=`choice` · choices={human, json} · default=`json`
+
+#### `empirica module`
+
+Practice-module manifest tooling (validate; fetch/provision land in later legs)
+
+**Subcommands:**
+
+##### `empirica module validate`
+
+Validate a module.yaml manifest (structural; fail-fast before install)
+
+**Arguments:**
+
+- `path` — **required**
+  Path to the module.yaml to validate
+- `--output` — optional · type=`choice` · choices={json, text} · default=`json`
+  Output format (default: json)
+
 
 #### `empirica performance`
 

--- a/empirica/cli/cli_core.py
+++ b/empirica/cli/cli_core.py
@@ -170,6 +170,7 @@ from .command_handlers.message_commands import (
     handle_message_send_command,
     handle_message_thread_command,
 )
+from .command_handlers.module_commands import handle_module_group_command
 from .command_handlers.persona_commands import (
     handle_persona_find_command,
     handle_persona_list_command,
@@ -218,6 +219,7 @@ from .parsers import (
     add_memory_parsers,
     add_mesh_parsers,
     add_message_parsers,
+    add_module_parsers,
     add_monitor_parsers,
     add_notify_parsers,
     add_onboarding_parsers,
@@ -309,6 +311,7 @@ def create_argument_parser():
     add_release_parsers(subparsers)
     add_lesson_parsers(subparsers)
     add_onboarding_parsers(subparsers)
+    add_module_parsers(subparsers)
     add_trajectory_parsers(subparsers)
     add_concept_graph_parsers(subparsers)
     add_mcp_parsers(subparsers)
@@ -661,6 +664,7 @@ def main(args=None):
             # Cockpit (proposal: PROPOSAL_SENTINEL_LOOP_TUI.md)
             "sentinel": handle_sentinel_group_command,
             "loop": handle_loop_group_command,
+            "module": handle_module_group_command,
             "listener": handle_listener_group_command,
             "mailbox": handle_mailbox_group_command,
             "instance": handle_instance_group_command,

--- a/empirica/cli/command_handlers/__init__.py
+++ b/empirica/cli/command_handlers/__init__.py
@@ -151,6 +151,7 @@ from .lesson_commands import (
     handle_lesson_stats_command,
 )
 from .mcp_commands import handle_mcp_list_tools_command
+from .module_commands import handle_module_group_command
 from .monitor_commands import (
     handle_assess_state_command,
     handle_calibration_dispute_command,
@@ -388,6 +389,7 @@ __all__ = [  # noqa: RUF022
     "handle_log_artifacts_command",
     # Loop / sentinel group dispatchers — re-exported for cli_core wildcard import
     "handle_loop_group_command",
+    "handle_module_group_command",
     "handle_mco_load_command",
     # MCP inspection (lifecycle owned by harness mcp.json — 5 commands retired 2026-06-03)
     "handle_mcp_list_tools_command",

--- a/empirica/cli/command_handlers/module_commands.py
+++ b/empirica/cli/command_handlers/module_commands.py
@@ -67,9 +67,47 @@ def handle_module_fetch_command(args) -> int:
     return 0 if receipt["ok"] else 1
 
 
+def handle_module_provision_command(args) -> int:
+    """Run the plugin layer for a module. Exit 0 on success, 1 on any error."""
+    from pathlib import Path
+
+    from empirica.core.modules.executors import provision_module
+    from empirica.core.modules.manifest import load_manifest
+
+    try:
+        manifest = load_manifest(args.path)
+    except Exception as e:
+        receipt = {"ok": False, "action": "provision", "errors": [str(e)]}
+        sys.stdout.write(json.dumps(receipt) + "\n")
+        return 1
+
+    receipt = provision_module(
+        manifest,
+        dry_run=getattr(args, "dry_run", False),
+        staging_root=Path(args.staging_root) if getattr(args, "staging_root", None) else None,
+        plugin_root=Path(args.plugin_root) if getattr(args, "plugin_root", None) else None,
+        cortex_url=getattr(args, "cortex_url", None),
+        org=getattr(args, "org", None),
+        tenant=getattr(args, "tenant", None),
+    )
+
+    if getattr(args, "output", "json") == "json":
+        sys.stdout.write(json.dumps(receipt) + "\n")
+    else:
+        head = "provision (dry-run)" if receipt["dry_run"] else "provision"
+        sys.stdout.write(f"{head}: {receipt['module']}\n")
+        for step in receipt["steps"]:
+            sys.stdout.write(f"  [{step['status']}] {step['kind']}: {step['target']} ({step['detail']})\n")
+        for err in receipt["errors"]:
+            sys.stdout.write(f"  ERROR: {err}\n")
+
+    return 0 if receipt["ok"] else 1
+
+
 _MODULE_DISPATCH = {
     "validate": handle_module_validate_command,
     "fetch": handle_module_fetch_command,
+    "provision": handle_module_provision_command,
 }
 
 

--- a/empirica/cli/command_handlers/module_commands.py
+++ b/empirica/cli/command_handlers/module_commands.py
@@ -1,0 +1,50 @@
+"""Command handlers for the ``empirica module`` group (practice-module system).
+
+Currently surfaces ``validate``. The group dispatcher mirrors the ``loop``
+group pattern (``handle_loop_group_command``) so ``fetch`` / ``provision`` slot
+in as additional ``_MODULE_DISPATCH`` entries in later legs.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+
+def handle_module_validate_command(args) -> int:
+    """Validate a ``module.yaml`` and report. Exit 0 on valid, 1 on invalid."""
+    from empirica.core.modules.manifest import validate_manifest_file
+
+    receipt = validate_manifest_file(args.path)
+
+    if getattr(args, "output", "json") == "json":
+        sys.stdout.write(json.dumps(receipt) + "\n")
+    elif receipt["ok"]:
+        m = receipt["manifest"]
+        sys.stdout.write(
+            f"ok: {receipt['path']} — module '{m.get('name')}' v{m.get('version')} ({m.get('visibility')}) valid\n"
+        )
+    else:
+        sys.stdout.write(f"INVALID: {receipt['path']}\n")
+        for err in receipt["errors"]:
+            sys.stdout.write(f"  - {err}\n")
+
+    return 0 if receipt["ok"] else 1
+
+
+_MODULE_DISPATCH = {
+    "validate": handle_module_validate_command,
+}
+
+
+def handle_module_group_command(args) -> int:
+    """Dispatch ``empirica module <action>`` to the matching handler."""
+    action = getattr(args, "module_action", None)
+    if not action:
+        sys.stdout.write("usage: empirica module <validate> [args...]\n")
+        return 2
+    handler = _MODULE_DISPATCH.get(action)
+    if handler is None:
+        sys.stdout.write(f"error: unknown module action: {action}\n")
+        return 2
+    return handler(args) or 0

--- a/empirica/cli/command_handlers/module_commands.py
+++ b/empirica/cli/command_handlers/module_commands.py
@@ -32,8 +32,44 @@ def handle_module_validate_command(args) -> int:
     return 0 if receipt["ok"] else 1
 
 
+def handle_module_fetch_command(args) -> int:
+    """Stage a module's distribution artifacts. Exit 0 on success, 1 on any error."""
+    from pathlib import Path
+
+    from empirica.core.modules.executors import fetch_module
+    from empirica.core.modules.manifest import load_manifest
+
+    try:
+        manifest = load_manifest(args.path)
+    except Exception as e:  # ManifestError — invalid manifest can't be fetched
+        receipt = {"ok": False, "action": "fetch", "errors": [str(e)]}
+        sys.stdout.write(json.dumps(receipt) + "\n")
+        return 1
+
+    receipt = fetch_module(
+        manifest,
+        dry_run=getattr(args, "dry_run", False),
+        staging_root=Path(args.staging_root) if getattr(args, "staging_root", None) else None,
+        registry_base=getattr(args, "registry", None),
+        index_url=getattr(args, "index_url", None),
+    )
+
+    if getattr(args, "output", "json") == "json":
+        sys.stdout.write(json.dumps(receipt) + "\n")
+    else:
+        head = "fetch (dry-run)" if receipt["dry_run"] else "fetch"
+        sys.stdout.write(f"{head}: {receipt['module']} → {receipt['staged_path']}\n")
+        for step in receipt["steps"]:
+            sys.stdout.write(f"  [{step['status']}] {step['kind']}: {step['target']} ({step['detail']})\n")
+        for err in receipt["errors"]:
+            sys.stdout.write(f"  ERROR: {err}\n")
+
+    return 0 if receipt["ok"] else 1
+
+
 _MODULE_DISPATCH = {
     "validate": handle_module_validate_command,
+    "fetch": handle_module_fetch_command,
 }
 
 

--- a/empirica/cli/parsers/__init__.py
+++ b/empirica/cli/parsers/__init__.py
@@ -64,6 +64,7 @@ from .mcp_parsers import add_mcp_parsers
 from .memory_parsers import add_memory_parsers
 from .mesh_parsers import add_mesh_parsers
 from .message_parsers import add_message_parsers
+from .module_parsers import add_module_parsers
 from .monitor_parsers import add_monitor_parsers
 from .notify_parsers import add_notify_parsers
 from .onboarding_parsers import add_onboarding_parsers
@@ -108,6 +109,7 @@ __all__ = [
     "add_memory_parsers",
     "add_mesh_parsers",
     "add_message_parsers",
+    "add_module_parsers",
     "add_monitor_parsers",
     "add_notify_parsers",
     "add_onboarding_parsers",

--- a/empirica/cli/parsers/module_parsers.py
+++ b/empirica/cli/parsers/module_parsers.py
@@ -38,3 +38,16 @@ def add_module_parsers(subparsers):
     fetch.add_argument("--index-url", help="pip index URL for python_packages (default: $EMPIRICA_MODULE_INDEX_URL)")
     fetch.add_argument("--staging-root", help="Override the staging root (default: ~/.empirica/module_staging)")
     fetch.add_argument("--output", choices=("json", "text"), default="json", help="Output format (default: json)")
+
+    provision = module_subs.add_parser(
+        "provision",
+        help="Plugin layer: place files, register automations, grant ntfy topics, check env",
+    )
+    provision.add_argument("path", help="Path to the module.yaml")
+    provision.add_argument("--dry-run", action="store_true", help="Compute the provision plan; perform nothing")
+    provision.add_argument("--plugin-root", help="Override plugin root (default: ~/.claude/plugins/local)")
+    provision.add_argument("--staging-root", help="Staging root holding fetched artifacts")
+    provision.add_argument("--cortex-url", help="Cortex base URL for ntfy ACL grants (default: credentials.yaml)")
+    provision.add_argument("--org", help="Org slug for ntfy grant users (e.g. empirica); topics skip without it")
+    provision.add_argument("--tenant", help="Tenant slug for the subscriber grant user")
+    provision.add_argument("--output", choices=("json", "text"), default="json", help="Output format (default: json)")

--- a/empirica/cli/parsers/module_parsers.py
+++ b/empirica/cli/parsers/module_parsers.py
@@ -1,0 +1,29 @@
+"""Parsers for the ``empirica module`` command group (practice-module system).
+
+``validate`` ships first (the piece that unblocks practices writing their
+``module.yaml``). ``fetch`` (auth-gated artifact pull) and ``provision``
+(plugin-layer install) land in later legs of the module-build SER.
+"""
+
+from __future__ import annotations
+
+
+def add_module_parsers(subparsers):
+    """Register the ``module`` command group."""
+    module_root = subparsers.add_parser(
+        "module",
+        help="Practice-module manifest tooling (validate; fetch/provision land in later legs)",
+    )
+    module_subs = module_root.add_subparsers(dest="module_action", metavar="action")
+
+    validate = module_subs.add_parser(
+        "validate",
+        help="Validate a module.yaml manifest (structural; fail-fast before install)",
+    )
+    validate.add_argument("path", help="Path to the module.yaml to validate")
+    validate.add_argument(
+        "--output",
+        choices=("json", "text"),
+        default="json",
+        help="Output format (default: json)",
+    )

--- a/empirica/cli/parsers/module_parsers.py
+++ b/empirica/cli/parsers/module_parsers.py
@@ -27,3 +27,14 @@ def add_module_parsers(subparsers):
         default="json",
         help="Output format (default: json)",
     )
+
+    fetch = module_subs.add_parser(
+        "fetch",
+        help="Stage a module's distribution artifacts (auth-gated pre-step before seat + provision)",
+    )
+    fetch.add_argument("path", help="Path to the module.yaml")
+    fetch.add_argument("--dry-run", action="store_true", help="Compute the fetch plan; write nothing")
+    fetch.add_argument("--registry", help="Plugin-archive registry base URL (default: $EMPIRICA_MODULE_REGISTRY)")
+    fetch.add_argument("--index-url", help="pip index URL for python_packages (default: $EMPIRICA_MODULE_INDEX_URL)")
+    fetch.add_argument("--staging-root", help="Override the staging root (default: ~/.empirica/module_staging)")
+    fetch.add_argument("--output", choices=("json", "text"), default="json", help="Output format (default: json)")

--- a/empirica/core/modules/__init__.py
+++ b/empirica/core/modules/__init__.py
@@ -1,0 +1,27 @@
+"""Empirica practice-module system.
+
+A practice-module bundles everything a practice needs to install as a
+mesh-coordinated practitioner. Installation is two layers over one shared
+declaration (``module.yaml``):
+
+- **seat layer** → autonomy's ``install_seat.py`` (the CLAUDE.md managed-block)
+- **plugin layer** → ``empirica module provision`` (skills/agents/automations/topics/env)
+
+This package holds the manifest schema + validator. The MIT core reads the
+manifest declaratively — it never imports a module's code to understand what
+the manifest would install.
+"""
+
+from empirica.core.modules.manifest import (
+    ManifestError,
+    ModuleManifest,
+    load_manifest,
+    validate_manifest_file,
+)
+
+__all__ = [
+    "ManifestError",
+    "ModuleManifest",
+    "load_manifest",
+    "validate_manifest_file",
+]

--- a/empirica/core/modules/__init__.py
+++ b/empirica/core/modules/__init__.py
@@ -12,7 +12,7 @@ manifest declaratively — it never imports a module's code to understand what
 the manifest would install.
 """
 
-from empirica.core.modules.executors import fetch_module
+from empirica.core.modules.executors import fetch_module, provision_module
 from empirica.core.modules.manifest import (
     ManifestError,
     ModuleManifest,
@@ -25,5 +25,6 @@ __all__ = [
     "ModuleManifest",
     "fetch_module",
     "load_manifest",
+    "provision_module",
     "validate_manifest_file",
 ]

--- a/empirica/core/modules/__init__.py
+++ b/empirica/core/modules/__init__.py
@@ -12,6 +12,7 @@ manifest declaratively — it never imports a module's code to understand what
 the manifest would install.
 """
 
+from empirica.core.modules.executors import fetch_module
 from empirica.core.modules.manifest import (
     ManifestError,
     ModuleManifest,
@@ -22,6 +23,7 @@ from empirica.core.modules.manifest import (
 __all__ = [
     "ManifestError",
     "ModuleManifest",
+    "fetch_module",
     "load_manifest",
     "validate_manifest_file",
 ]

--- a/empirica/core/modules/executors.py
+++ b/empirica/core/modules/executors.py
@@ -23,10 +23,13 @@ crashing.
 
 from __future__ import annotations
 
+import contextlib
+import json
 import os
 import shutil
 import subprocess
 import sys
+import tarfile
 import urllib.error
 import urllib.request
 from importlib import metadata
@@ -35,8 +38,13 @@ from pathlib import Path
 from empirica.core.modules.manifest import ModuleManifest
 
 STAGING_ROOT = Path.home() / ".empirica" / "module_staging"
+CLAUDE_PLUGIN_ROOT = Path.home() / ".claude" / "plugins" / "local"
 REGISTRY_ENV = "EMPIRICA_MODULE_REGISTRY"  # base URL for plugin-archive fetch
 INDEX_ENV = "EMPIRICA_MODULE_INDEX_URL"  # auth-gated pip index for python_packages
+
+# manifest automation.kind → empirica loop-registry kind (the registry has no
+# "listener" kind; a persistent stream-watcher IS a monitor-kind loop).
+_AUTOMATION_KIND_MAP = {"listener": "monitor", "interval": "interval", "cron": "cron"}
 
 
 def _resolve_secret_ref(ref: str | None) -> tuple[str | None, str]:
@@ -203,6 +211,166 @@ def fetch_module(
         "module": manifest.name,
         "dry_run": dry_run,
         "staged_path": str(staged),
+        "steps": steps,
+        "errors": errors,
+    }
+
+
+# ── provision (leg 3): the plugin layer ─────────────────────────────────────
+
+
+def _place_plugin_artifact(
+    manifest: ModuleManifest, staging_root: Path | None, plugin_root: Path | None, dry_run: bool
+) -> dict:
+    """Place the staged plugin archive into ~/.claude/plugins/local/<name>/."""
+    archive = manifest.artifacts.plugin_archive
+    dest = (plugin_root or CLAUDE_PLUGIN_ROOT) / manifest.name
+    if not archive:
+        return {
+            "kind": "plugin_files",
+            "target": manifest.name,
+            "status": "no_artifact",
+            "detail": "no plugin_archive declared",
+        }
+    if dest.exists() and any(dest.iterdir()):
+        return {"kind": "plugin_files", "target": str(dest), "status": "skipped", "detail": "already populated"}
+    staged = (staging_root or STAGING_ROOT) / manifest.name / Path(archive).name
+    if not staged.exists():
+        return {"kind": "plugin_files", "target": archive, "status": "not_staged", "detail": "run `module fetch` first"}
+    if dry_run:
+        return {
+            "kind": "plugin_files",
+            "target": str(dest),
+            "status": "would_place",
+            "detail": f"extract {staged.name}",
+        }
+    try:
+        dest.mkdir(parents=True, exist_ok=True)
+        if tarfile.is_tarfile(staged):
+            with tarfile.open(staged) as tf:
+                tf.extractall(dest, filter="data")  # filter=data → safe extraction (py3.11.4+)
+        else:
+            shutil.copy2(staged, dest / staged.name)
+        return {"kind": "plugin_files", "target": str(dest), "status": "placed", "detail": staged.name}
+    except (OSError, tarfile.TarError) as e:
+        return {"kind": "plugin_files", "target": archive, "status": "error", "detail": str(e)[:300]}
+
+
+def _register_automation(auto, dry_run: bool) -> dict:
+    """Register one automation via the canonical ``empirica loop register`` (idempotent)."""
+    kind = _AUTOMATION_KIND_MAP.get(auto.kind, auto.kind)
+    cmd = ["empirica", "loop", "register", "--name", auto.name, "--kind", kind]
+    if auto.kind == "interval" and auto.interval:
+        cmd += ["--interval", auto.interval]
+    elif auto.kind == "cron" and auto.cron:
+        cmd += ["--cron", auto.cron]
+    # loop register has no --command: it tracks the schedulable entry. A listener's
+    # command-as-service supervision (systemd autostart/restart) is the front-door's
+    # `empirica loop enable` step, not register's job.
+    note = " (command-supervision via `loop enable`)" if auto.kind == "listener" else ""
+    if dry_run:
+        return {"kind": "automation", "target": auto.name, "status": "would_register", "detail": " ".join(cmd) + note}
+    try:
+        subprocess.run(cmd, capture_output=True, text=True, timeout=60, check=True)
+        return {"kind": "automation", "target": auto.name, "status": "registered", "detail": f"kind={kind}{note}"}
+    except subprocess.CalledProcessError as e:
+        return {
+            "kind": "automation",
+            "target": auto.name,
+            "status": "error",
+            "detail": (e.stderr or e.stdout or "register failed").strip()[:300],
+        }
+    except (subprocess.SubprocessError, OSError) as e:
+        return {"kind": "automation", "target": auto.name, "status": "error", "detail": str(e)[:300]}
+
+
+def _post_grants(cortex_url: str, api_key: str, grants: list[dict]) -> tuple[bool, str]:
+    """POST ntfy ACL grants to cortex admin (the contract cortex shipped)."""
+    url = cortex_url.rstrip("/") + "/v1/admin/ntfy/grants"
+    body = json.dumps({"grants": grants}).encode()
+    req = urllib.request.Request(url, data=body, method="POST")
+    req.add_header("Authorization", f"Bearer {api_key}")
+    req.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return (resp.status in (200, 207), f"http {resp.status}")
+    except urllib.error.HTTPError as e:
+        return False, f"http {e.code}"
+    except (urllib.error.URLError, OSError) as e:
+        return False, str(e)[:300]
+
+
+def _grant_topics(manifest, cortex_url, cortex_api_key, org, tenant, dry_run) -> list[dict]:
+    """Register + grant each declared ntfy topic via the cortex admin ACL endpoint."""
+    topics = manifest.requires_runtime.topics
+    if not topics:
+        return []
+    if not (cortex_url and cortex_api_key and org):
+        return [
+            {"kind": "topic", "target": t, "status": "unconfigured", "detail": "needs cortex url/api_key + --org"}
+            for t in topics
+        ]
+    publisher = f"{org}-cortex-publisher"
+    subscriber = f"{org}-u-{tenant}" if tenant else f"{org}-{manifest.name}-subscriber"
+    out = []
+    for t in topics:
+        grants = [
+            {"user": publisher, "topic": t, "permission": "rw"},
+            {"user": subscriber, "topic": t, "permission": "read-only"},
+        ]
+        if dry_run:
+            out.append({"kind": "topic", "target": t, "status": "would_grant", "detail": json.dumps(grants)})
+            continue
+        ok, detail = _post_grants(cortex_url, cortex_api_key, grants)
+        out.append({"kind": "topic", "target": t, "status": "granted" if ok else "error", "detail": detail})
+    return out
+
+
+def _check_env(manifest) -> list[dict]:
+    """Presence-check each required env var. The value is never read (reference-only)."""
+    return [
+        {"kind": "env", "target": var, "status": "present" if var in os.environ else "missing", "detail": ""}
+        for var in manifest.requires_runtime.env
+    ]
+
+
+def provision_module(
+    manifest: ModuleManifest,
+    *,
+    dry_run: bool = False,
+    staging_root: Path | None = None,
+    plugin_root: Path | None = None,
+    cortex_url: str | None = None,
+    cortex_api_key: str | None = None,
+    org: str | None = None,
+    tenant: str | None = None,
+) -> dict:
+    """Run the plugin layer: place files, register automations, grant topics, check env.
+
+    Returns a receipt ``{ok, action, module, dry_run, steps, errors}``. A missing
+    env var is reported (``missing``) but is NOT an error — the value resolves at
+    runtime on the dispatching host, which may differ from the provisioning host.
+    """
+    if cortex_url is None or cortex_api_key is None:
+        # credentials absent/unreadable → topics simply report unconfigured
+        with contextlib.suppress(Exception):
+            from empirica.config.credentials_loader import CredentialsLoader
+
+            cfg = CredentialsLoader().get_cortex_config()
+            cortex_url = cortex_url or cfg.get("url")
+            cortex_api_key = cortex_api_key or cfg.get("api_key")
+
+    steps: list[dict] = [_place_plugin_artifact(manifest, staging_root, plugin_root, dry_run)]
+    steps += [_register_automation(a, dry_run) for a in manifest.provides.automations]
+    steps += _grant_topics(manifest, cortex_url, cortex_api_key, org, tenant, dry_run)
+    steps += _check_env(manifest)
+
+    errors = [f"{s['kind']} {s['target']}: {s['detail']}" for s in steps if s["status"] == "error"]
+    return {
+        "ok": not errors,
+        "action": "provision",
+        "module": manifest.name,
+        "dry_run": dry_run,
         "steps": steps,
         "errors": errors,
     }

--- a/empirica/core/modules/executors.py
+++ b/empirica/core/modules/executors.py
@@ -1,0 +1,208 @@
+"""Module install executors — the plugin-layer side of the two-layer install.
+
+``fetch_module`` is the **auth-gated artifact pre-step** (leg 2): it stages a
+module's distribution artifacts so the plugin layer can place them. The seat
+layer (autonomy's ``install_seat.py``) runs between fetch and provision; it
+never fetches — that's this module's job, keeping install_seat single-purpose.
+
+Design invariants (from the converged module SER):
+- **Write-by-default, ``--dry-run`` previews** — mirrors install_seat's contract,
+  so the front-door can dry-run the whole ``fetch → seat → provision`` chain.
+- **Idempotent** — re-fetching an already-staged/installed artifact is a no-op.
+- **Per-step receipt** — every artifact reports its own status so a bulk
+  front-door can see exactly which step needs attention.
+- **Reference-only secrets** — a ``secrets_ref`` is resolved via the
+  secrets-manager at runtime; a raw key never reaches this code (the manifest
+  validator already rejects one at the schema layer).
+
+The registry is config-driven (env), so this carries no fake infrastructure: a
+``plugin_archive`` resolves from a local path (dev/test) or a configured
+registry base URL; absent both, the step reports ``unconfigured`` rather than
+crashing.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from importlib import metadata
+from pathlib import Path
+
+from empirica.core.modules.manifest import ModuleManifest
+
+STAGING_ROOT = Path.home() / ".empirica" / "module_staging"
+REGISTRY_ENV = "EMPIRICA_MODULE_REGISTRY"  # base URL for plugin-archive fetch
+INDEX_ENV = "EMPIRICA_MODULE_INDEX_URL"  # auth-gated pip index for python_packages
+
+
+def _resolve_secret_ref(ref: str | None) -> tuple[str | None, str]:
+    """Resolve a reference-only secret to its value (never a raw key in source).
+
+    Returns ``(value, status)``. ``env:VAR`` reads the environment directly.
+    ``<scheme>://...`` is resolved by the manager's CLI if present on PATH
+    (``doppler``/``op``/``vault``), else reported ``manager_cli_absent`` — the
+    caller degrades gracefully rather than failing the whole fetch.
+    """
+    if not ref:
+        return None, "none"
+    if ref.startswith("env:"):
+        var = ref[len("env:") :]
+        val = os.environ.get(var)
+        return (val, "resolved") if val else (None, "env_unset")
+    scheme = ref.split("://", 1)[0] if "://" in ref else ""
+    if scheme and shutil.which(scheme):
+        try:
+            out = subprocess.run(
+                [scheme, "secrets", "get", ref] if scheme == "doppler" else [scheme, "read", ref],
+                capture_output=True,
+                text=True,
+                timeout=20,
+                check=True,
+            )
+            val = out.stdout.strip()
+            return (val, "resolved") if val else (None, "manager_empty")
+        except (subprocess.SubprocessError, OSError):
+            return None, "manager_error"
+    return None, "manager_cli_absent"
+
+
+def _pkg_installed(spec: str) -> bool:
+    """True if the (possibly ``name==ver``/``name>=ver``) package is importable."""
+    name = spec
+    for sep in ("==", ">=", "<=", "~=", ">", "<", "!=", "["):
+        if sep in name:
+            name = name.split(sep, 1)[0]
+    name = name.strip()
+    try:
+        metadata.version(name)
+        return True
+    except metadata.PackageNotFoundError:
+        return False
+
+
+def _pip_install(spec: str, index_url: str | None) -> tuple[bool, str]:
+    """Install one package via the current interpreter's pip. Returns (ok, detail)."""
+    cmd = [sys.executable, "-m", "pip", "install", spec]
+    if index_url:
+        cmd += ["--index-url", index_url]
+    try:
+        subprocess.run(cmd, capture_output=True, text=True, timeout=600, check=True)
+        return True, "installed"
+    except subprocess.CalledProcessError as e:
+        return False, (e.stderr or e.stdout or "pip failed").strip().splitlines()[-1][:300]
+    except (subprocess.SubprocessError, OSError) as e:
+        return False, str(e)[:300]
+
+
+def _fetch_archive(archive: str, dest: Path, registry_base: str | None, bearer: str | None) -> tuple[bool, str]:
+    """Stage ``archive`` to ``dest``. Local path → copy; else registry+bearer → download."""
+    local = Path(archive)
+    if local.exists():
+        shutil.copy2(local, dest)
+        return True, "copied_local"
+    if not registry_base:
+        return False, "no_registry_configured"
+    url = registry_base.rstrip("/") + "/" + archive
+    req = urllib.request.Request(url)
+    if bearer:
+        req.add_header("Authorization", f"Bearer {bearer}")
+    try:
+        with urllib.request.urlopen(req, timeout=120) as resp, open(dest, "wb") as fh:
+            shutil.copyfileobj(resp, fh)
+        return True, f"downloaded:{url}"
+    except (urllib.error.URLError, OSError) as e:
+        return False, str(e)[:300]
+
+
+def fetch_module(
+    manifest: ModuleManifest,
+    *,
+    dry_run: bool = False,
+    staging_root: Path | None = None,
+    registry_base: str | None = None,
+    index_url: str | None = None,
+) -> dict:
+    """Stage a module's distribution artifacts (python_packages + plugin_archive).
+
+    Returns a receipt: ``{ok, action, module, dry_run, staged_path, steps, errors}``
+    where each step carries its own ``status`` (``would_*`` under dry-run).
+    """
+    root = staging_root or STAGING_ROOT
+    registry_base = registry_base if registry_base is not None else os.environ.get(REGISTRY_ENV)
+    index_url = index_url if index_url is not None else os.environ.get(INDEX_ENV)
+
+    staged = root / manifest.name
+    steps: list[dict] = []
+    errors: list[str] = []
+
+    if not dry_run:
+        staged.mkdir(parents=True, exist_ok=True)
+
+    # python_packages → pip (idempotent: skip if already importable)
+    for spec in manifest.artifacts.python_packages:
+        if _pkg_installed(spec):
+            steps.append({"kind": "python_package", "target": spec, "status": "skipped", "detail": "already installed"})
+            continue
+        if dry_run:
+            steps.append({"kind": "python_package", "target": spec, "status": "would_install", "detail": "pip install"})
+            continue
+        ok, detail = _pip_install(spec, index_url)
+        steps.append(
+            {"kind": "python_package", "target": spec, "status": "installed" if ok else "error", "detail": detail}
+        )
+        if not ok:
+            errors.append(f"python_package {spec}: {detail}")
+
+    # plugin_archive → local copy or registry download (idempotent: skip if staged)
+    archive = manifest.artifacts.plugin_archive
+    if archive:
+        dest = staged / Path(archive).name
+        if dest.exists():
+            steps.append({"kind": "plugin_archive", "target": archive, "status": "skipped", "detail": "already staged"})
+        elif dry_run:
+            src = "local" if Path(archive).exists() else (f"{registry_base}" if registry_base else "unconfigured")
+            status = "unconfigured" if src == "unconfigured" else "would_fetch"
+            steps.append({"kind": "plugin_archive", "target": archive, "status": status, "detail": src})
+        else:
+            bearer, sref_status = _resolve_secret_ref(manifest.requires_runtime.secrets_ref)
+            need_remote = not Path(archive).exists()
+            if need_remote and not registry_base:
+                steps.append(
+                    {"kind": "plugin_archive", "target": archive, "status": "unconfigured", "detail": "no registry"}
+                )
+            elif need_remote and manifest.requires_runtime.secrets_ref and bearer is None:
+                steps.append(
+                    {
+                        "kind": "plugin_archive",
+                        "target": archive,
+                        "status": "unresolved_secret",
+                        "detail": sref_status,
+                    }
+                )
+                errors.append(f"plugin_archive {archive}: secret {sref_status}")
+            else:
+                ok, detail = _fetch_archive(archive, dest, registry_base, bearer)
+                steps.append(
+                    {
+                        "kind": "plugin_archive",
+                        "target": archive,
+                        "status": "fetched" if ok else "error",
+                        "detail": detail,
+                    }
+                )
+                if not ok:
+                    errors.append(f"plugin_archive {archive}: {detail}")
+
+    return {
+        "ok": not errors,
+        "action": "fetch",
+        "module": manifest.name,
+        "dry_run": dry_run,
+        "staged_path": str(staged),
+        "steps": steps,
+        "errors": errors,
+    }

--- a/empirica/core/modules/manifest.py
+++ b/empirica/core/modules/manifest.py
@@ -1,0 +1,209 @@
+"""``module.yaml`` — the practice-module manifest schema, loader, and validator.
+
+A practice-module declares its install bill-of-materials in a ``module.yaml``
+under a top-level ``empirica_module:`` key. The MIT core reads it *declaratively*
+(pydantic models, no import of any module's code) to understand what the
+manifest would install across the two install layers:
+
+- **seat layer** → autonomy's ``install_seat.py`` (CLAUDE.md managed-block).
+  ``seat.import`` / ``seat.mode`` / top-level ``seat_name`` map onto the
+  ``--seat-import`` / ``--mode`` / ``--seat-name`` flags.
+- **plugin layer** → ``empirica module provision`` (skills/agents/automations,
+  ntfy topics, env presence checks).
+
+Distribution artifacts (``artifacts``) are fetched by ``empirica module fetch``
+as a pre-step before either layer runs (install_seat itself never fetches).
+
+Validation is structural and fail-fast: a malformed manifest is rejected with a
+precise error *before* any install action runs. ``extra="forbid"`` turns a
+mis-spelled key into a loud error rather than a silently-ignored field, and the
+``secrets_ref`` validator enforces the reference-only discipline (a raw key is
+rejected at the schema layer, not just by the downstream secrets-manager).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Literal
+
+import yaml
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator, model_validator
+
+# A secrets reference is a manager pointer, never a raw key: ``doppler://...``,
+# ``op://...``, ``vault://...`` (scheme://...) or ``env:VARNAME``. Anything that
+# does not match is treated as a raw secret and rejected.
+_SECRETS_REF_RE = re.compile(r"^(?:[a-z][a-z0-9+.\-]*://.+|env:[A-Za-z_][A-Za-z0-9_]*)$")
+
+_ROOT_KEY = "empirica_module"
+
+
+class ManifestError(Exception):
+    """Raised when a ``module.yaml`` is missing, unreadable, or invalid."""
+
+
+class Seat(BaseModel):
+    """Seat layer declaration → ``install_seat.py`` flags."""
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    import_: str = Field(
+        alias="import",
+        description="@import body doc (relative to the seat root) → install_seat --seat-import",
+    )
+    mode: Literal["inject", "dedicated"] = "inject"
+
+
+class Artifacts(BaseModel):
+    """Distribution artifacts → ``empirica module fetch`` (auth-gated pre-step)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    plugin_archive: str | None = Field(
+        default=None, description="Plugin archive name fetched from the auth-gated registry"
+    )
+    python_packages: list[str] = Field(
+        default_factory=list, description="Closed-source wheels from an auth-gated index"
+    )
+
+
+class Automation(BaseModel):
+    """A declared automation wired via ``empirica loop register`` (canonical catalog).
+
+    ``kind=listener`` → a long-running systemd-user *service* (``autostart`` +
+    ``restart_policy`` apply). ``kind=interval`` / ``kind=cron`` → a systemd-user
+    *timer*.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    kind: Literal["listener", "interval", "cron"]
+    command: str | None = None
+    interval: str | None = None
+    cron: str | None = None
+    autostart: bool = False
+    restart_policy: Literal["no", "on-failure", "always"] = "no"
+
+    @model_validator(mode="after")
+    def _kind_requires_field(self) -> Automation:
+        if self.kind == "listener" and not self.command:
+            raise ValueError(f"automation {self.name!r}: kind=listener requires 'command'")
+        if self.kind == "interval" and not self.interval:
+            raise ValueError(f"automation {self.name!r}: kind=interval requires 'interval'")
+        if self.kind == "cron" and not self.cron:
+            raise ValueError(f"automation {self.name!r}: kind=cron requires 'cron'")
+        return self
+
+
+class Provides(BaseModel):
+    """Plugin-layer payload → ``empirica module provision``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    skills: list[str] = Field(default_factory=list)
+    agents: list[str] = Field(default_factory=list)
+    hooks: list[str] = Field(default_factory=list)
+    automations: list[Automation] = Field(default_factory=list)
+
+
+class RequiresRuntime(BaseModel):
+    """Runtime requirements — presence-validated at install, never raw-held.
+
+    ``env`` names are presence-checked only (the value is never read into the
+    provisioner). ``topics`` are registered via the cortex admin ntfy ACL.
+    ``secrets_ref`` is a single manager reference both install layers resolve.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    env: list[str] = Field(default_factory=list)
+    topics: list[str] = Field(default_factory=list)
+    secrets_ref: str | None = None
+
+    @field_validator("secrets_ref")
+    @classmethod
+    def _ref_only(cls, v: str | None) -> str | None:
+        if v is not None and not _SECRETS_REF_RE.match(v):
+            raise ValueError(
+                "secrets_ref must be a manager REFERENCE (e.g. doppler://, op://, "
+                "vault://, env:VARNAME), never a raw key"
+            )
+        return v
+
+
+class Requires(BaseModel):
+    """Compatibility constraints checked before install."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    empirica_core: str | None = None
+    cortex_api: str | None = None
+
+
+class ModuleManifest(BaseModel):
+    """The ``empirica_module:`` block of a ``module.yaml``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(description="Plugin/module id (drops into ~/.claude/plugins/local/<name>/)")
+    seat_name: str = Field(description="Canonical seat id → install_seat --seat-name")
+    version: str
+    visibility: Literal["public", "private", "enterprise"] = "private"
+    requires: Requires = Field(default_factory=Requires)
+    seat: Seat
+    artifacts: Artifacts = Field(default_factory=Artifacts)
+    provides: Provides = Field(default_factory=Provides)
+    requires_runtime: RequiresRuntime = Field(default_factory=RequiresRuntime)
+
+
+def _format_errors(exc: ValidationError) -> list[str]:
+    """Render pydantic errors as flat, human-readable ``path: message`` strings."""
+    out: list[str] = []
+    for err in exc.errors():
+        loc = ".".join(str(p) for p in err["loc"]) or "<root>"
+        out.append(f"{loc}: {err['msg']}")
+    return out
+
+
+def load_manifest(path: str | Path) -> ModuleManifest:
+    """Load + validate a ``module.yaml``. Raises ``ManifestError`` on any problem.
+
+    The file must contain a top-level ``empirica_module:`` mapping.
+    """
+    p = Path(path)
+    if not p.exists():
+        raise ManifestError(f"manifest not found: {p}")
+    try:
+        raw = yaml.safe_load(p.read_text())
+    except yaml.YAMLError as e:
+        raise ManifestError(f"invalid YAML in {p}: {e}") from e
+    if not isinstance(raw, dict) or _ROOT_KEY not in raw:
+        raise ManifestError(f"{p}: missing top-level '{_ROOT_KEY}:' key")
+    body = raw[_ROOT_KEY]
+    if not isinstance(body, dict):
+        raise ManifestError(f"{p}: '{_ROOT_KEY}' must be a mapping")
+    try:
+        return ModuleManifest.model_validate(body)
+    except ValidationError as e:
+        raise ManifestError("; ".join(_format_errors(e))) from e
+
+
+def validate_manifest_file(path: str | Path) -> dict:
+    """Validate a ``module.yaml`` and return a CLI-friendly receipt.
+
+    Returns ``{ok, path, errors, manifest}`` — ``manifest`` is the normalized
+    dict on success, ``errors`` the list of ``path: message`` strings on failure.
+    Never raises for a validation problem (the receipt carries it).
+    """
+    p = Path(path)
+    try:
+        manifest = load_manifest(p)
+    except ManifestError as e:
+        return {"ok": False, "path": str(p), "errors": [str(e)], "manifest": None}
+    return {
+        "ok": True,
+        "path": str(p),
+        "errors": [],
+        "manifest": manifest.model_dump(by_alias=True),
+    }

--- a/tests/test_module_fetch.py
+++ b/tests/test_module_fetch.py
@@ -1,0 +1,181 @@
+"""Tests for ``empirica module fetch`` — the auth-gated artifact pre-step.
+
+Covers: dry-run planning, idempotent skip (already-installed pkg / already-staged
+archive), local plugin_archive copy, unconfigured-registry graceful path,
+reference-only secret resolution, and the CLI handler exit codes. No real pip
+install or network — the install path is mocked; archive staging uses temp files.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import yaml
+
+from empirica.cli.command_handlers.module_commands import handle_module_fetch_command
+from empirica.core.modules import executors
+from empirica.core.modules.executors import _resolve_secret_ref, fetch_module
+from empirica.core.modules.manifest import load_manifest
+
+
+def _manifest(tmp_path, *, python_packages=None, plugin_archive=None, secrets_ref=None):
+    body = {
+        "name": "outreach",
+        "seat_name": "empirica-outreach",
+        "version": "0.4.0",
+        "seat": {"import": "docs/OUTREACH_SEAT.md"},
+        "artifacts": {},
+    }
+    if python_packages is not None:
+        body["artifacts"]["python_packages"] = python_packages
+    if plugin_archive is not None:
+        body["artifacts"]["plugin_archive"] = plugin_archive
+    if secrets_ref is not None:
+        body["requires_runtime"] = {"secrets_ref": secrets_ref}
+    p = tmp_path / "module.yaml"
+    p.write_text(yaml.safe_dump({"empirica_module": body}))
+    return load_manifest(p)
+
+
+# ── secret resolution (reference-only) ──────────────────────────────────
+
+
+def test_resolve_secret_env_scheme(monkeypatch):
+    monkeypatch.setenv("MY_TOKEN", "s3cr3t")
+    val, status = _resolve_secret_ref("env:MY_TOKEN")
+    assert val == "s3cr3t" and status == "resolved"
+
+
+def test_resolve_secret_env_unset(monkeypatch):
+    monkeypatch.delenv("MISSING_TOKEN", raising=False)
+    val, status = _resolve_secret_ref("env:MISSING_TOKEN")
+    assert val is None and status == "env_unset"
+
+
+def test_resolve_secret_none():
+    assert _resolve_secret_ref(None) == (None, "none")
+
+
+def test_resolve_secret_manager_absent(monkeypatch):
+    # a scheme whose CLI is not on PATH degrades gracefully
+    monkeypatch.setattr(executors.shutil, "which", lambda _c: None)
+    val, status = _resolve_secret_ref("doppler://empirica/outreach")
+    assert val is None and status == "manager_cli_absent"
+
+
+# ── dry-run planning ────────────────────────────────────────────────────
+
+
+def test_dry_run_writes_nothing(tmp_path):
+    m = _manifest(tmp_path, python_packages=["definitely-not-a-real-pkg==9.9"], plugin_archive="x.tar.gz")
+    staging = tmp_path / "staging"
+    receipt = fetch_module(m, dry_run=True, staging_root=staging)
+    assert receipt["dry_run"] is True
+    assert not staging.exists()  # nothing created under dry-run
+    kinds = {s["kind"]: s["status"] for s in receipt["steps"]}
+    assert kinds["python_package"] == "would_install"
+    assert kinds["plugin_archive"] == "unconfigured"  # not local, no registry
+
+
+def test_dry_run_skips_installed_package(tmp_path):
+    # pydantic is a hard dependency → always installed → skipped, not would_install
+    m = _manifest(tmp_path, python_packages=["pydantic"])
+    receipt = fetch_module(m, dry_run=True, staging_root=tmp_path / "s")
+    assert receipt["steps"][0]["status"] == "skipped"
+
+
+# ── plugin_archive staging ──────────────────────────────────────────────
+
+
+def test_local_archive_is_copied(tmp_path):
+    src = tmp_path / "outreach-0.4.0-plugin.tar.gz"
+    src.write_bytes(b"PK\x03\x04 fake archive")
+    m = _manifest(tmp_path, plugin_archive=str(src))
+    staging = tmp_path / "staging"
+    receipt = fetch_module(m, dry_run=False, staging_root=staging)
+    assert receipt["ok"] is True
+    step = receipt["steps"][0]
+    assert step["status"] == "fetched" and step["detail"] == "copied_local"
+    assert (staging / "outreach" / src.name).exists()
+
+
+def test_archive_idempotent_skip(tmp_path):
+    src = tmp_path / "plugin.tar.gz"
+    src.write_bytes(b"data")
+    m = _manifest(tmp_path, plugin_archive=str(src))
+    staging = tmp_path / "staging"
+    fetch_module(m, dry_run=False, staging_root=staging)  # first stages it
+    receipt = fetch_module(m, dry_run=False, staging_root=staging)  # second is a no-op
+    assert receipt["steps"][0]["status"] == "skipped"
+
+
+def test_remote_archive_unconfigured(tmp_path):
+    m = _manifest(tmp_path, plugin_archive="remote-only.tar.gz")
+    receipt = fetch_module(m, dry_run=False, staging_root=tmp_path / "s")
+    assert receipt["steps"][0]["status"] == "unconfigured"
+    assert receipt["ok"] is True  # unconfigured is not an error, just nothing to do
+
+
+def test_remote_archive_unresolved_secret(tmp_path, monkeypatch):
+    monkeypatch.delenv("ABSENT", raising=False)
+    m = _manifest(tmp_path, plugin_archive="remote.tar.gz", secrets_ref="env:ABSENT")
+    receipt = fetch_module(m, dry_run=False, staging_root=tmp_path / "s", registry_base="https://reg.example")
+    step = receipt["steps"][0]
+    assert step["status"] == "unresolved_secret" and receipt["ok"] is False
+
+
+# ── pip install path (mocked) ───────────────────────────────────────────
+
+
+def test_install_runs_pip(tmp_path, monkeypatch):
+    calls = []
+    monkeypatch.setattr(executors, "_pkg_installed", lambda spec: False)
+    monkeypatch.setattr(executors, "_pip_install", lambda spec, idx: calls.append((spec, idx)) or (True, "installed"))
+    m = _manifest(tmp_path, python_packages=["empirica-outreach==0.4.0"])
+    receipt = fetch_module(m, dry_run=False, staging_root=tmp_path / "s", index_url="https://idx.example")
+    assert receipt["steps"][0]["status"] == "installed"
+    assert calls == [("empirica-outreach==0.4.0", "https://idx.example")]
+
+
+def test_install_pip_error_surfaces(tmp_path, monkeypatch):
+    monkeypatch.setattr(executors, "_pkg_installed", lambda spec: False)
+    monkeypatch.setattr(executors, "_pip_install", lambda spec, idx: (False, "no matching distribution"))
+    m = _manifest(tmp_path, python_packages=["nope==1.0"])
+    receipt = fetch_module(m, dry_run=False, staging_root=tmp_path / "s")
+    assert receipt["ok"] is False and receipt["steps"][0]["status"] == "error"
+
+
+# ── CLI handler ─────────────────────────────────────────────────────────
+
+
+def test_cli_fetch_dry_run_exit_0(tmp_path, capsys):
+    m_path = tmp_path / "module.yaml"
+    _manifest(tmp_path)  # writes module.yaml then overwritten below for a clean one
+    m_path.write_text(
+        yaml.safe_dump(
+            {
+                "empirica_module": {
+                    "name": "outreach",
+                    "seat_name": "empirica-outreach",
+                    "version": "0.4.0",
+                    "seat": {"import": "docs/X.md"},
+                }
+            }
+        )
+    )
+    args = SimpleNamespace(
+        path=str(m_path), dry_run=True, registry=None, index_url=None, staging_root=str(tmp_path / "s"), output="json"
+    )
+    rc = handle_module_fetch_command(args)
+    out = json.loads(capsys.readouterr().out)
+    assert rc == 0 and out["ok"] is True and out["dry_run"] is True
+
+
+def test_cli_fetch_invalid_manifest_exit_1(tmp_path, capsys):
+    bad = tmp_path / "bad.yaml"
+    bad.write_text(yaml.safe_dump({"empirica_module": {"name": "x"}}))  # missing required fields
+    args = SimpleNamespace(path=str(bad), dry_run=True, output="json")
+    rc = handle_module_fetch_command(args)
+    out = json.loads(capsys.readouterr().out)
+    assert rc == 1 and out["ok"] is False

--- a/tests/test_module_manifest.py
+++ b/tests/test_module_manifest.py
@@ -1,0 +1,213 @@
+"""Tests for the practice-module manifest (``module.yaml``) schema + validator.
+
+Covers: full valid load, the top-level ``empirica_module:`` requirement,
+required-field + unknown-key (extra=forbid) rejection, the reference-only
+``secrets_ref`` discipline, automation kind↔field consistency, the
+``validate_manifest_file`` receipt shape, and the ``empirica module validate``
+CLI exit codes.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+import yaml
+
+from empirica.cli.command_handlers.module_commands import handle_module_validate_command
+from empirica.core.modules.manifest import (
+    ManifestError,
+    load_manifest,
+    validate_manifest_file,
+)
+
+
+def _valid_manifest() -> dict:
+    return {
+        "empirica_module": {
+            "name": "outreach",
+            "seat_name": "empirica-outreach",
+            "version": "0.4.0",
+            "visibility": "private",
+            "requires": {"empirica_core": ">=1.11.6", "cortex_api": ">=v1"},
+            "seat": {"import": "docs/OUTREACH_SEAT.md", "mode": "inject"},
+            "artifacts": {
+                "plugin_archive": "outreach-0.4.0-plugin.tar.gz",
+                "python_packages": ["empirica-outreach==0.4.0"],
+            },
+            "provides": {
+                "skills": ["devto", "voice-analyze", "brain-classifier"],
+                "agents": ["outreach-search", "outreach-scout"],
+                "automations": [
+                    {
+                        "name": "outreach-outbox-dispatcher",
+                        "kind": "listener",
+                        "command": "outreach dispatch-listen --instance empirica-outreach",
+                        "autostart": True,
+                        "restart_policy": "on-failure",
+                    }
+                ],
+            },
+            "requires_runtime": {
+                "env": ["DEVTO_API_KEY", "ZERNIO_API_KEY"],
+                "topics": ["empirica-outreach-dispatch"],
+                "secrets_ref": "doppler://empirica/outreach",
+            },
+        }
+    }
+
+
+def _write(tmp_path, data: dict):
+    p = tmp_path / "module.yaml"
+    p.write_text(yaml.safe_dump(data))
+    return p
+
+
+# ── happy path ──────────────────────────────────────────────────────────
+
+
+def test_valid_manifest_loads(tmp_path):
+    m = load_manifest(_write(tmp_path, _valid_manifest()))
+    assert m.name == "outreach"
+    assert m.seat_name == "empirica-outreach"
+    assert m.seat.import_ == "docs/OUTREACH_SEAT.md"  # alias 'import'
+    assert m.seat.mode == "inject"
+    assert m.provides.automations[0].kind == "listener"
+    assert m.requires_runtime.secrets_ref == "doppler://empirica/outreach"
+
+
+def test_round_trips_import_alias(tmp_path):
+    receipt = validate_manifest_file(_write(tmp_path, _valid_manifest()))
+    assert receipt["ok"] is True
+    # by_alias dump re-emits 'import', not 'import_'
+    assert receipt["manifest"]["seat"]["import"] == "docs/OUTREACH_SEAT.md"
+
+
+def test_minimal_manifest_defaults(tmp_path):
+    data = {
+        "empirica_module": {
+            "name": "x",
+            "seat_name": "empirica-x",
+            "version": "0.1.0",
+            "seat": {"import": "docs/X_SEAT.md"},
+        }
+    }
+    m = load_manifest(_write(tmp_path, data))
+    assert m.visibility == "private"  # default
+    assert m.seat.mode == "inject"  # default
+    assert m.provides.skills == [] and m.requires_runtime.env == []
+
+
+# ── structural rejection ────────────────────────────────────────────────
+
+
+def test_missing_root_key(tmp_path):
+    p = tmp_path / "module.yaml"
+    p.write_text(yaml.safe_dump({"name": "x"}))
+    with pytest.raises(ManifestError, match="empirica_module"):
+        load_manifest(p)
+
+
+def test_missing_required_field(tmp_path):
+    data = _valid_manifest()
+    del data["empirica_module"]["seat"]["import"]
+    receipt = validate_manifest_file(_write(tmp_path, data))
+    assert receipt["ok"] is False
+    assert any("seat.import" in e for e in receipt["errors"])
+
+
+def test_unknown_key_rejected(tmp_path):
+    data = _valid_manifest()
+    data["empirica_module"]["provides"]["skils"] = ["typo"]  # misspelled
+    receipt = validate_manifest_file(_write(tmp_path, data))
+    assert receipt["ok"] is False
+    assert any("skils" in e or "extra" in e.lower() for e in receipt["errors"])
+
+
+def test_missing_file(tmp_path):
+    receipt = validate_manifest_file(tmp_path / "nope.yaml")
+    assert receipt["ok"] is False
+    assert any("not found" in e for e in receipt["errors"])
+
+
+def test_invalid_yaml(tmp_path):
+    p = tmp_path / "module.yaml"
+    p.write_text("empirica_module: {name: x, : broken")
+    receipt = validate_manifest_file(p)
+    assert receipt["ok"] is False
+
+
+# ── reference-only secrets discipline ───────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "ref",
+    ["doppler://empirica/outreach", "op://vault/item", "vault://secret/data", "env:ZERNIO_API_KEY"],
+)
+def test_secrets_ref_accepts_references(tmp_path, ref):
+    data = _valid_manifest()
+    data["empirica_module"]["requires_runtime"]["secrets_ref"] = ref
+    assert validate_manifest_file(_write(tmp_path, data))["ok"] is True
+
+
+@pytest.mark.parametrize("raw", ["sk-abc123raw", "ZERNIO_KEY=topsecret", "just-a-string"])
+def test_secrets_ref_rejects_raw_keys(tmp_path, raw):
+    data = _valid_manifest()
+    data["empirica_module"]["requires_runtime"]["secrets_ref"] = raw
+    receipt = validate_manifest_file(_write(tmp_path, data))
+    assert receipt["ok"] is False
+    assert any("secrets_ref" in e for e in receipt["errors"])
+
+
+# ── automation kind↔field consistency ───────────────────────────────────
+
+
+def test_listener_requires_command(tmp_path):
+    data = _valid_manifest()
+    del data["empirica_module"]["provides"]["automations"][0]["command"]
+    receipt = validate_manifest_file(_write(tmp_path, data))
+    assert receipt["ok"] is False
+    assert any("command" in e for e in receipt["errors"])
+
+
+def test_interval_requires_interval(tmp_path):
+    data = _valid_manifest()
+    data["empirica_module"]["provides"]["automations"] = [
+        {"name": "poller", "kind": "interval"}  # missing interval
+    ]
+    receipt = validate_manifest_file(_write(tmp_path, data))
+    assert receipt["ok"] is False
+    assert any("interval" in e for e in receipt["errors"])
+
+
+def test_interval_automation_valid(tmp_path):
+    data = _valid_manifest()
+    data["empirica_module"]["provides"]["automations"] = [{"name": "poller", "kind": "interval", "interval": "5m"}]
+    assert validate_manifest_file(_write(tmp_path, data))["ok"] is True
+
+
+# ── CLI handler ─────────────────────────────────────────────────────────
+
+
+def test_cli_validate_exit_0_on_valid(tmp_path, capsys):
+    p = _write(tmp_path, _valid_manifest())
+    rc = handle_module_validate_command(SimpleNamespace(path=str(p), output="json"))
+    out = json.loads(capsys.readouterr().out)
+    assert rc == 0 and out["ok"] is True
+
+
+def test_cli_validate_exit_1_on_invalid(tmp_path, capsys):
+    data = _valid_manifest()
+    del data["empirica_module"]["version"]
+    p = _write(tmp_path, data)
+    rc = handle_module_validate_command(SimpleNamespace(path=str(p), output="json"))
+    out = json.loads(capsys.readouterr().out)
+    assert rc == 1 and out["ok"] is False
+
+
+def test_cli_validate_text_output(tmp_path, capsys):
+    p = _write(tmp_path, _valid_manifest())
+    rc = handle_module_validate_command(SimpleNamespace(path=str(p), output="text"))
+    text = capsys.readouterr().out
+    assert rc == 0 and "outreach" in text and "valid" in text

--- a/tests/test_module_provision.py
+++ b/tests/test_module_provision.py
@@ -1,0 +1,224 @@
+"""Tests for ``empirica module provision`` — the plugin layer (leg 3).
+
+Covers the four steps — plugin-file placement, automation registration
+(``empirica loop register``, kind-mapped), cortex ntfy-topic grants, and env
+presence — plus dry-run planning and CLI exit codes. No real subprocess,
+network, or ~/.claude writes: loop-register + grant POST are mocked; file
+placement uses temp dirs.
+"""
+
+from __future__ import annotations
+
+import json
+import tarfile
+from types import SimpleNamespace
+
+import yaml
+
+from empirica.cli.command_handlers.module_commands import handle_module_provision_command
+from empirica.core.modules import executors
+from empirica.core.modules.executors import provision_module
+from empirica.core.modules.manifest import load_manifest
+
+
+def _manifest(tmp_path, *, plugin_archive=None, automations=None, topics=None, env=None):
+    body = {
+        "name": "outreach",
+        "seat_name": "empirica-outreach",
+        "version": "0.4.0",
+        "seat": {"import": "docs/OUTREACH_SEAT.md"},
+        "artifacts": {},
+        "provides": {},
+        "requires_runtime": {},
+    }
+    if plugin_archive is not None:
+        body["artifacts"]["plugin_archive"] = plugin_archive
+    if automations is not None:
+        body["provides"]["automations"] = automations
+    if topics is not None:
+        body["requires_runtime"]["topics"] = topics
+    if env is not None:
+        body["requires_runtime"]["env"] = env
+    p = tmp_path / "module.yaml"
+    p.write_text(yaml.safe_dump({"empirica_module": body}))
+    return load_manifest(p)
+
+
+def _staged_tar(tmp_path, name="outreach", archive="outreach-0.4.0-plugin.tar.gz"):
+    """Create a staged plugin archive as ``module fetch`` would leave it."""
+    staging = tmp_path / "staging"
+    moddir = staging / name
+    moddir.mkdir(parents=True)
+    payload = tmp_path / "skill.md"
+    payload.write_text("# a skill")
+    tar_path = moddir / archive
+    with tarfile.open(tar_path, "w:gz") as tf:
+        tf.add(payload, arcname="skills/devto.md")
+    return staging
+
+
+# ── plugin file placement ───────────────────────────────────────────────
+
+
+def test_no_artifact_is_graceful(tmp_path):
+    m = _manifest(tmp_path)  # no plugin_archive
+    receipt = provision_module(m, dry_run=False, plugin_root=tmp_path / "plugins", staging_root=tmp_path / "s")
+    assert receipt["steps"][0]["status"] == "no_artifact" and receipt["ok"] is True
+
+
+def test_not_staged_reports_clearly(tmp_path):
+    m = _manifest(tmp_path, plugin_archive="missing.tar.gz")
+    receipt = provision_module(m, dry_run=False, plugin_root=tmp_path / "plugins", staging_root=tmp_path / "s")
+    assert receipt["steps"][0]["status"] == "not_staged"
+
+
+def test_staged_archive_is_extracted(tmp_path):
+    staging = _staged_tar(tmp_path)
+    m = _manifest(tmp_path, plugin_archive="outreach-0.4.0-plugin.tar.gz")
+    plugins = tmp_path / "plugins"
+    receipt = provision_module(m, dry_run=False, plugin_root=plugins, staging_root=staging)
+    assert receipt["steps"][0]["status"] == "placed"
+    assert (plugins / "outreach" / "skills" / "devto.md").exists()
+
+
+def test_placement_idempotent_skip(tmp_path):
+    staging = _staged_tar(tmp_path)
+    m = _manifest(tmp_path, plugin_archive="outreach-0.4.0-plugin.tar.gz")
+    plugins = tmp_path / "plugins"
+    provision_module(m, dry_run=False, plugin_root=plugins, staging_root=staging)
+    receipt = provision_module(m, dry_run=False, plugin_root=plugins, staging_root=staging)
+    assert receipt["steps"][0]["status"] == "skipped"
+
+
+# ── automation registration (loop register, mocked) ─────────────────────
+
+
+def test_listener_maps_to_monitor_kind(tmp_path, monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        executors.subprocess, "run", lambda cmd, **kw: calls.append(cmd) or SimpleNamespace(returncode=0)
+    )
+    m = _manifest(
+        tmp_path,
+        automations=[{"name": "outreach-outbox-dispatcher", "kind": "listener", "command": "outreach dispatch-listen"}],
+    )
+    receipt = provision_module(m, dry_run=False, plugin_root=tmp_path / "p", staging_root=tmp_path / "s")
+    auto_step = next(s for s in receipt["steps"] if s["kind"] == "automation")
+    assert auto_step["status"] == "registered"
+    assert calls[0][:5] == ["empirica", "loop", "register", "--name", "outreach-outbox-dispatcher"]
+    assert "monitor" in calls[0]  # listener → monitor
+
+
+def test_interval_automation_passes_interval(tmp_path, monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        executors.subprocess, "run", lambda cmd, **kw: calls.append(cmd) or SimpleNamespace(returncode=0)
+    )
+    m = _manifest(tmp_path, automations=[{"name": "poller", "kind": "interval", "interval": "5m"}])
+    provision_module(m, dry_run=False, plugin_root=tmp_path / "p", staging_root=tmp_path / "s")
+    assert "--interval" in calls[0] and "5m" in calls[0]
+
+
+def test_dry_run_registers_nothing(tmp_path, monkeypatch):
+    called = []
+    monkeypatch.setattr(executors.subprocess, "run", lambda *a, **k: called.append(1))
+    m = _manifest(tmp_path, automations=[{"name": "p", "kind": "interval", "interval": "5m"}])
+    receipt = provision_module(m, dry_run=True, plugin_root=tmp_path / "p", staging_root=tmp_path / "s")
+    auto_step = next(s for s in receipt["steps"] if s["kind"] == "automation")
+    assert auto_step["status"] == "would_register" and not called
+
+
+# ── topic grants (cortex admin, mocked) ─────────────────────────────────
+
+
+def test_topics_unconfigured_without_org(tmp_path):
+    m = _manifest(tmp_path, topics=["empirica-outreach-dispatch"])
+    receipt = provision_module(
+        m, dry_run=False, plugin_root=tmp_path / "p", staging_root=tmp_path / "s", cortex_url=None
+    )
+    topic_step = next(s for s in receipt["steps"] if s["kind"] == "topic")
+    assert topic_step["status"] == "unconfigured"
+
+
+def test_topics_dry_run_shows_grants(tmp_path):
+    m = _manifest(tmp_path, topics=["empirica-outreach-dispatch"])
+    receipt = provision_module(
+        m,
+        dry_run=True,
+        plugin_root=tmp_path / "p",
+        staging_root=tmp_path / "s",
+        cortex_url="https://cortex.example",
+        cortex_api_key="admin-key",
+        org="empirica",
+        tenant="david",
+    )
+    topic_step = next(s for s in receipt["steps"] if s["kind"] == "topic")
+    assert topic_step["status"] == "would_grant"
+    grants = json.loads(topic_step["detail"])
+    assert {g["user"] for g in grants} == {"empirica-cortex-publisher", "empirica-u-david"}
+    assert {g["permission"] for g in grants} == {"rw", "read-only"}
+
+
+def test_topics_granted_calls_cortex(tmp_path, monkeypatch):
+    posted = []
+    monkeypatch.setattr(
+        executors, "_post_grants", lambda url, key, grants: posted.append((url, grants)) or (True, "http 200")
+    )
+    m = _manifest(tmp_path, topics=["empirica-outreach-dispatch"])
+    receipt = provision_module(
+        m,
+        dry_run=False,
+        plugin_root=tmp_path / "p",
+        staging_root=tmp_path / "s",
+        cortex_url="https://cortex.example",
+        cortex_api_key="admin-key",
+        org="empirica",
+        tenant="david",
+    )
+    topic_step = next(s for s in receipt["steps"] if s["kind"] == "topic")
+    assert topic_step["status"] == "granted" and posted
+
+
+# ── env presence ────────────────────────────────────────────────────────
+
+
+def test_env_presence(tmp_path, monkeypatch):
+    monkeypatch.setenv("DEVTO_API_KEY", "x")
+    monkeypatch.delenv("ZERNIO_API_KEY", raising=False)
+    m = _manifest(tmp_path, env=["DEVTO_API_KEY", "ZERNIO_API_KEY"])
+    receipt = provision_module(m, dry_run=False, plugin_root=tmp_path / "p", staging_root=tmp_path / "s")
+    env_steps = {s["target"]: s["status"] for s in receipt["steps"] if s["kind"] == "env"}
+    assert env_steps == {"DEVTO_API_KEY": "present", "ZERNIO_API_KEY": "missing"}
+    assert receipt["ok"] is True  # missing env is reported, not an error
+
+
+# ── CLI handler ─────────────────────────────────────────────────────────
+
+
+def test_cli_provision_dry_run_exit_0(tmp_path, capsys):
+    m_path = tmp_path / "module.yaml"
+    m_path.write_text(
+        yaml.safe_dump(
+            {
+                "empirica_module": {
+                    "name": "outreach",
+                    "seat_name": "empirica-outreach",
+                    "version": "0.4.0",
+                    "seat": {"import": "docs/X.md"},
+                }
+            }
+        )
+    )
+    args = SimpleNamespace(
+        path=str(m_path),
+        dry_run=True,
+        plugin_root=str(tmp_path / "p"),
+        staging_root=str(tmp_path / "s"),
+        cortex_url=None,
+        org=None,
+        tenant=None,
+        output="json",
+    )
+    rc = handle_module_provision_command(args)
+    out = json.loads(capsys.readouterr().out)
+    assert rc == 0 and out["ok"] is True and out["action"] == "provision"


### PR DESCRIPTION
## What

The two plugin-layer executors that complete empirica's side of the installable practice-module system. Stacked on #147 (manifest schema + validator); base will retarget to `develop` when #147 merges.

The front-door sequences **fetch → install_seat (seat layer, autonomy) → provision (plugin layer)**.

### `empirica module fetch` (leg 2) — auth-gated artifact pre-step
Stages a module's distribution artifacts so the plugin layer can place them; install_seat never fetches, keeping it single-purpose.
- `python_packages` → pip (idempotent: skips already-installed)
- `plugin_archive` → local-path copy or configured-registry+bearer download → `~/.empirica/module_staging/<name>/`
- **reference-only secret resolution** (`env:` real; `doppler`/`op`/`vault` via manager CLI if present; graceful otherwise — a raw key never reaches the code)
- per-step receipt `{would_*|fetched|skipped|unconfigured|unresolved_secret|error}`; write-by-default + `--dry-run`; graceful when registry unconfigured (no fake infra)

### `empirica module provision` (leg 3) — the plugin layer
Four idempotent, dry-runnable, per-step-status steps over the validated manifest:
- **plugin_files** → extract the fetched archive into `~/.claude/plugins/local/<name>/` (graceful `no_artifact`/`not_staged`; idempotent skip; `tarfile` `filter=data`)
- **automations** → `empirica loop register` (kind map: `listener`→`monitor`, `interval`, `cron`)
- **topics** → cortex admin `POST /v1/admin/ntfy/grants` (publisher `rw` + subscriber `read-only` from `--org`/`--tenant`; reuses cortex credentials; graceful unconfigured; **dry-run previews the exact grants payload so nothing POSTs blind**)
- **env** → presence-check `requires_runtime.env` (value never read; missing is reported, not an error)

## Both executors share the proven contract
Write-by-default + `--dry-run`, idempotent, per-step receipt — so the front-door can dry-run the whole `fetch → seat → provision` chain uniformly and see exactly which step needs attention.

## Known limitation (tracked)
`loop register` has no `--command`, so a `listener` automation's command-as-persistent-service supervision (autostart/restart_policy) is the front-door's `loop enable`/systemd step — provision registers the schedulable loop entry; the service wiring is a follow-up.

## Tests
- 26 new tests (14 fetch + 12 provision); ruff + format clean (S202/S110 resolved properly, not suppressed); pyright 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)