### PR TITLE
feat(practitioner): wire session hooks to write/clear presence (B2b)

### DIFF
--- a/empirica/cli/cli_core.py
+++ b/empirica/cli/cli_core.py
@@ -479,6 +479,7 @@ _HELP_CATEGORIES = {
         "loop",
         "listener",
         "instance",
+        "practitioner",
         "mailbox",
         "cockpit",
         "daemon-list",
@@ -674,6 +675,7 @@ def main(args=None):
             "listener": handle_listener_group_command,
             "mailbox": handle_mailbox_group_command,
             "instance": handle_instance_group_command,
+            "practitioner": handle_practitioner_group_command,
             "status": handle_cockpit_status_command,
             "tui": handle_tui_command,
             # Chat (single-instance collaborative epistemic workspace)

--- a/empirica/cli/command_handlers/__init__.py
+++ b/empirica/cli/command_handlers/__init__.py
@@ -183,6 +183,7 @@ from .notify_commands import (
 )
 from .onboard import handle_onboard_command
 from .performance_commands import handle_benchmark_command, handle_performance_command
+from .practitioner_commands import handle_practitioner_group_command
 from .profile_commands import (
     handle_profile_import_command,
     handle_profile_prune_command,
@@ -533,6 +534,8 @@ __all__ = [  # noqa: RUF022
     "handle_engagement_list_command",
     "handle_engagement_show_command",
     "handle_engagement_walk_command",
+    # Practitioner presence CLI
+    "handle_practitioner_group_command",
     # Session-end command
     # 'handle_session_end_command',  # removed - use handoff-create
 ]

--- a/empirica/cli/command_handlers/practitioner_commands.py
+++ b/empirica/cli/command_handlers/practitioner_commands.py
@@ -1,0 +1,127 @@
+"""Practitioner presence CLI — the bridge the session hooks shell out to.
+
+The plugin hooks are stdlib-only and shell out to the ``empirica`` CLI (they do
+not import the empirica package), so presence is written/cleared via these verbs
+rather than an in-hook import:
+
+- ``empirica practitioner write --session <claude_session_id>`` — register +
+  heartbeat (resolves practice ai_id / location / empirica session /
+  active-transaction from the running context).
+- ``empirica practitioner clear --session <claude_session_id>`` — session-end.
+- ``empirica practitioner list [--practice <ai_id>]`` — the resolver surface
+  (practice → live practitioners), for the cockpit/autonomy + debugging.
+
+Presence is keyed on the DURABLE ``claude_session_id`` (see
+empirica.core.practitioner_presence) — the empirica session id rotates per
+compact window, so it rides along as a churning attribute.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+from ..cli_utils import handle_cli_error
+
+
+def _emit_user_error(args, message: str, error: str = "invalid_argument") -> int:
+    output = getattr(args, "output", "human")
+    payload = {"ok": False, "error": error, "message": message}
+    if output == "json":
+        print(json.dumps(payload, indent=2))
+    else:
+        print(f"❌ {message}", file=sys.stderr)
+    return 1
+
+
+def handle_practitioner_write_command(args) -> int:
+    """practitioner write — upsert this practitioner's presence (register + heartbeat)."""
+    try:
+        from empirica.core.practitioner_presence import write_presence
+        from empirica.utils.session_resolver import InstanceResolver as R
+        from empirica.utils.session_resolver import get_instance_id
+
+        cc = args.session
+        ai_id = getattr(args, "ai_id", None) or R.ai_id() or "unknown"
+        location = getattr(args, "location", None) or get_instance_id()
+        empirica_sid = getattr(args, "empirica_session", None) or R.session_id(claude_session_id=cc)
+        tx = getattr(args, "active_transaction", None) or R.transaction_id(claude_session_id=cc)
+        status = getattr(args, "status", "active")
+        try:
+            rec = write_presence(
+                cc,
+                practice_ai_id=ai_id,
+                location=location,
+                status=status,
+                pending_question=getattr(args, "pending_question", None),
+                active_transaction_id=tx,
+                empirica_session_id=empirica_sid,
+            )
+        except ValueError as ve:
+            return _emit_user_error(args, str(ve))
+        if getattr(args, "output", "human") == "json":
+            print(json.dumps({"ok": True, "presence": rec}, indent=2, default=str))
+        else:
+            print(f"📍 presence: {cc[:12]} @ {ai_id} ({status})")
+        return 0
+    except Exception as e:
+        handle_cli_error(e, "practitioner write", getattr(args, "verbose", False))
+        return 1
+
+
+def handle_practitioner_clear_command(args) -> int:
+    """practitioner clear — remove this practitioner's presence (session-end)."""
+    try:
+        from empirica.core.practitioner_presence import clear_presence
+
+        removed = clear_presence(args.session)
+        if getattr(args, "output", "human") == "json":
+            print(json.dumps({"ok": True, "removed": removed}))
+        else:
+            print(f"🧹 presence cleared: {args.session[:12]}" if removed else "(no presence to clear)")
+        return 0
+    except Exception as e:
+        handle_cli_error(e, "practitioner clear", getattr(args, "verbose", False))
+        return 1
+
+
+def handle_practitioner_list_command(args) -> int:
+    """practitioner list — the resolver: a practice's live practitioners."""
+    try:
+        from empirica.core.practitioner_presence import list_presence
+
+        rows = list_presence(getattr(args, "practice", None), include_stale=getattr(args, "include_stale", False))
+        if getattr(args, "output", "human") == "json":
+            print(json.dumps({"ok": True, "count": len(rows), "practitioners": rows}, indent=2, default=str))
+            return 0
+        if not rows:
+            print("(no live practitioners)")
+            return 0
+        for r in rows:
+            stale = " STALE" if r.get("stale") else ""
+            pq = f"  ?{r['pending_question']}" if r.get("pending_question") else ""
+            print(
+                f"  {r.get('practice_ai_id', '?'):28} {(r.get('claude_session_id') or '?')[:12]} "
+                f"{r.get('status', '?'):8} @ {r.get('location') or '-'}{stale}{pq}"
+            )
+        return 0
+    except Exception as e:
+        handle_cli_error(e, "practitioner list", getattr(args, "verbose", False))
+        return 1
+
+
+_DISPATCH = {
+    "write": handle_practitioner_write_command,
+    "clear": handle_practitioner_clear_command,
+    "list": handle_practitioner_list_command,
+}
+
+
+def handle_practitioner_group_command(args) -> int:
+    """`empirica practitioner <write|clear|list>` dispatcher."""
+    action = getattr(args, "practitioner_action", None)
+    handler = _DISPATCH.get(action)
+    if handler is None:
+        sys.stdout.write("usage: empirica practitioner <write|clear|list>\n")
+        return 2
+    return handler(args)

--- a/empirica/cli/parsers/cockpit_parsers.py
+++ b/empirica/cli/parsers/cockpit_parsers.py
@@ -55,13 +55,54 @@ def _add_sentinel_target(parser):
 
 
 def add_cockpit_parsers(subparsers):
-    """Register sentinel/loop/listener/instance subcommand groups + top-level status + tui."""
+    """Register sentinel/loop/listener/instance/practitioner groups + top-level status + tui."""
     _add_sentinel_group(subparsers)
     _add_loop_group(subparsers)
     _add_listener_group(subparsers)
     _add_instance_group(subparsers)
+    _add_practitioner_group(subparsers)
     _add_status_command(subparsers)
     _add_tui_command(subparsers)
+
+
+def _add_practitioner_group(subparsers):
+    """`empirica practitioner <write|clear|list>` — practitioner-presence control.
+
+    Presence is keyed on the durable claude_session_id (--session). write/clear
+    are the lifecycle the session hooks shell out to; list is the resolver
+    surface (a practice's live practitioners).
+    """
+    root = subparsers.add_parser(
+        "practitioner",
+        help="Practitioner presence: write/clear/list (keyed on claude_session_id)",
+    )
+    subs = root.add_subparsers(dest="practitioner_action", metavar="action")
+
+    write = subs.add_parser("write", help="Register/heartbeat this practitioner's presence")
+    write.add_argument("--session", required=True, help="claude_session_id (the durable practitioner key)")
+    write.add_argument("--status", default="active", help="active | idle | paused | blocked (default: active)")
+    write.add_argument("--pending-question", dest="pending_question", help="Blocked-reason (emit-and-park signal)")
+    write.add_argument("--ai-id", dest="ai_id", help="Practice ai_id (default: resolve from project context)")
+    write.add_argument("--location", help="Location/instance_id (default: resolve from current process)")
+    write.add_argument("--empirica-session", dest="empirica_session", help="Empirica session id (default: resolve)")
+    write.add_argument(
+        "--active-transaction", dest="active_transaction", help="Active transaction id (default: resolve)"
+    )
+    write.add_argument("--output", choices=["human", "json"], default="human", help="Output format")
+    write.add_argument("--verbose", action="store_true", help="Verbose output")
+
+    clear = subs.add_parser("clear", help="Clear this practitioner's presence (session-end)")
+    clear.add_argument("--session", required=True, help="claude_session_id")
+    clear.add_argument("--output", choices=["human", "json"], default="human", help="Output format")
+    clear.add_argument("--verbose", action="store_true", help="Verbose output")
+
+    plist = subs.add_parser("list", help="List live practitioners (optionally scoped to a practice)")
+    plist.add_argument("--practice", help="Scope to a practice ai_id")
+    plist.add_argument(
+        "--include-stale", dest="include_stale", action="store_true", help="Include stale (no recent heartbeat)"
+    )
+    plist.add_argument("--output", choices=["human", "json"], default="human", help="Output format")
+    plist.add_argument("--verbose", action="store_true", help="Verbose output")
 
 
 def _add_tui_command(subparsers):

--- a/empirica/plugins/claude-code-integration/hooks/session-end-postflight.py
+++ b/empirica/plugins/claude-code-integration/hooks/session-end-postflight.py
@@ -215,6 +215,20 @@ def _cleanup_session_files(claude_session_id: str | None):
     except Exception:
         pass
 
+    # Clear practitioner presence (keyed on the same durable claude_session_id).
+    # Best-effort shell-out to the CLI — the hook is stdlib-only and does not
+    # import the empirica package. Never fail session-end on a presence clear.
+    try:
+        subprocess.run(
+            ["empirica", "practitioner", "clear", "--session", claude_session_id, "--output", "json"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            stdin=subprocess.DEVNULL,
+        )
+    except Exception:
+        pass
+
     # Clean up TTY session file (terminal association is gone)
     try:
         tty_sessions_dir = Path.home() / ".empirica" / "tty_sessions"

--- a/empirica/plugins/claude-code-integration/hooks/session-init.py
+++ b/empirica/plugins/claude-code-integration/hooks/session-init.py
@@ -1487,6 +1487,32 @@ def main():
 
     if result.get("session_id"):
         _write_instance_projects(str(project_root), claude_session_id, result["session_id"])
+        # Register practitioner presence, keyed on the durable claude_session_id
+        # (survives compaction; the empirica session_id rotates per compact
+        # window). Best-effort — never fail session-init on a presence write.
+        if claude_session_id:
+            try:
+                subprocess.run(
+                    [
+                        "empirica",
+                        "practitioner",
+                        "write",
+                        "--session",
+                        claude_session_id,
+                        "--ai-id",
+                        ai_id,
+                        "--empirica-session",
+                        result["session_id"],
+                        "--output",
+                        "json",
+                    ],
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                    stdin=subprocess.DEVNULL,
+                )
+            except Exception:
+                pass
 
     if result.get("error"):
         _emit_session_error(result["error"], ai_id)

--- a/tests/test_practitioner_cli.py
+++ b/tests/test_practitioner_cli.py
@@ -1,0 +1,187 @@
+"""Tests for the `empirica practitioner write|clear|list` CLI group (B2b).
+
+These verbs are the bridge the stdlib-only session hooks shell out to (the hooks
+do not import the empirica package). The group resolves the practitioner's
+identity and upserts/clears/lists presence keyed on the DURABLE
+``claude_session_id``.
+
+The load-bearing invariant — David's anchor — is encoded in
+``test_write_is_keyed_on_claude_session_not_empirica_session``: the empirica
+session id rotates per compact window, but presence must stay ONE practitioner
+across those rotations because the key is the claude_session_id.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import pytest
+
+from empirica.cli.command_handlers.practitioner_commands import (
+    handle_practitioner_group_command,
+)
+from empirica.cli.parsers.cockpit_parsers import add_cockpit_parsers
+from empirica.core import practitioner_presence
+
+
+@pytest.fixture
+def presence_dir(tmp_path, monkeypatch):
+    """Redirect presence storage to a tmp dir so tests never touch the real ~/.empirica."""
+    d = tmp_path / "empirica"
+    monkeypatch.setattr(practitioner_presence, "EMPIRICA_DIR", d)
+    return d
+
+
+def _parse(argv):
+    """Parse a real `empirica <argv>` through the cockpit parser (tests wiring too)."""
+    parser = argparse.ArgumentParser(prog="empirica")
+    subparsers = parser.add_subparsers(dest="command")
+    add_cockpit_parsers(subparsers)
+    return parser.parse_args(argv)
+
+
+def _write_argv(session, **over):
+    """A fully-overridden write argv — hermetic (no resolver calls hit real state)."""
+    argv = [
+        "practitioner",
+        "write",
+        "--session",
+        session,
+        "--ai-id",
+        over.get("ai_id", "empirica-test"),
+        "--location",
+        over.get("location", "tmux_test"),
+        "--empirica-session",
+        over.get("empirica_session", "esid-1"),
+        "--active-transaction",
+        over.get("active_transaction", "tx-1"),
+        "--output",
+        "json",
+    ]
+    if "status" in over:
+        argv += ["--status", over["status"]]
+    if "pending_question" in over:
+        argv += ["--pending-question", over["pending_question"]]
+    return argv
+
+
+# ---- parser wiring -------------------------------------------------------
+
+
+def test_parser_registers_practitioner_group():
+    args = _parse(["practitioner", "write", "--session", "cc-1"])
+    assert args.command == "practitioner"
+    assert args.practitioner_action == "write"
+    assert args.session == "cc-1"
+
+
+def test_group_dispatch_usage_on_no_action(capsys):
+    args = _parse(["practitioner"])
+    # No sub-action → dispatcher prints usage and returns 2 (argparse convention).
+    rc = handle_practitioner_group_command(args)
+    assert rc == 2
+    assert "usage: empirica practitioner" in capsys.readouterr().out
+
+
+# ---- write ---------------------------------------------------------------
+
+
+def test_write_upserts_presence(presence_dir, capsys):
+    args = _parse(_write_argv("cc-write", status="active"))
+    rc = handle_practitioner_group_command(args)
+    assert rc == 0
+    capsys.readouterr()  # drain
+
+    rec = practitioner_presence.read_presence("cc-write")
+    assert rec is not None
+    assert rec["claude_session_id"] == "cc-write"
+    assert rec["practice_ai_id"] == "empirica-test"
+    assert rec["location"] == "tmux_test"
+    assert rec["status"] == "active"
+    assert rec["empirica_session_id"] == "esid-1"
+    assert rec["active_transaction_id"] == "tx-1"
+    assert isinstance(rec["last_heartbeat"], (int, float))
+
+
+def test_write_carries_pending_question(presence_dir, capsys):
+    args = _parse(_write_argv("cc-blocked", status="blocked", pending_question="need schema review"))
+    rc = handle_practitioner_group_command(args)
+    assert rc == 0
+    capsys.readouterr()
+
+    rec = practitioner_presence.read_presence("cc-blocked")
+    assert rec["status"] == "blocked"
+    assert rec["pending_question"] == "need schema review"
+
+
+def test_write_invalid_status_fails_loud(presence_dir, capsys):
+    args = _parse(_write_argv("cc-bad", status="nonsense"))
+    rc = handle_practitioner_group_command(args)
+    assert rc == 1  # write_presence raises ValueError → _emit_user_error → 1
+    assert practitioner_presence.read_presence("cc-bad") is None
+
+
+def test_write_is_keyed_on_claude_session_not_empirica_session(presence_dir, capsys):
+    """David's anchor: the empirica session rotates per compact window, but the
+    claude_session_id is durable — so two heartbeats with DIFFERENT empirica
+    sessions under the SAME claude session must remain ONE practitioner."""
+    handle_practitioner_group_command(_parse(_write_argv("cc-stable", empirica_session="esid-A")))
+    handle_practitioner_group_command(_parse(_write_argv("cc-stable", empirica_session="esid-B")))
+    capsys.readouterr()
+
+    # Exactly one presence file for the stable claude_session_id.
+    files = list(presence_dir.glob("practitioner_presence_*.json"))
+    assert len(files) == 1
+    rec = practitioner_presence.read_presence("cc-stable")
+    # The churning measurement-cycle attribute reflects the latest heartbeat.
+    assert rec["empirica_session_id"] == "esid-B"
+
+
+# ---- clear ---------------------------------------------------------------
+
+
+def test_clear_removes_presence(presence_dir, capsys):
+    handle_practitioner_group_command(_parse(_write_argv("cc-clear")))
+    assert practitioner_presence.read_presence("cc-clear") is not None
+
+    rc = handle_practitioner_group_command(
+        _parse(["practitioner", "clear", "--session", "cc-clear", "--output", "json"])
+    )
+    assert rc == 0
+    capsys.readouterr()
+    assert practitioner_presence.read_presence("cc-clear") is None
+
+
+def test_clear_missing_is_noop_success(presence_dir, capsys):
+    rc = handle_practitioner_group_command(
+        _parse(["practitioner", "clear", "--session", "cc-none", "--output", "json"])
+    )
+    assert rc == 0  # idempotent — clearing a non-existent practitioner is not an error
+
+
+# ---- list ----------------------------------------------------------------
+
+
+def test_list_scopes_to_practice(presence_dir, capsys):
+    handle_practitioner_group_command(_parse(_write_argv("cc-a", ai_id="empirica-alpha")))
+    handle_practitioner_group_command(_parse(_write_argv("cc-b", ai_id="empirica-beta")))
+    capsys.readouterr()
+
+    rows = practitioner_presence.list_presence("empirica-alpha")
+    assert [r["claude_session_id"] for r in rows] == ["cc-a"]
+
+    # The resolver returns nothing for a practice with no live practitioner.
+    assert practitioner_presence.list_presence("empirica-nobody") == []
+
+
+def test_list_command_json_returns_zero(presence_dir, capsys):
+    handle_practitioner_group_command(_parse(_write_argv("cc-list", ai_id="empirica-gamma")))
+    capsys.readouterr()
+
+    rc = handle_practitioner_group_command(
+        _parse(["practitioner", "list", "--practice", "empirica-gamma", "--output", "json"])
+    )
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "cc-list" in out
+    assert "empirica-gamma" in out


### PR DESCRIPTION
## What

Completes the **local write-side** of practitioner presence (B2b). The read-side resolver + store landed in B2a; this PR adds the CLI verbs and wires the session hooks to them.

A *practitioner* is a Claude conversation occupying a *practice*. Its durable identity is the `claude_session_id` (survives compaction, already anchors `active_work_*`). The empirica `session_id` rotates per compact window — it's the measurement-cycle container — so it rides along as a churning attribute, not the key.

## Changes

- **`practitioner_commands.py`** (new) — `empirica practitioner write|clear|list`:
  - `write` — register + heartbeat in one call; resolves practice ai_id / location / empirica-session / active-transaction from running context (all overridable via flags).
  - `clear` — session-end removal.
  - `list` — the `practice → live practitioner(s)` resolver surface.
- **`cockpit_parsers.py`** — `_add_practitioner_group` + registration.
- **`__init__.py` + `cli_core.py`** — re-export + command-dict / verb-list wiring.
- **`session-init.py`** — best-effort shell-out to `practitioner write` after session-create.
- **`session-end-postflight.py`** — best-effort `practitioner clear` alongside the existing `active_work` cleanup.

## Why shell-out (not in-hook import)

The session hooks are stdlib-only standalone scripts that do **not** import the empirica package — they already shell out to `empirica session-create`. Presence write/clear follow the same pattern. Both shell-outs are best-effort (`try/except` + `timeout` + `DEVNULL` stdin): a presence write/clear can never fail the hook.

## Tests

`tests/test_practitioner_cli.py` — 10 tests through the real parser + dispatcher. The load-bearing one (`test_write_is_keyed_on_claude_session_not_empirica_session`) encodes the durable-key invariant: two heartbeats with *different* empirica sessions under the *same* `claude_session_id` stay ONE practitioner.

## Gate (local)

- `ruff format --check` + `ruff check` — clean
- `pyright` on changed modules — 0 errors
- `pytest tests/test_practitioner_cli.py` — 10 passed
- `pytest tests/test_cli_lazy_imports.py` (CLI contract) — passed
- Live round-trip: `write → list (finds it) → clear → list (gone)` ✅
- Both hooks `py_compile` clean

## Deploy note

CI tests the verbs; the live hook effect (real heartbeats on session start/end) needs a release + pip-upgrade or plugin-sync to take effect on installed instances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)