### PR TITLE
chore(repo): transferred-sibling URLs Nubaeon → EmpiricaAI (cortex/extension/workspace + homebrew-tap)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ empirica setup-claude-code --force
 <summary>Homebrew (macOS)</summary>
 
 ```bash
-brew tap nubaeon/tap
+brew tap empiricaai/tap
 brew install empirica
 empirica setup-claude-code
 ```

--- a/docs/architecture/CI_CD.md
+++ b/docs/architecture/CI_CD.md
@@ -105,11 +105,11 @@ Missing secrets → step skips with a `::warning::` (forks don't break).
 
 ### Homebrew tap
 
-The workflow checks out `Nubaeon/homebrew-tap`, updates `Formula/empirica.rb`
+The workflow checks out `EmpiricaAI/homebrew-tap`, updates `Formula/empirica.rb`
 with the new version + sha256, commits + pushes.
 
 Required secret:
-- `HOMEBREW_TAP_TOKEN` — PAT with `repo` scope on `Nubaeon/homebrew-tap`
+- `HOMEBREW_TAP_TOKEN` — PAT with `repo` scope on `EmpiricaAI/homebrew-tap`
 
 Missing token → step skips with a `::warning::`.
 

--- a/docs/human/end-users/01_START_HERE.md
+++ b/docs/human/end-users/01_START_HERE.md
@@ -193,7 +193,7 @@ For more: [03_TROUBLESHOOTING.md](03_TROUBLESHOOTING.md).
 
 ### For Teams
 
-- **[empirica-workspace](https://github.com/Nubaeon/empirica-workspace)** — cross-project calibration, multi-entity pattern matching, TUI analytics
+- **[empirica-workspace](https://github.com/EmpiricaAI/empirica-workspace)** — cross-project calibration, multi-entity pattern matching, TUI analytics
 
 ---
 

--- a/docs/human/end-users/02_INSTALLATION.md
+++ b/docs/human/end-users/02_INSTALLATION.md
@@ -85,7 +85,7 @@ pip install --upgrade empirica
 
 ### Option 2: Homebrew (macOS)
 ```bash
-brew tap nubaeon/tap
+brew tap empiricaai/tap
 brew install empirica
 ```
 

--- a/docs/human/end-users/ECOSYSTEM_OVERVIEW.md
+++ b/docs/human/end-users/ECOSYSTEM_OVERVIEW.md
@@ -66,9 +66,9 @@ that extend it:
 
 | Layer | What it adds | Repo |
 |---|---|---|
-| **empirica-workspace** | TUI analytics, CRM (clients + engagements + memories), portfolio dashboards | `Nubaeon/empirica-workspace` |
+| **empirica-workspace** | TUI analytics, CRM (clients + engagements + memories), portfolio dashboards | `EmpiricaAI/empirica-workspace` |
 | **empirica-cortex** | Cross-AI orchestration — proposal pipeline, listener mesh, ECO trust gating (proprietary) | [getempirica.com](https://getempirica.com) |
-| **empirica-extension** | Browser extension surfacing artifacts in Chrome | `Nubaeon/empirica-extension` |
+| **empirica-extension** | Browser extension surfacing artifacts in Chrome | `EmpiricaAI/empirica-extension` |
 | **empirica-mcp** | MCP server bridge for Claude Desktop / Cursor / etc. | `EmpiricaAI/empirica` (`empirica-mcp/`) |
 
 Base empirica (this package) is the measurement + storage core. The

--- a/docs/human/end-users/MCP_INSTALLATION.md
+++ b/docs/human/end-users/MCP_INSTALLATION.md
@@ -26,7 +26,7 @@ which empirica-mcp     # verify on PATH
 
 Or via Homebrew:
 ```bash
-brew install nubaeon/tap/empirica
+brew install empiricaai/tap/empirica
 ```
 
 The `empirica-mcp` package ships its own entry point — it shells out to

--- a/docs/reference/CONFIGURATION_REFERENCE.md
+++ b/docs/reference/CONFIGURATION_REFERENCE.md
@@ -723,7 +723,7 @@ has_key = loader.has_credential("MINIMAX_API_KEY")
   - CHECK: `calibration_bias` (systematic bias detection)
   - Does NOT affect: POSTFLIGHT grounded verification (always runs), Sentinel gating (always uses raw vectors), learning trajectory (informational)
 
-> **Cross-project calibration, multi-entity pattern matching, TUI analytics, and API integrations** are available in [empirica-workspace](https://github.com/Nubaeon/empirica-workspace) — the commercial extension for teams and organizations.
+> **Cross-project calibration, multi-entity pattern matching, TUI analytics, and API integrations** are available in [empirica-workspace](https://github.com/EmpiricaAI/empirica-workspace) — the commercial extension for teams and organizations.
 
 ### Features
 

--- a/docs/reference/ENVIRONMENT_VARIABLES.md
+++ b/docs/reference/ENVIRONMENT_VARIABLES.md
@@ -92,7 +92,7 @@ This takes priority over the env var and is dynamically settable without restart
 
 Controls PREFLIGHT enrichment (grounded gaps, calibration warnings), CHECK enrichment (calibration bias detection). Does NOT affect POSTFLIGHT data collection, Sentinel gating (raw vectors), or learning trajectory (informational).
 
-> **Cross-project calibration, multi-entity pattern matching, TUI analytics, and API integrations** are available in [empirica-workspace](https://github.com/Nubaeon/empirica-workspace).
+> **Cross-project calibration, multi-entity pattern matching, TUI analytics, and API integrations** are available in [empirica-workspace](https://github.com/EmpiricaAI/empirica-workspace).
 
 ---
 

--- a/packaging/homebrew/empirica.rb
+++ b/packaging/homebrew/empirica.rb
@@ -2,10 +2,10 @@
 # Documentation: https://docs.brew.sh/Formula-Cookbook
 #
 # This is the packaging template. The actual formula is in:
-#   https://github.com/Nubaeon/homebrew-tap/blob/main/empirica.rb
+#   https://github.com/EmpiricaAI/homebrew-tap/blob/main/empirica.rb
 #
 # Installation:
-#   brew tap nubaeon/tap
+#   brew tap empiricaai/tap
 #   brew install empirica
 
 class Empirica < Formula

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -885,7 +885,7 @@ docker pull nubaeon/empirica:{self.version}
 
 ### Homebrew
 ```bash
-brew tap nubaeon/tap
+brew tap empiricaai/tap
 brew install empirica
 ```
 """

--- a/tests/test_daemon_project_resolver.py
+++ b/tests/test_daemon_project_resolver.py
@@ -357,7 +357,7 @@ def test_resolve_for_request_returns_uuid_project_id_for_uuid_yaml(tmp_path):
                 "slug": "empirica-cortex",
                 "name": "empirica-cortex",
                 "path": str(proj),
-                "repo_url": "https://github.com/Nubaeon/empirica-cortex",
+                "repo_url": "https://github.com/EmpiricaAI/empirica-cortex",
             }
         ],
     }
@@ -371,7 +371,7 @@ def test_resolve_for_request_returns_uuid_project_id_for_uuid_yaml(tmp_path):
     # Slug + name + repo_url still carry the human-readable form for routing.
     assert result["project_slug"] == "empirica-cortex"
     assert result["project_name"] == "empirica-cortex"
-    assert result["repo_url"] == "https://github.com/Nubaeon/empirica-cortex"
+    assert result["repo_url"] == "https://github.com/EmpiricaAI/empirica-cortex"
     assert result["project_path"] == str(proj)
 
 
@@ -391,7 +391,7 @@ def test_resolve_for_request_preserves_registry_metadata_overrides(tmp_path):
                 "slug": "empirica-extension",
                 "name": "Empirica Extension",  # human-friendly name
                 "path": str(proj),
-                "repo_url": "https://github.com/Nubaeon/empirica-extension",
+                "repo_url": "https://github.com/EmpiricaAI/empirica-extension",
             }
         ],
     }
@@ -403,7 +403,7 @@ def test_resolve_for_request_preserves_registry_metadata_overrides(tmp_path):
     assert result["project_id"] == uuid  # UUID for DB
     assert result["project_slug"] == "empirica-extension"  # registry override
     assert result["project_name"] == "Empirica Extension"  # registry override
-    assert result["repo_url"] == "https://github.com/Nubaeon/empirica-extension"
+    assert result["repo_url"] == "https://github.com/EmpiricaAI/empirica-extension"
 
 
 def test_resolve_for_request_slug_yaml_still_resolves(tmp_path):

--- a/tests/test_projects_bulk_register_scope.py
+++ b/tests/test_projects_bulk_register_scope.py
@@ -129,7 +129,7 @@ def test_registry_slug_preferred_over_name():
                 "slug": "empirica-cortex",
                 "name": "empirica-cortex",
                 "path": "/tmp/x",
-                "repo_url": "https://github.com/Nubaeon/empirica-cortex",
+                "repo_url": "https://github.com/EmpiricaAI/empirica-cortex",
             },
         ]
     )
@@ -148,7 +148,7 @@ def test_registry_slug_preferred_over_name():
 
     assert len(posted) == 1
     assert posted[0]["name"] == "empirica-cortex"
-    assert posted[0]["repo_url"] == "https://github.com/Nubaeon/empirica-cortex"
+    assert posted[0]["repo_url"] == "https://github.com/EmpiricaAI/empirica-cortex"
 
 
 # ─── Dry-run + force-metadata-update ────────────────────────────────


### PR DESCRIPTION
Follow-up to #149. After verifying transfer status repo-by-repo (gh + GitHub transfer-redirect + Docker Hub API), the **important siblings did transfer** to EmpiricaAI — so their URLs update too.

## Updated (transferred)
- `github.com/Nubaeon/empirica-{cortex,extension,workspace}` → EmpiricaAI (docs + URL-normalization test fixtures — fixtures rewrite input+expected consistently)
- **Homebrew** (the tap repo moved): `github.com/Nubaeon/homebrew-tap` → EmpiricaAI, `brew tap nubaeon/tap` → `empiricaai/tap` (README, formula comment, release.py message)

## Left untouched (verified)
- `empirica-iris`, `docpistemic`, `breadcrumbs`, `world-model-mcp` — **not** transferred, still on Nubaeon
- Docker Hub `nubaeon/empirica` — separate registry, did **not** move (API: `nubaeon/empirica` 200, `empiricaai/empirica` 404)
- `.github/workflows/release.yml` homebrew CI config — works via transfer-redirect (proven by the 1.12.4 publish). **Left for a separate, token-gated pass** — see note.

## ⚠️ Needs David before it matters for publish
`release.yml` still checks out `Nubaeon/homebrew-tap` with `HOMEBREW_TAP_TOKEN`. It works today via redirect, but to canonicalize it to `EmpiricaAI/homebrew-tap`, confirm the token has push access to the new location.

34 fixture tests green; ruff + format clean in CI scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)