### PR TITLE
fix(sentinel): resolve practice ai_id → live runtime instance (practitioner-identity ①)

### DIFF
--- a/empirica/cli/command_handlers/cockpit_commands.py
+++ b/empirica/cli/command_handlers/cockpit_commands.py
@@ -77,6 +77,102 @@ def _resolve_instance_id(args, fallback_to_current: bool = True) -> str | None:
     return None
 
 
+class SentinelResolveError(ValueError):
+    """A sentinel target could not be resolved to a live runtime instance, or
+    resolved ambiguously (a practice ai_id mapping to >1 live instance with no
+    --all/--session selector).
+
+    This is the loud-fail invariant for practitioner-identity phase ①
+    (docs/architecture/instance_isolation/PRACTITIONER_IDENTITY.md §6). It
+    replaces the silent pause-miss class: `sentinel pause --instance <ai_id>`
+    used to write sentinel_paused_<ai_id> while the gate — keyed on the runtime
+    instance_id (tmux_N) — never read it, so the pauser saw success but nothing
+    paused. Now a no-match / ambiguous target is an explicit error.
+
+    Inherits ValueError (not SystemExit) so `except Exception` callers catch it
+    cleanly. Same hazard pattern as InstanceIdRequiredError below.
+    """
+
+
+def _resolve_sentinel_targets(args) -> list[str | None]:
+    """Resolve sentinel pause/resume/status target(s) from args.
+
+    Returns the list of instance_ids the verb should act on:
+      - [None]          → no selector: current process / global (legacy default)
+      - [instance_id]   → one resolved live runtime instance
+      - [id1, id2, ...] → --all fan-out across a practice's live instances
+
+    Resolution order:
+      1. No --instance / --session / --all → [get_instance_id()] (may be None →
+         global), preserving the pre-① default.
+      2. --session <claude_session_id>     → the live instance running it.
+      3. --instance <X> where X is a live runtime instance_id → [X] (back-compat
+         passthrough — the common autonomy/cockpit path).
+      4. --instance <X> where X is a practice ai_id:
+           1 live instance  → [that instance_id]   (the ① fix: ai_id → runtime)
+           0 live instances → SentinelResolveError  (the silent-miss class)
+           N>1 live         → SentinelResolveError unless --all (decision-2:
+                              no silent fan-out — require --session/--all)
+
+    Raises SentinelResolveError on no-match or unresolved ambiguity (loud-fail).
+    """
+    requested = getattr(args, "instance", None)
+    session = getattr(args, "session", None)
+    want_all = bool(getattr(args, "all", False))
+
+    if not requested and not session and not want_all:
+        return [get_instance_id()]  # may be None → global pause (unchanged)
+
+    # Snapshot live instances once. Each carries {instance_id, ai_id, session_id}.
+    try:
+        live = aggregate_all(include_dead=False).get("instances", [])
+    except Exception:  # discovery failure must not silently mis-target
+        live = []
+
+    def _fmt(insts: list[dict[str, Any]]) -> str:
+        return ", ".join(f"{i.get('ai_id') or '?'}/{i.get('instance_id') or '?'}" for i in insts) or "(none)"
+
+    # --session wins: resolve to the live instance running that conversation.
+    if session:
+        matches = [i["instance_id"] for i in live if i.get("session_id") == session]
+        if not matches:
+            raise SentinelResolveError(f"no live instance for session '{session}'. Live: {_fmt(live)}")
+        return matches
+
+    # Direct runtime instance_id match → passthrough (back-compat fast path).
+    if requested and any(i.get("instance_id") == requested for i in live):
+        return [requested]
+
+    # --all with no --instance → every live instance (whole-fleet quarantine).
+    if want_all and not requested:
+        ids = [i["instance_id"] for i in live]
+        if not ids:
+            raise SentinelResolveError("no live instances to target with --all")
+        return ids
+
+    # Practice (ai_id) resolution.
+    practice = [i["instance_id"] for i in live if i.get("ai_id") == requested]
+    if not practice:
+        # 0 → loud error (the silent pause-miss class being killed).
+        raise SentinelResolveError(
+            f"no live runtime instance for '{requested}' (not a live instance_id, and no live "
+            f"instance has ai_id '{requested}'). Live: {_fmt(live)}"
+        )
+    if len(practice) == 1:
+        return practice  # the fix: ai_id → its single live runtime instance
+    if want_all:
+        return practice  # deliberate whole-practice fan-out (decision-2)
+    raise SentinelResolveError(
+        f"'{requested}' resolves to {len(practice)} live instances ({practice}). "
+        f"Pass --instance <runtime-id>, --session <claude_session_id>, or --all."
+    )
+
+
+def _emit_sentinel_error(args, message: str) -> int:
+    """Loud-fail emit for an unresolved/ambiguous sentinel target (exit 1)."""
+    return _emit(args, {"ok": False, "error": message}, f"error: {message}")
+
+
 def _emit(args, payload: dict[str, Any], human_summary: str) -> int:
     """Emit JSON or human output based on --output."""
     fmt = getattr(args, "output", "human")
@@ -91,64 +187,110 @@ def _emit(args, payload: dict[str, Any], human_summary: str) -> int:
 
 
 def handle_sentinel_pause_command(args) -> int:
-    instance_id = _resolve_instance_id(args, fallback_to_current=True)
+    try:
+        targets = _resolve_sentinel_targets(args)
+    except SentinelResolveError as e:
+        return _emit_sentinel_error(args, str(e))
     reason = getattr(args, "reason", None)
-    status = pause_sentinel(instance_id, reason=reason)
+    statuses = [pause_sentinel(t, reason=reason) for t in targets]
+    if len(statuses) == 1:
+        status = statuses[0]
+        payload = {
+            "ok": True,
+            "paused": status.paused,
+            "instance_id": status.instance_id,
+            "scope": status.scope,
+            "since": status.since,
+            "reason": status.reason,
+        }
+        target = status.instance_id or "global"
+        summary = f"Sentinel paused for {target}"
+        if status.reason:
+            summary += f" (reason: {status.reason})"
+        return _emit(args, payload, summary)
     payload = {
         "ok": True,
-        "paused": status.paused,
-        "instance_id": status.instance_id,
-        "scope": status.scope,
-        "since": status.since,
-        "reason": status.reason,
+        "paused_count": len(statuses),
+        "instances": [{"instance_id": s.instance_id, "paused": s.paused, "scope": s.scope} for s in statuses],
     }
-    target = status.instance_id or "global"
-    summary = f"Sentinel paused for {target}"
-    if status.reason:
-        summary += f" (reason: {status.reason})"
-    return _emit(args, payload, summary)
+    ids = ", ".join(s.instance_id or "global" for s in statuses)
+    return _emit(args, payload, f"Sentinel paused for {len(statuses)} instances: {ids}")
 
 
 def handle_sentinel_resume_command(args) -> int:
-    instance_id = _resolve_instance_id(args, fallback_to_current=True)
-    status = resume_sentinel(instance_id)
+    try:
+        targets = _resolve_sentinel_targets(args)
+    except SentinelResolveError as e:
+        return _emit_sentinel_error(args, str(e))
+    results = [(t, resume_sentinel(t)) for t in targets]
+    if len(results) == 1:
+        instance_id, status = results[0]
+        payload = {
+            "ok": True,
+            "paused": status.paused,
+            "instance_id": status.instance_id,
+            "scope": status.scope,
+        }
+        target = instance_id or "global"
+        if status.paused:
+            # The instance pause was removed but a global pause still applies.
+            summary = (
+                f"Sentinel resume requested for {target}, but global pause is still in effect (scope={status.scope})"
+            )
+        else:
+            summary = f"Sentinel resumed for {target}"
+        return _emit(args, payload, summary)
     payload = {
         "ok": True,
-        "paused": status.paused,
-        "instance_id": status.instance_id,
-        "scope": status.scope,
+        "resumed_count": len(results),
+        "instances": [{"instance_id": s.instance_id, "paused": s.paused, "scope": s.scope} for _, s in results],
     }
-    target = instance_id or "global"
-    if status.paused:
-        # The instance pause was removed but a global pause still applies.
-        summary = f"Sentinel resume requested for {target}, but global pause is still in effect (scope={status.scope})"
-    else:
-        summary = f"Sentinel resumed for {target}"
-    return _emit(args, payload, summary)
+    ids = ", ".join((iid or "global") for iid, _ in results)
+    return _emit(args, payload, f"Sentinel resume requested for {len(results)} instances: {ids}")
 
 
 def handle_sentinel_status_command_cockpit(args) -> int:
     """`empirica sentinel status` — distinct from existing `sentinel-status`."""
-    instance_id = _resolve_instance_id(args, fallback_to_current=True)
-    status = sentinel_status(instance_id)
+    try:
+        targets = _resolve_sentinel_targets(args)
+    except SentinelResolveError as e:
+        return _emit_sentinel_error(args, str(e))
+    statuses = [sentinel_status(t) for t in targets]
+    if len(statuses) == 1:
+        status = statuses[0]
+        payload = {
+            "ok": True,
+            "paused": status.paused,
+            "instance_id": status.instance_id,
+            "scope": status.scope,
+            "since": status.since,
+            "reason": status.reason,
+        }
+        target = status.instance_id or "global"
+        if status.paused:
+            summary = f"Sentinel PAUSED for {target} (scope={status.scope})"
+            if status.since:
+                summary += f" since {status.since}"
+            if status.reason:
+                summary += f" — {status.reason}"
+        else:
+            summary = f"Sentinel ON for {target}"
+        return _emit(args, payload, summary)
     payload = {
         "ok": True,
-        "paused": status.paused,
-        "instance_id": status.instance_id,
-        "scope": status.scope,
-        "since": status.since,
-        "reason": status.reason,
+        "instances": [
+            {
+                "instance_id": s.instance_id,
+                "paused": s.paused,
+                "scope": s.scope,
+                "since": s.since,
+                "reason": s.reason,
+            }
+            for s in statuses
+        ],
     }
-    target = status.instance_id or "global"
-    if status.paused:
-        summary = f"Sentinel PAUSED for {target} (scope={status.scope})"
-        if status.since:
-            summary += f" since {status.since}"
-        if status.reason:
-            summary += f" — {status.reason}"
-    else:
-        summary = f"Sentinel ON for {target}"
-    return _emit(args, payload, summary)
+    parts = [f"{(s.instance_id or 'global')}={'PAUSED' if s.paused else 'ON'}" for s in statuses]
+    return _emit(args, payload, "Sentinel status — " + ", ".join(parts))
 
 
 # ─── empirica loop ──────────────────────────────────────────────────────────

--- a/empirica/cli/parsers/cockpit_parsers.py
+++ b/empirica/cli/parsers/cockpit_parsers.py
@@ -26,6 +26,34 @@ def _add_instance(parser):
     )
 
 
+def _add_sentinel_target(parser):
+    """Target selection for sentinel pause/resume/status verbs.
+
+    Beyond a raw runtime --instance, accepts a practice ai_id (resolved to its
+    live runtime instance), --session <claude_session_id>, or --all (fan out
+    across a practice's live instances). No-match / ambiguous resolution fails
+    loud — practitioner-identity phase ①
+    (docs/architecture/instance_isolation/PRACTITIONER_IDENTITY.md §6).
+    """
+    parser.add_argument(
+        "--instance",
+        metavar="ID",
+        help="Target instance_id OR a practice ai_id (resolved to its live runtime instance; "
+        "no-match or ambiguous resolution fails loud)",
+    )
+    parser.add_argument(
+        "--session",
+        metavar="SESSION_ID",
+        help="Target the live instance running this claude_session_id",
+    )
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Fan out across ALL live instances of the resolved practice "
+        "(required when an ai_id maps to >1 live instance)",
+    )
+
+
 def add_cockpit_parsers(subparsers):
     """Register sentinel/loop/listener/instance subcommand groups + top-level status + tui."""
     _add_sentinel_group(subparsers)
@@ -100,15 +128,15 @@ def _add_sentinel_group(subparsers):
 
     pause = sentinel_subs.add_parser("pause", help="Pause Sentinel for an instance")
     pause.add_argument("--reason", help="Optional human-readable reason for the pause")
-    _add_instance(pause)
+    _add_sentinel_target(pause)
     _add_output(pause)
 
     resume = sentinel_subs.add_parser("resume", help="Resume Sentinel for an instance")
-    _add_instance(resume)
+    _add_sentinel_target(resume)
     _add_output(resume)
 
     status = sentinel_subs.add_parser("status", help="Show Sentinel pause state")
-    _add_instance(status)
+    _add_sentinel_target(status)
     _add_output(status)
 
 

--- a/tests/test_sentinel_target_resolve.py
+++ b/tests/test_sentinel_target_resolve.py
@@ -1,0 +1,147 @@
+"""Tests for the practitioner-identity phase ① sentinel target resolver.
+
+`_resolve_sentinel_targets` is the band-aid that kills the silent pause-miss:
+`empirica sentinel pause --instance <ai_id>` used to write sentinel_paused_<ai_id>
+while the gate (keyed on the runtime instance_id) never read it — the pauser saw
+success, nothing paused. The resolver now maps a practice ai_id to its live
+runtime instance, fails LOUD on no-match (the silent-miss class), and requires
+--session/--all when an ai_id is ambiguous (>1 live instance — decision-2: no
+silent fan-out).
+
+See docs/architecture/instance_isolation/PRACTITIONER_IDENTITY.md §6.
+"""
+
+from __future__ import annotations
+
+import types
+
+import pytest
+
+from empirica.cli.command_handlers import cockpit_commands as cc
+
+
+def _inst(instance_id, ai_id=None, session_id=None):
+    return {"instance_id": instance_id, "ai_id": ai_id, "session_id": session_id, "alive": True}
+
+
+def _args(**kw):
+    base = {"instance": None, "session": None, "all": False, "output": "json", "reason": None}
+    base.update(kw)
+    return types.SimpleNamespace(**base)
+
+
+@pytest.fixture
+def patch_live(monkeypatch):
+    """Override cockpit_commands.aggregate_all with a controlled live-instance set."""
+
+    def _set(*instances):
+        monkeypatch.setattr(cc, "aggregate_all", lambda include_dead=False: {"instances": list(instances)})
+
+    return _set
+
+
+# ── default / passthrough ────────────────────────────────────────────────────
+
+
+def test_no_selector_uses_current_instance(monkeypatch, patch_live):
+    patch_live(_inst("tmux_5", ai_id="empirica"))
+    monkeypatch.setattr(cc, "get_instance_id", lambda: "tmux_5")
+    assert cc._resolve_sentinel_targets(_args()) == ["tmux_5"]
+
+
+def test_no_selector_global_when_no_current(monkeypatch, patch_live):
+    patch_live()
+    monkeypatch.setattr(cc, "get_instance_id", lambda: None)
+    assert cc._resolve_sentinel_targets(_args()) == [None]
+
+
+def test_direct_instance_id_passthrough(patch_live):
+    patch_live(_inst("tmux_3", ai_id="empirica"), _inst("tmux_8", ai_id="cortex"))
+    assert cc._resolve_sentinel_targets(_args(instance="tmux_3")) == ["tmux_3"]
+
+
+# ── ai_id resolution (the fix) ───────────────────────────────────────────────
+
+
+def test_ai_id_single_resolves_to_runtime(patch_live):
+    patch_live(_inst("tmux_8", ai_id="empirica"))
+    # The ① fix: --instance <ai_id> → its live runtime instance, not verbatim.
+    assert cc._resolve_sentinel_targets(_args(instance="empirica")) == ["tmux_8"]
+
+
+def test_ai_id_no_live_instance_is_loud(patch_live):
+    patch_live(_inst("tmux_8", ai_id="cortex"))
+    with pytest.raises(cc.SentinelResolveError):
+        cc._resolve_sentinel_targets(_args(instance="empirica"))
+
+
+def test_unknown_instance_id_is_loud(patch_live):
+    # Previously a silent success: wrote sentinel_paused_<ghost> the gate never reads.
+    patch_live(_inst("tmux_8", ai_id="empirica"))
+    with pytest.raises(cc.SentinelResolveError):
+        cc._resolve_sentinel_targets(_args(instance="tmux_99"))
+
+
+def test_ai_id_ambiguous_without_all_is_loud(patch_live):
+    patch_live(_inst("tmux_3", ai_id="empirica"), _inst("tmux_8", ai_id="empirica"))
+    with pytest.raises(cc.SentinelResolveError):
+        cc._resolve_sentinel_targets(_args(instance="empirica"))
+
+
+def test_ai_id_ambiguous_with_all_fans_out(patch_live):
+    patch_live(_inst("tmux_3", ai_id="empirica"), _inst("tmux_8", ai_id="empirica"))
+    out = cc._resolve_sentinel_targets(_args(instance="empirica", all=True))
+    assert sorted(out) == ["tmux_3", "tmux_8"]
+
+
+# ── --session / --all selectors ──────────────────────────────────────────────
+
+
+def test_session_resolves_to_instance(patch_live):
+    patch_live(_inst("tmux_8", ai_id="empirica", session_id="sess-abc"))
+    assert cc._resolve_sentinel_targets(_args(session="sess-abc")) == ["tmux_8"]
+
+
+def test_session_no_match_is_loud(patch_live):
+    patch_live(_inst("tmux_8", ai_id="empirica", session_id="sess-abc"))
+    with pytest.raises(cc.SentinelResolveError):
+        cc._resolve_sentinel_targets(_args(session="sess-zzz"))
+
+
+def test_all_without_instance_targets_every_live(patch_live):
+    patch_live(_inst("tmux_3", ai_id="empirica"), _inst("tmux_8", ai_id="cortex"))
+    out = cc._resolve_sentinel_targets(_args(all=True))
+    assert sorted(out) == ["tmux_3", "tmux_8"]
+
+
+# ── handler integration: loud-fail + resolution land in pause_sentinel ───────
+
+
+def test_pause_handler_loud_fail_does_not_pause(monkeypatch, patch_live):
+    patch_live(_inst("tmux_8", ai_id="cortex"))
+    calls: list = []
+    monkeypatch.setattr(cc, "pause_sentinel", lambda *a, **k: calls.append((a, k)))
+    rc = cc.handle_sentinel_pause_command(_args(instance="empirica"))
+    assert rc == 1  # loud (non-zero exit)
+    assert calls == []  # never paused anything on a no-match
+
+
+def test_pause_handler_resolves_ai_id_before_pausing(monkeypatch, patch_live):
+    patch_live(_inst("tmux_8", ai_id="empirica"))
+    calls: list = []
+
+    class _St:
+        paused = True
+        instance_id = "tmux_8"
+        scope = "instance"
+        since = "now"
+        reason = None
+
+    def _fake_pause(instance_id, reason=None):
+        calls.append(instance_id)
+        return _St()
+
+    monkeypatch.setattr(cc, "pause_sentinel", _fake_pause)
+    rc = cc.handle_sentinel_pause_command(_args(instance="empirica"))
+    assert rc == 0
+    assert calls == ["tmux_8"]  # the resolved runtime id, NOT the literal "empirica"


### PR DESCRIPTION
## What

`empirica sentinel pause/resume/status --instance <ai_id>` passed the value **verbatim** — so it wrote `sentinel_paused_<ai_id>` while the gate, keyed on the runtime `instance_id` (`tmux_N`), never read it. The pauser saw success; **nothing actually paused.** Fatal for a liveness watch-layer that must reliably pause stuck practitioners.

## Fix

A **sentinel-specific** `_resolve_sentinel_targets` (the shared `_resolve_instance_id` is left untouched → **zero blast radius** on loop/listener callers):

| Selector | Behavior |
|---|---|
| `--instance <runtime-id>` | passthrough (back-compat) |
| `--instance <practice ai_id>` → **1 live** | resolved to that runtime instance (**the fix**) |
| `--instance <practice ai_id>` → **0 live** | **loud error** (the silent-miss class, killed) |
| `--instance <practice ai_id>` → **N>1 live** | loud error requiring `--session`/`--all` (no silent fan-out) |
| `--session <claude_session_id>` | the live instance running that conversation |
| `--all` | fan out across the practice's live instances |

Discovery via `aggregate_all()` (`instance_id ↔ ai_id ↔ session_id`). New `--session`/`--all` flags on the sentinel parsers.

## Why this shape

Band-aid for the 1:1 era per `docs/architecture/instance_isolation/PRACTITIONER_IDENTITY.md` §6 (loud-fail invariant) + the ratified no-silent-fan-out decision. It stops the active bug today without committing to the larger control-plane re-key (later phases).

## Tests

13 new tests (`tests/test_sentinel_target_resolve.py`): resolution paths, the three loud-fail cases, `--session`/`--all`, and handler integration (no-match never pauses; ai_id resolves to the runtime id before pausing). Full local gate green: `ruff format --check`, `ruff check`, `pyright` (0 errors), 49 cockpit/CLI tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)