### PR TITLE
feat(goals): add nullable engagement_id column (migration 051)

### DIFF
--- a/empirica/data/migrations/migrations.py
+++ b/empirica/data/migrations/migrations.py
@@ -1466,6 +1466,11 @@ ALL_MIGRATIONS: list[tuple[str, str, Callable]] = [
         "Add content-identity columns (content_hash, size_bytes, canonical_path, mime_type) to epistemic_sources — empirica slice of the unified source-identity model: reconcile matching + sync-when-small both key on content identity; canonical_path ends the source_url path/URL overload behind the title-in-url bug class.",
         lambda cursor: migration_050_source_content_identity(cursor),
     ),
+    (
+        "051_goals_engagement_id",
+        "Add nullable engagement_id column to goals — scopes a goal to an engagement (the artifact → goal → engagement linkage of the engagement substrate). Cross-db by-id reference (goals in sessions.db, engagements in workspace.db); no FK, enforced at the API layer.",
+        lambda cursor: migration_051_goals_engagement_id(cursor),
+    ),
 ]
 
 
@@ -2003,6 +2008,23 @@ def migration_050_source_content_identity(cursor: sqlite3.Cursor):
     add_column_if_missing(cursor, "epistemic_sources", "mime_type", "TEXT", "NULL")
     cursor.execute("CREATE INDEX IF NOT EXISTS idx_epistemic_sources_content_hash ON epistemic_sources(content_hash)")
     logger.info("✅ Migration 050 complete: content-identity columns added to epistemic_sources")
+
+
+def migration_051_goals_engagement_id(cursor: sqlite3.Cursor):
+    """Add `engagement_id` TEXT (nullable) column to goals.
+
+    Scopes a goal to an engagement — the canonical artifact → goal →
+    engagement linkage of the engagement substrate. Most goals are unscoped
+    (NULL); engagement-scoped goals carry the engagement_id.
+
+    No FK constraint: sqlite can't ALTER-add one, and goals live in sessions.db
+    while the engagements table lives in workspace.db — the link is a by-id
+    convention enforced at the API layer. Indexed for "goals where engagement=X"
+    lookups. Idempotent via add_column_if_missing.
+    """
+    add_column_if_missing(cursor, "goals", "engagement_id", "TEXT")
+    cursor.execute("CREATE INDEX IF NOT EXISTS idx_goals_engagement_id ON goals(engagement_id)")
+    logger.info("✅ Migration 051 complete: engagement_id column added to goals")
 
 
 def migration_044_source_lifecycle(cursor: sqlite3.Cursor):

--- a/tests/test_migration_051_goals_engagement_id.py
+++ b/tests/test_migration_051_goals_engagement_id.py
@@ -1,0 +1,57 @@
+"""Test migration 051 — nullable engagement_id column on goals.
+
+Scopes a goal to an engagement (the artifact → goal → engagement linkage of the
+engagement substrate). Additive, nullable, idempotent.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+from empirica.data.migrations.migrations import migration_051_goals_engagement_id
+
+
+def _goals_db() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE goals (id TEXT PRIMARY KEY, objective TEXT NOT NULL)")
+    return conn
+
+
+def _cols(conn: sqlite3.Connection) -> set[str]:
+    return {r[1] for r in conn.execute("PRAGMA table_info(goals)").fetchall()}
+
+
+def test_adds_engagement_id_column():
+    conn = _goals_db()
+    migration_051_goals_engagement_id(conn.cursor())
+    conn.commit()
+    assert "engagement_id" in _cols(conn)
+
+
+def test_engagement_id_is_nullable():
+    conn = _goals_db()
+    migration_051_goals_engagement_id(conn.cursor())
+    conn.commit()
+    # insert without engagement_id succeeds → column is nullable
+    conn.execute("INSERT INTO goals (id, objective) VALUES ('g1', 'x')")
+    assert conn.execute("SELECT engagement_id FROM goals WHERE id='g1'").fetchone()[0] is None
+
+
+def test_creates_index():
+    conn = _goals_db()
+    migration_051_goals_engagement_id(conn.cursor())
+    conn.commit()
+    indexes = {r[1] for r in conn.execute("PRAGMA index_list(goals)").fetchall()}
+    assert "idx_goals_engagement_id" in indexes
+
+
+def test_idempotent():
+    conn = _goals_db()
+    cur = conn.cursor()
+    migration_051_goals_engagement_id(cur)
+    migration_051_goals_engagement_id(cur)  # second run must not raise
+    conn.commit()
+    # re-run did not raise and the column is still present + queryable
+    assert "engagement_id" in _cols(conn)
+    conn.execute("INSERT INTO goals (id, objective, engagement_id) VALUES ('g2', 'y', 'e1')")
+    assert conn.execute("SELECT engagement_id FROM goals WHERE id='g2'").fetchone()[0] == "e1"


### PR DESCRIPTION
## What

Adds a nullable `engagement_id` column to the `goals` table (migration 051) so a goal can be scoped to an engagement — the canonical **artifact → goal → engagement** linkage of the engagement substrate.

- additive nullable `TEXT` column + `idx_goals_engagement_id`
- cross-db **by-id reference**: goals live in sessions.db, the `engagements` table lives in workspace.db, so no FK constraint — the link is convention, enforced at the API layer
- idempotent via `add_column_if_missing`

## Tests

4 tests (`tests/test_migration_051_goals_engagement_id.py`): column added, nullable, index created, idempotent re-run. Local gate green.

Part of the engagement-substrate E2 lane (follows the schema-vendor PR #153; independent of it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)