### PR TITLE
chore(repo): update github.com/Nubaeon/empirica → EmpiricaAI/empirica URLs

### DIFF
--- a/.docker/DESCRIPTION.txt
+++ b/.docker/DESCRIPTION.txt
@@ -10,5 +10,5 @@ Key Features:
 Perfect for AI agents that need genuine metacognitive awareness and calibration.
 
 PyPI: https://pypi.org/project/empirica/
-GitHub: https://github.com/Nubaeon/empirica
-Docs: https://github.com/Nubaeon/empirica/tree/main/docs
+GitHub: https://github.com/EmpiricaAI/empirica
+Docs: https://github.com/EmpiricaAI/empirica/tree/main/docs

--- a/.docker/README.md
+++ b/.docker/README.md
@@ -1,7 +1,7 @@
 # Empirica - Epistemic Self-Assessment Framework for AI Agents
 
 **Docker Hub:** https://hub.docker.com/r/nubaeon/empirica  
-**GitHub:** https://github.com/Nubaeon/empirica  
+**GitHub:** https://github.com/EmpiricaAI/empirica  
 **PyPI:** https://pypi.org/project/empirica/
 
 ## What is Empirica?
@@ -173,23 +173,23 @@ docker run -it \
 
 ## Documentation
 
-- **Quick Start:** https://github.com/Nubaeon/empirica/blob/main/docs/human/end-users/01_START_HERE.md
-- **CLI Guide:** https://github.com/Nubaeon/empirica/blob/main/docs/human/end-users/04_QUICKSTART_CLI.md
-- **Installation:** https://github.com/Nubaeon/empirica/blob/main/docs/human/end-users/02_INSTALLATION.md
-- **Full Docs:** https://github.com/Nubaeon/empirica/tree/main/docs
+- **Quick Start:** https://github.com/EmpiricaAI/empirica/blob/main/docs/human/end-users/01_START_HERE.md
+- **CLI Guide:** https://github.com/EmpiricaAI/empirica/blob/main/docs/human/end-users/04_QUICKSTART_CLI.md
+- **Installation:** https://github.com/EmpiricaAI/empirica/blob/main/docs/human/end-users/02_INSTALLATION.md
+- **Full Docs:** https://github.com/EmpiricaAI/empirica/tree/main/docs
 
 ## Links
 
-- **GitHub Repository:** https://github.com/Nubaeon/empirica
+- **GitHub Repository:** https://github.com/EmpiricaAI/empirica
 - **PyPI Package:** https://pypi.org/project/empirica/
-- **Issues:** https://github.com/Nubaeon/empirica/issues
+- **Issues:** https://github.com/EmpiricaAI/empirica/issues
 - **License:** MIT
 
 ## Building from Source
 
 ```bash
 # Clone the repository
-git clone https://github.com/Nubaeon/empirica.git
+git clone https://github.com/EmpiricaAI/empirica.git
 cd empirica
 
 # Build the image
@@ -201,8 +201,8 @@ docker run -it empirica:custom empirica --help
 
 ## Support
 
-- GitHub Issues: https://github.com/Nubaeon/empirica/issues
-- Documentation: https://github.com/Nubaeon/empirica/tree/main/docs
+- GitHub Issues: https://github.com/EmpiricaAI/empirica/issues
+- Documentation: https://github.com/EmpiricaAI/empirica/tree/main/docs
 
 ---
 

--- a/.empirica-project/PROJECT_CONFIG.yaml
+++ b/.empirica-project/PROJECT_CONFIG.yaml
@@ -4,7 +4,7 @@
 project:
   name: "empirica-development"
   description: "Using Empirica to manage Empirica itself - dogfooding at its finest"
-  repository: "https://github.com/Nubaeon/empirica"
+  repository: "https://github.com/EmpiricaAI/empirica"
   version: "1.12.4"
   
 bootstrap:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1808,7 +1808,7 @@ to restart the daemon to switch project context.
       slug: empirica
       name: empirica
       path: /home/user/empirical-ai/empirica
-      repo_url: https://github.com/Nubaeon/empirica
+      repo_url: https://github.com/EmpiricaAI/empirica
       last_seen: 2026-05-12T08:32:00Z
   ```
   `project_id` is the Cortex UUID when registered, or a local slug for
@@ -5253,6 +5253,6 @@ First stable release of Empirica - genuine AI epistemic self-assessment framewor
 
 ## Links
 
-- [GitHub Repository](https://github.com/Nubaeon/empirica)
-- [Documentation](https://github.com/Nubaeon/empirica/tree/main/docs)
-- [Issue Tracker](https://github.com/Nubaeon/empirica/issues)
+- [GitHub Repository](https://github.com/EmpiricaAI/empirica)
+- [Documentation](https://github.com/EmpiricaAI/empirica/tree/main/docs)
+- [Issue Tracker](https://github.com/EmpiricaAI/empirica/issues)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,8 +15,8 @@ main (stable, production-ready)
 
 | Branch | Purpose | Direct commits | Install command |
 |---|---|---|---|
-| `main` | Production-ready, stable | Not allowed (PR + review) | `pip install git+https://github.com/Nubaeon/empirica.git@main` |
-| `develop` | Integration of new features | Allowed for maintainers | `pip install git+https://github.com/Nubaeon/empirica.git@develop` |
+| `main` | Production-ready, stable | Not allowed (PR + review) | `pip install git+https://github.com/EmpiricaAI/empirica.git@main` |
+| `develop` | Integration of new features | Allowed for maintainers | `pip install git+https://github.com/EmpiricaAI/empirica.git@develop` |
 | `feature/*` | New work | Free-form on your branch | — |
 | `hotfix/*` | Emergency fixes from main | Maintainers only | — |
 
@@ -59,7 +59,7 @@ When AI-pair-programmed, include the `Co-Authored-By` trailer so attribution is 
 ## Local setup
 
 ```bash
-git clone https://github.com/Nubaeon/empirica.git
+git clone https://github.com/EmpiricaAI/empirica.git
 cd empirica
 python3 -m venv .venv && source .venv/bin/activate
 pip install -e ".[dev]"
@@ -182,6 +182,6 @@ Full meta-development guide: [`.empirica-project/README.md`](.empirica-project/R
 
 ## Reporting issues
 
-GitHub issues: https://github.com/Nubaeon/empirica/issues
+GitHub issues: https://github.com/EmpiricaAI/empirica/issues
 
 For sensitive issues (security, credentials), email `david@getempirica.com` directly.

--- a/DOCKERHUB_README.md
+++ b/DOCKERHUB_README.md
@@ -4,9 +4,9 @@
 
 Teaching AI to know what it knows—and what it doesn't.
 
-[![GitHub](https://img.shields.io/badge/GitHub-Nubaeon%2Fempirica-blue)](https://github.com/Nubaeon/empirica)
+[![GitHub](https://img.shields.io/badge/GitHub-EmpiricaAI%2Fempirica-blue)](https://github.com/EmpiricaAI/empirica)
 [![PyPI](https://img.shields.io/pypi/v/empirica)](https://pypi.org/project/empirica/)
-[![License](https://img.shields.io/badge/license-MIT-green)](https://github.com/Nubaeon/empirica/blob/main/LICENSE)
+[![License](https://img.shields.io/badge/license-MIT-green)](https://github.com/EmpiricaAI/empirica/blob/main/LICENSE)
 
 ---
 
@@ -175,9 +175,9 @@ docker run --rm nubaeon/empirica:1.6.6-alpine empirica --version
 
 | Resource | Link |
 |----------|------|
-| Full Documentation | [github.com/Nubaeon/empirica/docs](https://github.com/Nubaeon/empirica/tree/main/docs) |
-| CLI Reference | [CLI_COMMANDS_UNIFIED.md](https://github.com/Nubaeon/empirica/blob/main/docs/human/developers/CLI_COMMANDS_UNIFIED.md) |
-| CASCADE Workflow | [CASCADE_WORKFLOW.md](https://github.com/Nubaeon/empirica/blob/main/docs/architecture/CASCADE_WORKFLOW.md) |
+| Full Documentation | [github.com/EmpiricaAI/empirica/docs](https://github.com/EmpiricaAI/empirica/tree/main/docs) |
+| CLI Reference | [CLI_COMMANDS_UNIFIED.md](https://github.com/EmpiricaAI/empirica/blob/main/docs/human/developers/CLI_COMMANDS_UNIFIED.md) |
+| CASCADE Workflow | [CASCADE_WORKFLOW.md](https://github.com/EmpiricaAI/empirica/blob/main/docs/architecture/CASCADE_WORKFLOW.md) |
 | Getting Started | [getempirica.com](https://getempirica.com) |
 
 ---
@@ -186,6 +186,6 @@ docker run --rm nubaeon/empirica:1.6.6-alpine empirica --version
 
 MIT License
 
-**GitHub:** [github.com/Nubaeon/empirica](https://github.com/Nubaeon/empirica)
+**GitHub:** [github.com/EmpiricaAI/empirica](https://github.com/EmpiricaAI/empirica)
 
 **Website:** [getempirica.com](https://getempirica.com)

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -69,5 +69,5 @@ HEALTHCHECK --interval=30s --timeout=3s --start-period=5s \
 CMD ["empirica", "--help"]
 
 # Security labels
-LABEL org.opencontainers.image.source="https://github.com/Nubaeon/empirica"
+LABEL org.opencontainers.image.source="https://github.com/EmpiricaAI/empirica"
 LABEL org.opencontainers.image.licenses="MIT"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > **We Gave AI a Mirror. Now It Measures What It Believes.**
 
-[![Version](https://img.shields.io/badge/version-1.12.4-blue)](https://github.com/Nubaeon/empirica/releases/tag/v1.12.4)
+[![Version](https://img.shields.io/badge/version-1.12.4-blue)](https://github.com/EmpiricaAI/empirica/releases/tag/v1.12.4)
 [![PyPI](https://img.shields.io/pypi/v/empirica)](https://pypi.org/project/empirica/)
 [![Python](https://img.shields.io/badge/python-3.10%2B-blue)]()
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
@@ -327,7 +327,7 @@ All read-only, all support `--output json`. Backs cross-project orchestration, C
 
 | Project | Description | Status |
 |---------|-------------|--------|
-| **[Empirica](https://github.com/Nubaeon/empirica)** | Core measurement system — epistemic transactions, Sentinel, calibration, 13 vectors | Open source |
+| **[Empirica](https://github.com/EmpiricaAI/empirica)** | Core measurement system — epistemic transactions, Sentinel, calibration, 13 vectors | Open source |
 | **[Empirica Iris](https://github.com/Nubaeon/empirica-iris)** | Epistemic browser automation with SVG spatial indexing — Sentinel gating for visual interactions | Open source |
 | **[Docpistemic](https://github.com/Nubaeon/docpistemic)** | Epistemic documentation coverage assessment — know what your docs know | Open source |
 | **[Breadcrumbs](https://github.com/Nubaeon/breadcrumbs)** | Survive context compacts with git notes — dead simple session continuity | Open source |
@@ -335,7 +335,7 @@ All read-only, all support `--output json`. Backs cross-project orchestration, C
 | **[Empirica Workspace](https://getempirica.com)** | Entity Knowledge Graph, Epistemic Prompt Engine, CRM, portfolio dashboard | Proprietary |
 | **[Empirica Extension](https://getempirica.com)** | Chrome extension — desktop face of the mesh. ECO Accept/Decline, inbox/outbox triage, publish review, conversation extraction from Claude.ai / ChatGPT / Gemini / Grok | Proprietary |
 
-**Building something with Empirica?** [Open an issue](https://github.com/Nubaeon/empirica/issues) to get listed.
+**Building something with Empirica?** [Open an issue](https://github.com/EmpiricaAI/empirica/issues) to get listed.
 
 ---
 
@@ -362,8 +362,8 @@ No cloud dependencies. No telemetry. Your epistemic data is yours.
 ## Community & Support
 
 - **Website:** [getempirica.com](https://getempirica.com)
-- **Issues:** [GitHub Issues](https://github.com/Nubaeon/empirica/issues)
-- **Discussions:** [GitHub Discussions](https://github.com/Nubaeon/empirica/discussions)
+- **Issues:** [GitHub Issues](https://github.com/EmpiricaAI/empirica/issues)
+- **Discussions:** [GitHub Discussions](https://github.com/EmpiricaAI/empirica/discussions)
 
 ---
 

--- a/docs/architecture/EPISTEMIC_STATE_COMPLETE_CAPTURE.md
+++ b/docs/architecture/EPISTEMIC_STATE_COMPLETE_CAPTURE.md
@@ -214,7 +214,7 @@
     "project_id": "def456",
     "name": "empirica",
     "description": "Empirica CLI and framework",
-    "repos": ["https://github.com/Nubaeon/empirica.git"],
+    "repos": ["https://github.com/EmpiricaAI/empirica.git"],
     "active_sessions": [
       {"session_id": "abc123", "ai_id": "empirica-hook-debug"},
       {"session_id": "xyz789", "ai_id": "qwen-testing"}

--- a/docs/human/developers/EXTENDING_EMPIRICA.md
+++ b/docs/human/developers/EXTENDING_EMPIRICA.md
@@ -404,4 +404,4 @@ def test_my_extension(db, bus):
 
 ---
 
-**Questions?** Open an issue at [github.com/Nubaeon/empirica](https://github.com/Nubaeon/empirica)
+**Questions?** Open an issue at [github.com/EmpiricaAI/empirica](https://github.com/EmpiricaAI/empirica)

--- a/docs/human/end-users/01_START_HERE.md
+++ b/docs/human/end-users/01_START_HERE.md
@@ -32,7 +32,7 @@ The core mechanic:
 pip install empirica
 
 # Or from source
-git clone https://github.com/Nubaeon/empirica.git
+git clone https://github.com/EmpiricaAI/empirica.git
 cd empirica && pip install -e .
 
 # Verify

--- a/docs/human/end-users/02_INSTALLATION.md
+++ b/docs/human/end-users/02_INSTALLATION.md
@@ -104,7 +104,7 @@ docker run -it -v $(pwd)/.empirica:/data/.empirica nubaeon/empirica:1.12.4 /bin/
 ### Option 4: From Source
 ```bash
 # Clone repository
-git clone https://github.com/Nubaeon/empirica.git
+git clone https://github.com/EmpiricaAI/empirica.git
 cd empirica
 
 # Install in development mode
@@ -310,7 +310,7 @@ For contributors or advanced users:
 
 ```bash
 # Clone repository
-git clone https://github.com/Nubaeon/empirica.git
+git clone https://github.com/EmpiricaAI/empirica.git
 cd empirica
 
 # Create virtual environment
@@ -388,7 +388,7 @@ rm -rf .empirica/
 
 - **Issues:** Check [03_TROUBLESHOOTING.md](03_TROUBLESHOOTING.md)
 - **Documentation:** Browse `docs/` directory
-- **Source code:** [github.com/Nubaeon/empirica](https://github.com/Nubaeon/empirica)
+- **Source code:** [github.com/EmpiricaAI/empirica](https://github.com/EmpiricaAI/empirica)
 
 ---
 

--- a/docs/human/end-users/ECOSYSTEM_OVERVIEW.md
+++ b/docs/human/end-users/ECOSYSTEM_OVERVIEW.md
@@ -69,7 +69,7 @@ that extend it:
 | **empirica-workspace** | TUI analytics, CRM (clients + engagements + memories), portfolio dashboards | `Nubaeon/empirica-workspace` |
 | **empirica-cortex** | Cross-AI orchestration — proposal pipeline, listener mesh, ECO trust gating (proprietary) | [getempirica.com](https://getempirica.com) |
 | **empirica-extension** | Browser extension surfacing artifacts in Chrome | `Nubaeon/empirica-extension` |
-| **empirica-mcp** | MCP server bridge for Claude Desktop / Cursor / etc. | `Nubaeon/empirica-mcp` |
+| **empirica-mcp** | MCP server bridge for Claude Desktop / Cursor / etc. | `EmpiricaAI/empirica` (`empirica-mcp/`) |
 
 Base empirica (this package) is the measurement + storage core. The
 extensions layer different surfaces on top.

--- a/docs/human/end-users/FIRST_TIME_SETUP.md
+++ b/docs/human/end-users/FIRST_TIME_SETUP.md
@@ -253,4 +253,4 @@ empirica project-init  # start over
 
 - **`empirica diagnose`** for integration checks
 - **`empirica --help`** or **`empirica <command> --help`**
-- **GitHub Issues:** https://github.com/Nubaeon/empirica/issues
+- **GitHub Issues:** https://github.com/EmpiricaAI/empirica/issues

--- a/docs/reference/api/SERVE_API.md
+++ b/docs/reference/api/SERVE_API.md
@@ -103,7 +103,7 @@ curl http://localhost:8000/api/v1/health
   "project_path": "/home/user/code/empirica",
   "project_name": "Empirica",
   "project_slug": "empirica",
-  "repo_url": "https://github.com/Nubaeon/empirica"
+  "repo_url": "https://github.com/EmpiricaAI/empirica"
 }
 ```
 

--- a/empirica-mcp/README.md
+++ b/empirica-mcp/README.md
@@ -236,9 +236,9 @@ docker run -p 3000:3000 nubaeon/empirica:1.6.6 empirica-mcp
 
 ## Documentation
 
-- [Empirica Documentation](https://github.com/Nubaeon/empirica/tree/main/docs)
+- [Empirica Documentation](https://github.com/EmpiricaAI/empirica/tree/main/docs)
 - [MCP Protocol](https://modelcontextprotocol.io)
 
 ## License
 
-MIT License - See [Empirica repository](https://github.com/Nubaeon/empirica) for details.
+MIT License - See [Empirica repository](https://github.com/EmpiricaAI/empirica) for details.

--- a/empirica-mcp/empirica_mcp/server.py
+++ b/empirica-mcp/empirica_mcp/server.py
@@ -1131,7 +1131,7 @@ async def call_tool(name: str, arguments: dict) -> list[types.TextContent]:
                         "purpose": "Measurement and calibration layer for AI — track what it knows, gate what it does",
                         "workflow": "PREFLIGHT → CHECK → work → POSTFLIGHT",
                         "vectors": 13,
-                        "docs": "https://github.com/Nubaeon/empirica",
+                        "docs": "https://github.com/EmpiricaAI/empirica",
                         "commands": sorted(TOOL_REGISTRY.keys()),
                     },
                     indent=2,

--- a/empirica-mcp/pyproject.toml
+++ b/empirica-mcp/pyproject.toml
@@ -28,10 +28,10 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/Nubaeon/empirica"
-Documentation = "https://github.com/Nubaeon/empirica/tree/main/docs"
-Repository = "https://github.com/Nubaeon/empirica"
-Issues = "https://github.com/Nubaeon/empirica/issues"
+Homepage = "https://github.com/EmpiricaAI/empirica"
+Documentation = "https://github.com/EmpiricaAI/empirica/tree/main/docs"
+Repository = "https://github.com/EmpiricaAI/empirica"
+Issues = "https://github.com/EmpiricaAI/empirica/issues"
 
 [project.scripts]
 empirica-mcp = "empirica_mcp.server:run"

--- a/empirica/cli/command_handlers/projects_commands.py
+++ b/empirica/cli/command_handlers/projects_commands.py
@@ -125,8 +125,8 @@ def _normalize_remote_url(raw: str) -> str | None:
     """Convert ssh-form remotes to https-form. Pass through https-form. None on garbage.
 
     Examples:
-      git@github.com:Nubaeon/empirica.git → https://github.com/Nubaeon/empirica
-      https://github.com/Nubaeon/empirica.git → https://github.com/Nubaeon/empirica
+      git@github.com:EmpiricaAI/empirica.git → https://github.com/EmpiricaAI/empirica
+      https://github.com/EmpiricaAI/empirica.git → https://github.com/EmpiricaAI/empirica
     """
     if not raw:
         return None

--- a/empirica/cli/command_handlers/setup_claude_code.py
+++ b/empirica/cli/command_handlers/setup_claude_code.py
@@ -758,7 +758,7 @@ def _register_marketplace(marketplace_dir, plugins_dir, claude_dir, plugin_dir, 
                 "name": PLUGIN_NAME,
                 "description": "Noetic firewall + CASCADE workflow automation for Claude Code",
                 "version": PLUGIN_VERSION,
-                "author": {"name": "Empirica Project", "url": "https://github.com/Nubaeon/empirica"},
+                "author": {"name": "Empirica Project", "url": "https://github.com/EmpiricaAI/empirica"},
                 "source": f"./{PLUGIN_NAME}",
                 "category": "productivity",
             }

--- a/empirica/plugins/claude-code-integration/.claude-plugin/plugin.json
+++ b/empirica/plugins/claude-code-integration/.claude-plugin/plugin.json
@@ -3,7 +3,7 @@
   "description": "4-phase epistemic transaction workflow (PREFLIGHT → CHECK → POSTFLIGHT → POST-TEST) with noetic firewall, dual-track calibration, and grounded verification for Claude Code",
   "author": {
     "name": "Empirica Project",
-    "url": "https://github.com/Nubaeon/empirica"
+    "url": "https://github.com/EmpiricaAI/empirica"
   },
   "version": "1.12.4"
 }

--- a/empirica/plugins/claude-code-integration/README.md
+++ b/empirica/plugins/claude-code-integration/README.md
@@ -230,7 +230,7 @@ You: "Fix the auth bug"
 
 ## Further Reading
 
-- [CLI Reference](https://github.com/Nubaeon/empirica/blob/main/docs/human/developers/CLI_COMMANDS_UNIFIED.md)
-- [Architecture](https://github.com/Nubaeon/empirica/tree/main/docs/architecture/)
+- [CLI Reference](https://github.com/EmpiricaAI/empirica/blob/main/docs/human/developers/CLI_COMMANDS_UNIFIED.md)
+- [Architecture](https://github.com/EmpiricaAI/empirica/tree/main/docs/architecture/)
 - [Training & Guides](https://getempirica.com)
-- [Upgrade Guide](https://github.com/Nubaeon/empirica/blob/main/docs/guides/UPGRADE_TO_1.9.md)
+- [Upgrade Guide](https://github.com/EmpiricaAI/empirica/blob/main/docs/guides/UPGRADE_TO_1.9.md)

--- a/empirica/plugins/claude-code-integration/install.sh
+++ b/empirica/plugins/claude-code-integration/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # empirica installer - one-line install for Claude Code
-# Usage: curl -fsSL https://raw.githubusercontent.com/Nubaeon/empirica/main/empirica/plugins/claude-code-integration/install.sh | bash
+# Usage: curl -fsSL https://raw.githubusercontent.com/EmpiricaAI/empirica/main/empirica/plugins/claude-code-integration/install.sh | bash
 #
 # This script installs empirica via pip and delegates plugin setup to
 # `empirica setup-claude-code`, which is the single canonical method

--- a/empirica/plugins/claude-code-integration/skills/epistemic-persistence-protocol/SKILL.md
+++ b/empirica/plugins/claude-code-integration/skills/epistemic-persistence-protocol/SKILL.md
@@ -11,7 +11,7 @@ description: >
   This skill prevents both full capitulation (abandoning positions under emotional
   pressure) and inverse sycophancy (resisting all pushback uniformly). It replaces
   the Anti-Agreement Protocol (AAP) with a calibrated, evidence-gated approach.
-  Part of the Empirica epistemic measurement framework (github.com/Nubaeon/empirica).
+  Part of the Empirica epistemic measurement framework (github.com/EmpiricaAI/empirica).
 ---
 
 # Epistemic Persistence Protocol (EPP)
@@ -254,7 +254,7 @@ Part of the Empirica epistemic measurement and governance framework.
 Developed to address RLHF-induced sycophancy through architectural
 epistemic governance rather than prompt-level instruction.
 
-MIT License — github.com/Nubaeon/empirica
+MIT License — github.com/EmpiricaAI/empirica
 
 The Epistemic Persistence Protocol was designed by David (Nubaeon) and Claude
 as a CASCADE module addressing calibrated position-holding under pushback.

--- a/examples/README.md
+++ b/examples/README.md
@@ -54,5 +54,5 @@ This means:
 
 ## Requires
 
-- [Empirica](https://github.com/Nubaeon/empirica) (`pip install empirica`)
+- [Empirica](https://github.com/EmpiricaAI/empirica) (`pip install empirica`)
 - Claude Code with Empirica plugin (`empirica setup-claude-code --force`)

--- a/examples/codebase-onboarder/README.md
+++ b/examples/codebase-onboarder/README.md
@@ -54,5 +54,5 @@ REST API for managing customer orders with Stripe payment integration. (confiden
 
 ## Requires
 
-- [Empirica](https://github.com/Nubaeon/empirica) installed (`pip install empirica`)
+- [Empirica](https://github.com/EmpiricaAI/empirica) installed (`pip install empirica`)
 - Claude Code with Empirica plugin (`empirica setup-claude-code --force`)

--- a/examples/competitor-monitor/README.md
+++ b/examples/competitor-monitor/README.md
@@ -75,6 +75,6 @@ This works because Empirica's findings persist across sessions. The agent search
 
 ## Requires
 
-- [Empirica](https://github.com/Nubaeon/empirica) installed (`pip install empirica`)
+- [Empirica](https://github.com/EmpiricaAI/empirica) installed (`pip install empirica`)
 - Claude Code with Empirica plugin (`empirica setup-claude-code --force`)
 - Web access (for fetching competitor pages)

--- a/examples/missed-opportunities/README.md
+++ b/examples/missed-opportunities/README.md
@@ -61,6 +61,6 @@ The agent works with whatever data you point it at:
 
 ## Requires
 
-- [Empirica](https://github.com/Nubaeon/empirica) installed (`pip install empirica`)
+- [Empirica](https://github.com/EmpiricaAI/empirica) installed (`pip install empirica`)
 - Claude Code with Empirica plugin (`empirica setup-claude-code --force`)
 - Your business data in an accessible format

--- a/examples/token-budget/README.md
+++ b/examples/token-budget/README.md
@@ -53,5 +53,5 @@ cp agent.md ~/.claude/plugins/local/empirica/agents/token-budget.md
 
 ## Requires
 
-- [Empirica](https://github.com/Nubaeon/empirica) installed (`pip install empirica`)
+- [Empirica](https://github.com/EmpiricaAI/empirica) installed (`pip install empirica`)
 - Claude Code session transcripts (`.claude/projects/*/*.jsonl`)

--- a/packaging/chocolatey/PUSH_INSTRUCTIONS.md
+++ b/packaging/chocolatey/PUSH_INSTRUCTIONS.md
@@ -15,7 +15,7 @@ iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocola
 
 ### 2. Clone Repo and Navigate
 ```powershell
-git clone https://github.com/Nubaeon/empirica.git
+git clone https://github.com/EmpiricaAI/empirica.git
 cd empirica/packaging/chocolatey
 ```
 

--- a/packaging/chocolatey/packaging/chocolatey/VERIFICATION.txt
+++ b/packaging/chocolatey/packaging/chocolatey/VERIFICATION.txt
@@ -16,4 +16,4 @@ Package can be verified like this:
    - Use Chocolatey utility 'checksum.exe'
 
 File 'LICENSE.txt' is obtained from:
-   https://github.com/Nubaeon/empirica/blob/main/LICENSE
+   https://github.com/EmpiricaAI/empirica/blob/main/LICENSE

--- a/packaging/homebrew/empirica.rb
+++ b/packaging/homebrew/empirica.rb
@@ -12,7 +12,7 @@ class Empirica < Formula
   include Language::Python::Virtualenv
 
   desc "Epistemic self-assessment framework for AI agents"
-  homepage "https://github.com/Nubaeon/empirica"
+  homepage "https://github.com/EmpiricaAI/empirica"
   url "https://files.pythonhosted.org/packages/source/e/empirica/empirica-1.12.4.tar.gz"
   sha256 "37c7ac888ffa5c83f1db938f9451e58e2d63f915d64aa3b6fbef542a59b038ab"
   license "MIT"

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -403,8 +403,8 @@ class ReleaseManager:
             # README.md version badge and footer
             (
                 self.repo_root / "README.md",
-                r'badge/version-[0-9]+\.[0-9]+\.[0-9]+-blue\)\]\(https://github\.com/Nubaeon/empirica/releases/tag/v[0-9]+\.[0-9]+\.[0-9]+\)',
-                f'badge/version-{self.version}-blue)](https://github.com/Nubaeon/empirica/releases/tag/v{self.version})',
+                r'badge/version-[0-9]+\.[0-9]+\.[0-9]+-blue\)\]\(https://github\.com/EmpiricaAI/empirica/releases/tag/v[0-9]+\.[0-9]+\.[0-9]+\)',
+                f'badge/version-{self.version}-blue)](https://github.com/EmpiricaAI/empirica/releases/tag/v{self.version})',
             ),
             # README.md docker tag references (standalone — added 1.8.16 to plug the
             # gap that left "nubaeon/empirica:1.8.14" lying around after the 1.8.15
@@ -1324,7 +1324,7 @@ brew install empirica
             info(f"PyPI (MCP): https://pypi.org/project/empirica-mcp/{self.version}/")
             info(f"Docker: docker pull nubaeon/empirica:{self.version}")
             info(f"Docker: docker pull nubaeon/empirica:{self.version}-alpine")
-            info(f"GitHub: https://github.com/Nubaeon/empirica/releases/tag/v{self.version}")
+            info(f"GitHub: https://github.com/EmpiricaAI/empirica/releases/tag/v{self.version}")
             info(f"Homebrew: brew upgrade empirica")
             info(f"Chocolatey: choco upgrade empirica")
 
@@ -1399,7 +1399,7 @@ brew install empirica
             info(f"PyPI (MCP): https://pypi.org/project/empirica-mcp/{self.version}/")
             info(f"Docker: docker pull nubaeon/empirica:{self.version}")
             info(f"Docker: docker pull nubaeon/empirica:{self.version}-alpine")
-            info(f"GitHub: https://github.com/Nubaeon/empirica/releases/tag/v{self.version}")
+            info(f"GitHub: https://github.com/EmpiricaAI/empirica/releases/tag/v{self.version}")
             info(f"Homebrew: brew upgrade empirica")
             info(f"Chocolatey: choco upgrade empirica")
 

--- a/tests/test_daemon_project_resolver.py
+++ b/tests/test_daemon_project_resolver.py
@@ -260,20 +260,20 @@ def test_read_git_remote_normalizes_ssh_form(tmp_path, monkeypatch):
     def _fake_run(*args, **kwargs):
         from types import SimpleNamespace
 
-        return SimpleNamespace(returncode=0, stdout="git@github.com:Nubaeon/empirica.git\n")
+        return SimpleNamespace(returncode=0, stdout="git@github.com:EmpiricaAI/empirica.git\n")
 
     monkeypatch.setattr("subprocess.run", _fake_run)
-    assert _read_git_remote(tmp_path) == "https://github.com/Nubaeon/empirica"
+    assert _read_git_remote(tmp_path) == "https://github.com/EmpiricaAI/empirica"
 
 
 def test_read_git_remote_strips_dot_git_from_https(tmp_path, monkeypatch):
     def _fake_run(*args, **kwargs):
         from types import SimpleNamespace
 
-        return SimpleNamespace(returncode=0, stdout="https://github.com/Nubaeon/empirica.git\n")
+        return SimpleNamespace(returncode=0, stdout="https://github.com/EmpiricaAI/empirica.git\n")
 
     monkeypatch.setattr("subprocess.run", _fake_run)
-    assert _read_git_remote(tmp_path) == "https://github.com/Nubaeon/empirica"
+    assert _read_git_remote(tmp_path) == "https://github.com/EmpiricaAI/empirica"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_projects_discover.py
+++ b/tests/test_projects_discover.py
@@ -161,15 +161,17 @@ def test_walk_finds_nested_projects_when_outer_is_also_a_project(tmp_path):
 
 
 def test_normalize_ssh_form_strips_git_suffix():
-    assert _normalize_remote_url("git@github.com:Nubaeon/empirica.git") == "https://github.com/Nubaeon/empirica"
+    assert _normalize_remote_url("git@github.com:EmpiricaAI/empirica.git") == "https://github.com/EmpiricaAI/empirica"
 
 
 def test_normalize_ssh_form_without_git_suffix():
-    assert _normalize_remote_url("git@github.com:Nubaeon/empirica") == "https://github.com/Nubaeon/empirica"
+    assert _normalize_remote_url("git@github.com:EmpiricaAI/empirica") == "https://github.com/EmpiricaAI/empirica"
 
 
 def test_normalize_https_form_strips_git_suffix():
-    assert _normalize_remote_url("https://github.com/Nubaeon/empirica.git") == "https://github.com/Nubaeon/empirica"
+    assert (
+        _normalize_remote_url("https://github.com/EmpiricaAI/empirica.git") == "https://github.com/EmpiricaAI/empirica"
+    )
 
 
 def test_normalize_http_form_passes_through():


### PR DESCRIPTION
## What

Updates the moved repo's GitHub URLs after `empirica` transferred **Nubaeon → EmpiricaAI**.

**Key finding:** this was a **single-repo transfer, not an org rename.** Verified `EmpiricaAI/empirica-iris` does not exist and `Nubaeon/empirica-iris` still does — so the sibling repos (`empirica-iris`, `-cortex`, `-extension`, `-workspace`) stay on Nubaeon. A naive `s/Nubaeon\/empirica/EmpiricaAI\/empirica/` would have broken those links.

## Surgical approach

- **`Nubaeon/empirica`** → `EmpiricaAI/empirica`, case-sensitive with a **negative-lookahead** (`(?![-\w])`) so the `-iris`/`-cortex`/etc. siblings are protected.
- Case-sensitivity also auto-skips lowercase **Docker Hub** `nubaeon/empirica` and **Homebrew** `nubaeon/tap` — separate registry namespaces that did **not** move (changing them would point at nonexistent images).
- shields.io badge label `Nubaeon%2Fempirica` → `EmpiricaAI%2Fempirica`.
- `release.py` badge regex + emit strings, `plugin.json` author URL, all README/doc links.
- **`ECOSYSTEM_OVERVIEW`**: the `empirica-mcp` repo cell was a phantom — `Nubaeon/empirica-mcp` 404s on *both* orgs because empirica-mcp lives in this monorepo (`empirica-mcp/`), not a separate repo. Repointed at `EmpiricaAI/empirica`.

## Verification

- 35 files, **78/78 symmetric** (pure find-replace)
- Normalization **test fixtures** (`test_projects_discover`, `test_daemon_project_resolver`) had `Nubaeon/empirica` on both input and expected sides → rewriting both keeps them consistent; **80 tests green**
- ruff + `ruff format --check` clean across CI scope
- Sibling Nubaeon repos + Docker/Homebrew refs confirmed untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)