### PR TITLE
feat(erm): module.yaml provides.domains → practice_domains (E2 / A5)

### DIFF
--- a/empirica/core/modules/executors.py
+++ b/empirica/core/modules/executors.py
@@ -334,6 +334,50 @@ def _check_env(manifest) -> list[dict]:
     ]
 
 
+def _register_practice_domains(manifest: ModuleManifest, dry_run: bool) -> list[dict]:
+    """Register the module's practice in each declared engagement domain
+    (``provides.domains`` → ``practice_domains``). The practice is the module's
+    canonical seat (``seat_name``). Idempotent via ``join_practice_domain``;
+    unknown domain ids are reported as error steps (the engagement substrate
+    validates them). No-op when ``provides.domains`` is empty.
+    """
+    domains = manifest.provides.domains
+    if not domains:
+        return []
+    practice_id = manifest.seat_name
+    if dry_run:
+        return [
+            {
+                "kind": "practice_domain",
+                "target": d,
+                "status": "dry_run",
+                "detail": f"would join practice {practice_id!r} to domain {d!r}",
+            }
+            for d in domains
+        ]
+    steps: list[dict] = []
+    try:
+        from empirica.data.repositories.workspace_db import WorkspaceDBRepository
+
+        with WorkspaceDBRepository.open() as repo:
+            for d in domains:
+                try:
+                    repo.join_practice_domain(practice_id, d)
+                    steps.append(
+                        {
+                            "kind": "practice_domain",
+                            "target": d,
+                            "status": "ok",
+                            "detail": f"practice {practice_id!r} joined domain {d!r}",
+                        }
+                    )
+                except ValueError as ve:
+                    steps.append({"kind": "practice_domain", "target": d, "status": "error", "detail": str(ve)})
+    except Exception as e:  # workspace.db unavailable on this host
+        steps.append({"kind": "practice_domain", "target": "*", "status": "error", "detail": f"workspace.db: {e}"})
+    return steps
+
+
 def provision_module(
     manifest: ModuleManifest,
     *,
@@ -364,6 +408,7 @@ def provision_module(
     steps += [_register_automation(a, dry_run) for a in manifest.provides.automations]
     steps += _grant_topics(manifest, cortex_url, cortex_api_key, org, tenant, dry_run)
     steps += _check_env(manifest)
+    steps += _register_practice_domains(manifest, dry_run)
 
     errors = [f"{s['kind']} {s['target']}: {s['detail']}" for s in steps if s["status"] == "error"]
     return {

--- a/empirica/core/modules/manifest.py
+++ b/empirica/core/modules/manifest.py
@@ -105,6 +105,10 @@ class Provides(BaseModel):
     agents: list[str] = Field(default_factory=list)
     hooks: list[str] = Field(default_factory=list)
     automations: list[Automation] = Field(default_factory=list)
+    domains: list[str] = Field(
+        default_factory=list,
+        description="Engagement domain ids this module's practice joins (→ practice_domains at provision)",
+    )
 
 
 class RequiresRuntime(BaseModel):

--- a/tests/test_module_provision.py
+++ b/tests/test_module_provision.py
@@ -21,7 +21,7 @@ from empirica.core.modules.executors import provision_module
 from empirica.core.modules.manifest import load_manifest
 
 
-def _manifest(tmp_path, *, plugin_archive=None, automations=None, topics=None, env=None):
+def _manifest(tmp_path, *, plugin_archive=None, automations=None, topics=None, env=None, domains=None):
     body = {
         "name": "outreach",
         "seat_name": "empirica-outreach",
@@ -35,6 +35,8 @@ def _manifest(tmp_path, *, plugin_archive=None, automations=None, topics=None, e
         body["artifacts"]["plugin_archive"] = plugin_archive
     if automations is not None:
         body["provides"]["automations"] = automations
+    if domains is not None:
+        body["provides"]["domains"] = domains
     if topics is not None:
         body["requires_runtime"]["topics"] = topics
     if env is not None:
@@ -222,3 +224,50 @@ def test_cli_provision_dry_run_exit_0(tmp_path, capsys):
     rc = handle_module_provision_command(args)
     out = json.loads(capsys.readouterr().out)
     assert rc == 0 and out["ok"] is True and out["action"] == "provision"
+
+
+# ── provides.domains → practice_domains (A5) ─────────────────────────────
+
+
+def _pd_steps(receipt):
+    return [s for s in receipt["steps"] if s["kind"] == "practice_domain"]
+
+
+def test_no_domains_no_practice_domain_steps(tmp_path, monkeypatch):
+    monkeypatch.setenv("EMPIRICA_WORKSPACE_DB", str(tmp_path / "workspace.db"))
+    m = _manifest(tmp_path)
+    receipt = provision_module(m, dry_run=False, plugin_root=tmp_path / "p", staging_root=tmp_path / "s")
+    assert _pd_steps(receipt) == []
+
+
+def test_domains_dry_run_registers_nothing(tmp_path, monkeypatch):
+    monkeypatch.setenv("EMPIRICA_WORKSPACE_DB", str(tmp_path / "workspace.db"))
+    m = _manifest(tmp_path, domains=["outreach", "sales"])
+    receipt = provision_module(m, dry_run=True, plugin_root=tmp_path / "p", staging_root=tmp_path / "s")
+    pd = _pd_steps(receipt)
+    assert {s["target"] for s in pd} == {"outreach", "sales"}
+    assert all(s["status"] == "dry_run" for s in pd)
+
+
+def test_domains_provisioned_write_practice_domains(tmp_path, monkeypatch):
+    monkeypatch.setenv("EMPIRICA_WORKSPACE_DB", str(tmp_path / "workspace.db"))
+    m = _manifest(tmp_path, domains=["outreach", "support"])
+    receipt = provision_module(m, dry_run=False, plugin_root=tmp_path / "p", staging_root=tmp_path / "s")
+    pd = _pd_steps(receipt)
+    assert {s["target"] for s in pd} == {"outreach", "support"}
+    assert all(s["status"] == "ok" for s in pd)
+
+    from empirica.data.repositories.workspace_db import WorkspaceDBRepository
+
+    with WorkspaceDBRepository.open() as repo:
+        joined = {d["domain_id"] for d in repo.get_practice_domains("empirica-outreach")}
+    assert joined == {"outreach", "support"}
+
+
+def test_unknown_domain_is_error_step(tmp_path, monkeypatch):
+    monkeypatch.setenv("EMPIRICA_WORKSPACE_DB", str(tmp_path / "workspace.db"))
+    m = _manifest(tmp_path, domains=["not_a_domain"])
+    receipt = provision_module(m, dry_run=False, plugin_root=tmp_path / "p", staging_root=tmp_path / "s")
+    pd = _pd_steps(receipt)
+    assert pd and pd[0]["status"] == "error"
+    assert receipt["ok"] is False  # an error step makes the receipt not-ok


### PR DESCRIPTION
## What

The last engagement-substrate leg — wires the module system to the `practice_domains` table:

- adds **`provides.domains`** (list of engagement domain ids) to the `ModuleManifest` schema (additive; `extra=forbid` still guards typos)
- `module provision` registers the module's practice (`seat_name`) in each declared domain via `WorkspaceDBRepository.join_practice_domain` → `practice_domains`

Behavior: idempotent; `--dry-run` reports the would-join steps; unknown domain ids surface as **error steps** (the engagement substrate validates them, so a typo fails loud); no-op when `provides.domains` is empty.

## Tests

4 tests added to `tests/test_module_provision.py`: no-domains no-op, dry-run, real provisioning (asserts the `practice_domains` rows land), unknown-domain error step. 37 module tests green; ruff/pyright clean.

Completes **E2** (schema #153 → migration #154 → repo #155 → CLI #156 → module domains). Builds on #153 + #155.

🤖 Generated with [Claude Code](https://claude.com/claude-code)