### PR TITLE
feat(practitioner): presence substrate keyed on claude_session_id (B2a)

### DIFF
--- a/empirica/core/practitioner_presence.py
+++ b/empirica/core/practitioner_presence.py
@@ -1,0 +1,157 @@
+"""Practitioner presence — the per-practitioner liveness + control substrate.
+
+A *practitioner* is a Claude conversation occupying a *practice*. Its durable
+identity is the ``claude_session_id`` (it survives compaction and already
+anchors ``active_work_*``), NOT the empirica ``session_id`` — that one rotates
+per compact window because it is the *measurement-cycle* container (it tracks
+transactions). Presence is therefore keyed on ``claude_session_id`` so a single
+practitioner stays continuous across compactions; ``empirica_session_id`` and
+``active_transaction_id`` ride along as the churning measurement-cycle
+attributes.
+
+Storage is one JSON file per practitioner at
+``~/.empirica/practitioner_presence_<claude_session_id>.json`` — matching the
+existing ``active_work_*`` / control-plane file pattern (lock-free, atomic
+replace, high-churn-friendly for 30–120s heartbeats). The resolver globs these
+files → "practice → its active practitioner(s) → location + gate state".
+
+This is the local substrate that session-init writes (B2b), the heartbeat emitter
+pushes to cortex's ``POST /v1/practitioners/heartbeat`` (B2c), and autonomy's
+watch-sweep reads as a deterministic liveness sensor (via ``pending_question``:
+blocked-on-question vs idle vs working).
+
+See docs/architecture/instance_isolation/PRACTITIONER_IDENTITY.md §5.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+EMPIRICA_DIR = Path.home() / ".empirica"
+_PREFIX = "practitioner_presence_"
+
+# A practitioner is considered stale (likely gone) after this long with no
+# heartbeat. ~3× the default 60s cadence — past the realtime (30s) / default
+# (60s) bands with margin; the spec's "stale-after-2N → unreachable" rule.
+DEFAULT_STALE_AFTER_S = 180.0
+
+VALID_STATUS = ("active", "idle", "paused", "blocked")
+
+
+def _safe(text: str) -> str:
+    """Filesystem-safe suffix (same sanitization as the cockpit pause files)."""
+    return text.replace("/", "-").replace("%", "").replace("..", "")
+
+
+def presence_path(claude_session_id: str) -> Path:
+    return EMPIRICA_DIR / f"{_PREFIX}{_safe(claude_session_id)}.json"
+
+
+def write_presence(
+    claude_session_id: str,
+    *,
+    practice_ai_id: str,
+    location: str | None = None,
+    status: str = "active",
+    pending_question: str | None = None,
+    active_transaction_id: str | None = None,
+    empirica_session_id: str | None = None,
+    practitioner_id: str | None = None,
+) -> dict[str, Any]:
+    """Upsert the practitioner's presence record (stamps ``last_heartbeat``=now).
+
+    Idempotent register + heartbeat in one call. ``status`` must be a valid
+    state. The stable key is ``claude_session_id``; ``empirica_session_id`` +
+    ``active_transaction_id`` are the churning measurement-cycle attributes.
+    """
+    if status not in VALID_STATUS:
+        raise ValueError(f"invalid status {status!r} — must be one of {VALID_STATUS}")
+    EMPIRICA_DIR.mkdir(parents=True, exist_ok=True)
+    record: dict[str, Any] = {
+        "claude_session_id": claude_session_id,
+        # nullable seam — becomes user_id × practice_id × harness_class when the
+        # durable cross-session id lands (spec §5 / open decision 1).
+        "practitioner_id": practitioner_id,
+        "practice_ai_id": practice_ai_id,
+        "location": location,
+        "status": status,
+        "pending_question": pending_question,
+        "active_transaction_id": active_transaction_id,
+        "empirica_session_id": empirica_session_id,
+        "last_heartbeat": time.time(),
+    }
+    path = presence_path(claude_session_id)
+    tmp = path.with_name(path.name + ".tmp")
+    tmp.write_text(json.dumps(record), encoding="utf-8")
+    tmp.replace(path)  # atomic
+    return record
+
+
+def read_presence(claude_session_id: str) -> dict[str, Any] | None:
+    path = presence_path(claude_session_id)
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def clear_presence(claude_session_id: str) -> bool:
+    """Remove the practitioner's presence (session-end). True if a file was removed."""
+    try:
+        presence_path(claude_session_id).unlink()
+        return True
+    except (FileNotFoundError, OSError):
+        return False
+
+
+def _all_presence_files() -> list[Path]:
+    if not EMPIRICA_DIR.exists():
+        return []
+    return sorted(EMPIRICA_DIR.glob(f"{_PREFIX}*.json"))
+
+
+def list_presence(
+    practice_ai_id: str | None = None,
+    *,
+    include_stale: bool = False,
+    stale_after: float = DEFAULT_STALE_AFTER_S,
+) -> list[dict[str, Any]]:
+    """Resolve practitioners → presence records.
+
+    With ``practice_ai_id`` set, scopes to that practice's practitioners (the
+    "practice → its active practitioner(s)" resolver). Each returned record gets
+    a derived ``stale`` flag (``last_heartbeat`` older than ``stale_after``, or
+    missing); stale records are excluded unless ``include_stale``.
+    """
+    now = time.time()
+    out: list[dict[str, Any]] = []
+    for path in _all_presence_files():
+        try:
+            rec = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if practice_ai_id is not None and rec.get("practice_ai_id") != practice_ai_id:
+            continue
+        last = rec.get("last_heartbeat")
+        age = (now - last) if isinstance(last, (int, float)) else None
+        rec["stale"] = age is None or age > stale_after
+        if rec["stale"] and not include_stale:
+            continue
+        out.append(rec)
+    return out
+
+
+def resolve_practitioners(practice_ai_id: str, *, include_stale: bool = False) -> list[dict[str, Any]]:
+    """Control-verb resolver: a practice's live practitioners.
+
+    Returns the presence records (claude_session_id + location + status +
+    active_transaction_id + pending_question) for ``practice_ai_id``. Used by
+    sentinel pause/resume/status to address a practitioner of a practice, and by
+    autonomy's watch-sweep as a liveness sensor.
+    """
+    return list_presence(practice_ai_id, include_stale=include_stale)

--- a/tests/test_practitioner_presence.py
+++ b/tests/test_practitioner_presence.py
@@ -1,0 +1,106 @@
+"""Tests for the practitioner-presence substrate (B2a).
+
+File-per-practitioner presence keyed on the durable claude_session_id.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+
+import pytest
+
+from empirica.core import practitioner_presence as pp
+
+
+@pytest.fixture
+def fake_home(tmp_path, monkeypatch):
+    d = tmp_path / ".empirica"
+    d.mkdir()
+    monkeypatch.setattr(pp, "EMPIRICA_DIR", d)
+    return d
+
+
+def test_write_read_roundtrip(fake_home):
+    rec = pp.write_presence(
+        "cc-abc",
+        practice_ai_id="empirica",
+        location="tmux_8",
+        active_transaction_id="tx1",
+        empirica_session_id="es1",
+    )
+    assert rec["claude_session_id"] == "cc-abc"
+    assert rec["practice_ai_id"] == "empirica"
+    assert rec["status"] == "active"
+    assert rec["last_heartbeat"] > 0
+    got = pp.read_presence("cc-abc")
+    assert got["location"] == "tmux_8"
+    assert got["active_transaction_id"] == "tx1"
+    assert got["empirica_session_id"] == "es1"
+    assert got["practitioner_id"] is None  # nullable seam
+
+
+def test_keyed_on_claude_session_id_not_empirica(fake_home):
+    # The durable key is claude_session_id; the empirica session id is a churning
+    # attribute. A compaction rotates the empirica id but it's the SAME practitioner.
+    pp.write_presence("cc-1", practice_ai_id="empirica", empirica_session_id="es-A")
+    pp.write_presence("cc-1", practice_ai_id="empirica", empirica_session_id="es-B")
+    assert len(pp.list_presence(include_stale=True)) == 1  # one practitioner, not two
+    assert pp.read_presence("cc-1")["empirica_session_id"] == "es-B"
+
+
+def test_invalid_status_rejected(fake_home):
+    with pytest.raises(ValueError, match="invalid status"):
+        pp.write_presence("cc-x", practice_ai_id="empirica", status="zombie")
+
+
+def test_clear_is_idempotent(fake_home):
+    pp.write_presence("cc-c", practice_ai_id="empirica")
+    assert pp.clear_presence("cc-c") is True
+    assert pp.read_presence("cc-c") is None
+    assert pp.clear_presence("cc-c") is False
+
+
+def test_read_missing_is_none(fake_home):
+    assert pp.read_presence("nope") is None
+
+
+def test_list_scoped_by_practice(fake_home):
+    pp.write_presence("cc-e1", practice_ai_id="empirica")
+    pp.write_presence("cc-e2", practice_ai_id="empirica")
+    pp.write_presence("cc-c1", practice_ai_id="cortex")
+    assert {r["claude_session_id"] for r in pp.list_presence("empirica")} == {"cc-e1", "cc-e2"}
+    assert {r["claude_session_id"] for r in pp.list_presence("cortex")} == {"cc-c1"}
+
+
+def test_stale_excluded_by_default(fake_home):
+    pp.write_presence("cc-live", practice_ai_id="empirica")
+    pp.write_presence("cc-old", practice_ai_id="empirica")
+    # back-date one record past the stale threshold
+    p = pp.presence_path("cc-old")
+    data = json.loads(p.read_text())
+    data["last_heartbeat"] = time.time() - (pp.DEFAULT_STALE_AFTER_S + 60)
+    p.write_text(json.dumps(data))
+
+    assert {r["claude_session_id"] for r in pp.list_presence("empirica")} == {"cc-live"}
+    everyone = pp.list_presence("empirica", include_stale=True)
+    assert {r["claude_session_id"] for r in everyone} == {"cc-live", "cc-old"}
+    old = next(r for r in everyone if r["claude_session_id"] == "cc-old")
+    assert old["stale"] is True
+
+
+def test_resolve_practitioners_carries_gate_state(fake_home):
+    pp.write_presence("cc-1", practice_ai_id="empirica", location="tmux_8", status="active")
+    pp.write_presence(
+        "cc-2", practice_ai_id="empirica", location="tmux_9", status="blocked", pending_question="which db?"
+    )
+    by_id = {r["claude_session_id"]: r for r in pp.resolve_practitioners("empirica")}
+    assert by_id["cc-2"]["status"] == "blocked"
+    assert by_id["cc-2"]["pending_question"] == "which db?"
+    assert by_id["cc-1"]["location"] == "tmux_8"
+
+
+def test_safe_filename(fake_home):
+    pp.write_presence("a/b%c", practice_ai_id="empirica")
+    assert pp.presence_path("a/b%c").name == "practitioner_presence_a-bc.json"
+    assert pp.read_presence("a/b%c") is not None


### PR DESCRIPTION
## What

The local **practitioner-presence store + resolver** — the keystone of the practitioner-identity consolidation (phase ②).

A *practitioner* (a Claude conversation occupying a *practice*) is keyed on its **durable `claude_session_id`**, **not** the empirica `session_id`. The empirica session id rotates per compact window (it's the *measurement-cycle* container that tracks transactions), so keying presence on it would make one practitioner look like a new one after every compaction. `claude_session_id` already anchors `active_work_*` and survives compaction — it's the stable practitioner anchor; `empirica_session_id` + `active_transaction_id` ride along as churning attributes.

Storage: one JSON file per practitioner at `~/.empirica/practitioner_presence_<id>.json` — atomic replace, lock-free, high-churn-friendly (30–120s heartbeats), matching the existing `active_work_*` / control-plane pattern. (The spec's "table" is realized server-side by cortex's aggregate; empirica pushes its file-based local presence up via heartbeat.)

```
write_presence / read_presence / clear_presence   register / heartbeat / clear
list_presence(practice_ai_id, include_stale, stale_after)    the resolver
resolve_practitioners(practice_ai_id)   practice → live practitioners
        (+ location, status, active_transaction_id, pending_question)
```

## Tests

9 tests (`tests/test_practitioner_presence.py`) — roundtrip, the **durable-key invariant** (a compaction-rotated empirica id keeps ONE practitioner), status validation, idempotent clear, practice-scoped listing, stale exclusion, the gate-state resolver, safe filenames. ruff/pyright clean.

## Follow-ups (this is the substrate)

- **B2b** — session-init writes presence on start / clears on end
- **B2c** — the cortex `POST /v1/practitioners/heartbeat` emitter (the write-side gate cortex is waiting on)

Spec: `docs/architecture/instance_isolation/PRACTITIONER_IDENTITY.md` §5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)