### PR TITLE
fix(sentinel): deadlock-hardening — self-heal verbs never rush-blocked + stuck→collab reflex

### DIFF
--- a/empirica/plugins/claude-code-integration/hooks/sentinel-gate.py
+++ b/empirica/plugins/claude-code-integration/hooks/sentinel-gate.py
@@ -699,6 +699,11 @@ EMPIRICA_TIER2_PREFIXES = (
     "empirica profile-sync",
     "empirica profile-prune",  # Profile management - state-changing
     "empirica release",  # Release pipeline — mechanical, no PREFLIGHT needed
+    # Self-heal / maintenance verbs — must NEVER be rush-blocked, or a box with a
+    # stale hook can't run the very command that fixes it (deploy-staleness deadlock).
+    "empirica setup-claude-code",
+    "empirica plugin-sync",
+    "empirica plugin-version",
 )
 
 

--- a/empirica/plugins/claude-code-integration/skills/empirica-constitution/SKILL.md
+++ b/empirica/plugins/claude-code-integration/skills/empirica-constitution/SKILL.md
@@ -227,6 +227,17 @@ gate, ungated by the Sentinel). Do not guess in isolation when a peer
 can answer. Asking is the cheap path; the expensive path is shipping
 on a bad assumption and having a peer correct you at review time.
 
+**Stuck → collab is a reflex, not a courtesy.** "Pull when uncertain"
+is not only for clean knowledge gaps — it is the *first move* whenever
+you are blocked, looping, or stuck and your local attempts (1–2 tries)
+aren't resolving it. The mesh is always open: collab immediately
+(noetic, ungated), and if the fix needs a peer to *act*, propose
+(ECO/autonomy). Grinding a local blocker past a couple of attempts
+without surfacing it is the anti-pattern — the same free-ride as a
+dropped thread, just pointed inward. The blocker you can't crack alone
+is exactly what the mesh is for; the cost of grinding it silently lands
+on the user's time and on yours.
+
 **Push when convergent.** When you reach a grounded, actionable
 conclusion that crosses a practice boundary — a code change request,
 a spec update, an architecture decision — emit it as a typed propose

--- a/empirica/plugins/claude-code-integration/templates/empirica-system-prompt-lean.md
+++ b/empirica/plugins/claude-code-integration/templates/empirica-system-prompt-lean.md
@@ -351,6 +351,7 @@ For full CLI reference: load `/empirica-commands` skill.
 - When user mentions something unfamiliar: `project-search` before responding
 - Surface insights proactively — don't wait to be asked
 {% if cortex %}- **Pull your weight in the mesh.** Multi-practitioner teams are only as strong as everyone doing their share: pull when uncertain (collab — auto-accepted, cheap), push when convergent (typed propose — ECO-gated), ack what you complete (closes the source AI's outbox), don't drop threads (reply even if "can't help"), and register canonical sources at `--visibility shared` so peers reference rather than re-derive. Full framing: `/empirica-constitution` §V.{% endif %}
+{% if cortex %}- **Stuck → collab, immediately — it's a reflex, not a courtesy.** If you're blocked, looping, or genuinely uncertain and your local moves (1–2 attempts) aren't resolving it, collab the mesh right then (noetic — always open, ungated by the Sentinel); if you need a peer to *do* something, propose (ECO/autonomy). Grinding a local blocker past a couple of attempts without surfacing it to the mesh is the anti-pattern — the blocker you can't crack alone is exactly what the mesh is for.{% endif %}
 
 ---
 

--- a/tests/test_sentinel_recovery_escape.py
+++ b/tests/test_sentinel_recovery_escape.py
@@ -67,6 +67,36 @@ def test_recovery_verb_escapes_rush_guard(command):
     assert result is None, f"{command!r} should escape the gate (allow), got {result!r}"
 
 
+# --- self-heal verbs must escape the rush-guard (self-gated-fix gap) ---------- #
+# On a box with a stale hook, the very command that fixes the deadlock
+# (setup-claude-code / plugin-sync) must NOT itself be rush-blocked, or there is
+# no escape without a manual sentinel-pause.
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        "empirica setup-claude-code",
+        "empirica setup-claude-code --force",
+        "empirica plugin-sync",
+        "empirica plugin-version",
+    ],
+)
+def test_self_heal_verbs_allow_listed(cmd):
+    assert sg.is_safe_empirica_command(cmd) is True
+
+
+@pytest.mark.parametrize("command", ["empirica setup-claude-code --force", "empirica plugin-sync"])
+def test_self_heal_verb_escapes_rush_guard(command):
+    result = sg._validate_check_record(
+        None,
+        "sess",
+        None,
+        0,
+        tool_input={"command": command},
+        tool_name="Bash",
+    )
+    assert result is None, f"{command!r} (self-heal) must escape the gate, got {result!r}"
+
+
 def test_noetic_tool_escapes_rush_guard():
     result = sg._validate_check_record(
         None,


### PR DESCRIPTION
Two fixes for the recurring "Rushed assessment" deadlock class (reported via the mesh; David-directed). Pairs with the plugin auto-sync PR.

## A) The self-heal command was self-gated
On a box with a **stale hook**, `empirica setup-claude-code --force` (and the plugin-sync verbs) were **not** in the rush-bypass whitelist — so the very command that fixes the deadlock got rush-blocked. No escape without a manual sentinel-pause.

**Fix:** added `setup-claude-code` / `plugin-sync` / `plugin-version` to `EMPIRICA_TIER2_PREFIXES` (alongside the existing `empirica release` maintenance-verb precedent), so they always escape the rush guard via the recovery hoist. Combined with the session-init plugin auto-heal: a stale box self-heals at next session-init, and if that window is missed the manual fix is always runnable.

## B) Stuck → collab is now a reflex (David's directive)
Elevated the mesh framing from optional "pull when uncertain" to a **stuck→collab reflex** in the lean system-prompt template (PROACTIVE BEHAVIORS) + constitution §V:

> blocked / looping / uncertain and local moves (1–2 attempts) aren't resolving it → collab the mesh immediately (noetic); need a peer to *act* → propose (ECO/autonomy). Grinding a local blocker past a couple of attempts without surfacing it is the anti-pattern.

## Tests
4 new tests (self-heal verbs allow-listed + escape the rush-guard); 17 recovery-escape tests green; ruff + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)