### PR TITLE
feat(practitioner): cortex presence heartbeat emitter (B2c)

### DIFF
--- a/empirica/cli/command_handlers/practitioner_commands.py
+++ b/empirica/cli/command_handlers/practitioner_commands.py
@@ -110,18 +110,63 @@ def handle_practitioner_list_command(args) -> int:
         return 1
 
 
+def handle_practitioner_heartbeat_command(args) -> int:
+    """practitioner heartbeat — push local presence to cortex (one session or all).
+
+    Reads the local presence store and forwards each record to cortex's
+    POST /v1/practitioners/heartbeat. With --session, emits just that
+    practitioner; otherwise emits every local non-stale practitioner. This is
+    the one-shot the persistent service / loop body triggers on a cadence.
+    """
+    try:
+        from empirica.core.loop_scheduler.practitioner_heartbeat import (
+            emit_practitioner_heartbeat,
+        )
+        from empirica.core.practitioner_presence import list_presence, read_presence
+
+        session = getattr(args, "session", None)
+        if session:
+            rec = read_presence(session)
+            records = [rec] if rec else []
+        else:
+            records = list_presence(include_stale=getattr(args, "include_stale", False))
+
+        results = []
+        for rec in records:
+            code = emit_practitioner_heartbeat(rec)
+            results.append({"session_id": rec.get("claude_session_id"), "status_code": code})
+
+        if getattr(args, "output", "human") == "json":
+            print(json.dumps({"ok": True, "emitted": len(results), "results": results}, indent=2, default=str))
+            return 0
+        if not results:
+            print("(no local presence to emit)" if not session else f"(no local presence for {session[:12]})")
+            return 0
+        for r in results:
+            code = r["status_code"]
+            label = {0: "skipped (no cortex creds / unmappable)", 200: "ok", -1: "network error"}.get(
+                code, f"http {code}"
+            )
+            print(f"  📡 {(r['session_id'] or '?')[:12]} → {label}")
+        return 0
+    except Exception as e:
+        handle_cli_error(e, "practitioner heartbeat", getattr(args, "verbose", False))
+        return 1
+
+
 _DISPATCH = {
     "write": handle_practitioner_write_command,
     "clear": handle_practitioner_clear_command,
     "list": handle_practitioner_list_command,
+    "heartbeat": handle_practitioner_heartbeat_command,
 }
 
 
 def handle_practitioner_group_command(args) -> int:
-    """`empirica practitioner <write|clear|list>` dispatcher."""
+    """`empirica practitioner <write|clear|list|heartbeat>` dispatcher."""
     action = getattr(args, "practitioner_action", None)
     handler = _DISPATCH.get(action)
     if handler is None:
-        sys.stdout.write("usage: empirica practitioner <write|clear|list>\n")
+        sys.stdout.write("usage: empirica practitioner <write|clear|list|heartbeat>\n")
         return 2
     return handler(args)

--- a/empirica/cli/parsers/cockpit_parsers.py
+++ b/empirica/cli/parsers/cockpit_parsers.py
@@ -104,6 +104,14 @@ def _add_practitioner_group(subparsers):
     plist.add_argument("--output", choices=["human", "json"], default="human", help="Output format")
     plist.add_argument("--verbose", action="store_true", help="Verbose output")
 
+    hb = subs.add_parser("heartbeat", help="Push local presence to cortex's /v1/practitioners/heartbeat")
+    hb.add_argument("--session", help="claude_session_id to emit (default: all local non-stale practitioners)")
+    hb.add_argument(
+        "--include-stale", dest="include_stale", action="store_true", help="Include stale records when emitting all"
+    )
+    hb.add_argument("--output", choices=["human", "json"], default="human", help="Output format")
+    hb.add_argument("--verbose", action="store_true", help="Verbose output")
+
 
 def _add_tui_command(subparsers):
     tui = subparsers.add_parser(

--- a/empirica/core/loop_scheduler/listener.py
+++ b/empirica/core/loop_scheduler/listener.py
@@ -607,6 +607,23 @@ def run_listener(  # noqa: C901 — held-connection loop; clarity beats decompos
     except Exception as e:
         err_stream.write(f"listener: heartbeat start failed (non-fatal): {e}\n")
 
+    # Start the practitioner-presence emitter. Forwards the LOCAL per-session
+    # presence store (one row per live claude_session) to cortex's
+    # /v1/practitioners/heartbeat so the mesh sees per-practitioner liveness +
+    # gate state. Machine-anchored like the listener heartbeat above. Failures
+    # are non-fatal — the emitter never crashes the listener.
+    practitioner_heartbeat = None
+    try:
+        from empirica.core.loop_scheduler.practitioner_heartbeat import (
+            PractitionerHeartbeatEmitter,
+        )
+
+        practitioner_heartbeat = PractitionerHeartbeatEmitter()
+        practitioner_heartbeat.start()
+        err_stream.write("listener: practitioner-presence emitter started\n")
+    except Exception as e:
+        err_stream.write(f"listener: practitioner emitter start failed (non-fatal): {e}\n")
+
     try:
         while True:
             proc = _stream_factory(url, headers)
@@ -776,6 +793,11 @@ def run_listener(  # noqa: C901 — held-connection loop; clarity beats decompos
                 heartbeat.stop(timeout=2.0)
             except Exception as e:
                 err_stream.write(f"listener: heartbeat stop failed (non-fatal): {e}\n")
+        if practitioner_heartbeat is not None:
+            try:
+                practitioner_heartbeat.stop(timeout=2.0)
+            except Exception as e:
+                err_stream.write(f"listener: practitioner emitter stop failed (non-fatal): {e}\n")
         if probe is not None:
             try:
                 probe.stop(timeout=2.0)

--- a/empirica/core/loop_scheduler/practitioner_heartbeat.py
+++ b/empirica/core/loop_scheduler/practitioner_heartbeat.py
@@ -1,0 +1,236 @@
+"""Practitioner-presence heartbeat emitter — pushes local presence to cortex.
+
+Companion to the listener ``HeartbeatEmitter`` (which posts ai_id/machine-level
+liveness to ``/v1/listeners/heartbeat``). This emitter posts the richer
+PER-PRACTITIONER presence — one row per live ``claude_session`` — to cortex's
+``POST /v1/practitioners/heartbeat`` so the mesh sees per-session liveness plus
+gate state (status, pending_question, active_transaction_id).
+
+Source of truth is the LOCAL presence store (``empirica.core.practitioner_presence``
+— file-per-practitioner keyed on the durable ``claude_session_id``). The session
+hooks write/clear those files (B2b); this emitter forwards the non-stale ones to
+cortex on a cadence so cortex's TTL reflects the live practitioners. A session
+that ends clears its file → the emitter stops forwarding → cortex's staleness
+window marks it offline.
+
+cortex contract (``transport_handlers_practitioners.py``)::
+
+    POST /v1/practitioners/heartbeat
+    auth: Bearer api_key — the key's tenant.user_id is the authoritative writer.
+    body: {machine, session_id  [both required, non-empty],
+           status, location, active_transaction_id, practitioner_id,
+           pending_question, blocked_at, blocked_reason}
+
+``ai_id`` is OMITTED deliberately. It's an optional cross-check that cortex
+resolves strict-canonically (``<org>.<tenant>.<project>``); a bare basename
+returns None → the handler 403s. The field is never stored in the presence row
+anyway (it's keyed user_id × machine × session_id), and the api_key already
+identifies the writing user — so omitting it is both correct and robust.
+
+mesh_mode-driven cadence (cortex's "30s/60s/120s by
+``practitioner_registrations.mesh_mode``") is a cortex-side registration field,
+not locally readable — so this emitter uses a fixed default interval (60s, ~3×
+margin under cortex's ~180s staleness window). Coupling the cadence to the live
+loop band is a follow-on.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import socket
+import threading
+import urllib.error
+import urllib.request
+from collections.abc import Callable
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_HEARTBEAT_ENDPOINT_PATH = "/v1/practitioners/heartbeat"
+_DEFAULT_INTERVAL_SEC = 60.0
+_DEFAULT_TIMEOUT_SEC = 5.0
+
+
+def _default_post(url: str, body: bytes, headers: dict, timeout: float) -> int:
+    """HTTP POST returning status code (or -1 on network error). Defensive — never raises."""
+    req = urllib.request.Request(url, data=body, method="POST", headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return resp.status
+    except urllib.error.HTTPError as e:
+        return e.code
+    except Exception:
+        return -1
+
+
+def _default_resolve_creds() -> tuple[str | None, str | None]:
+    """Resolve Cortex URL + api_key from credentials_loader. Defensive — returns (None, None) on any failure."""
+    try:
+        from empirica.config.credentials_loader import get_credentials_loader
+
+        cfg = get_credentials_loader().get_cortex_config()
+        return cfg.get("url"), cfg.get("api_key")
+    except Exception:
+        return None, None
+
+
+def _practitioner_body(record: dict[str, Any], *, machine: str) -> dict[str, Any] | None:
+    """Map a local presence record → cortex heartbeat body. None if unmappable.
+
+    ``ai_id`` is intentionally omitted (see module docstring). ``machine`` and
+    ``session_id`` are cortex-required and non-empty; a record without a
+    ``claude_session_id`` cannot be emitted and returns None.
+    """
+    session_id = (record.get("claude_session_id") or "").strip()
+    if not session_id or not machine:
+        return None
+    status = record.get("status") or "active"
+    body: dict[str, Any] = {
+        "machine": machine,
+        "session_id": session_id,
+        "status": status,
+        "location": record.get("location") or "",
+        "active_transaction_id": record.get("active_transaction_id"),
+        "practitioner_id": record.get("practitioner_id"),
+        "pending_question": record.get("pending_question"),
+    }
+    # When blocked, surface the reason in cortex's blocked_reason column too.
+    if status == "blocked" and record.get("pending_question"):
+        body["blocked_reason"] = record["pending_question"]
+    return body
+
+
+def emit_practitioner_heartbeat(
+    record: dict[str, Any],
+    *,
+    machine: str | None = None,
+    post_fn: Callable[[str, bytes, dict, float], int] = _default_post,
+    resolve_creds_fn: Callable[[], tuple] = _default_resolve_creds,
+    timeout: float = _DEFAULT_TIMEOUT_SEC,
+) -> int:
+    """Emit one local presence record to cortex's practitioners/heartbeat.
+
+    Returns the HTTP status code: 200 on success, 4xx/5xx on cortex error, -1 on
+    network failure, 0 when skipped (cortex creds unconfigured, or the record is
+    unmappable — e.g. no claude_session_id).
+    """
+    url, api_key = resolve_creds_fn()
+    if not url or not api_key:
+        return 0  # SKIP — cortex not configured
+    body = _practitioner_body(record, machine=machine or socket.gethostname() or "unknown-host")
+    if body is None:
+        return 0  # SKIP — unmappable record
+    endpoint = f"{url.rstrip('/')}{_HEARTBEAT_ENDPOINT_PATH}"
+    payload = json.dumps(body).encode("utf-8")
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+    return post_fn(endpoint, payload, headers, timeout)
+
+
+class PractitionerHeartbeatEmitter:
+    """Background emitter: forwards local practitioner presence → cortex.
+
+    On each tick, reads the LOCAL non-stale presence records (the
+    file-per-practitioner store) and posts each to cortex's
+    ``/v1/practitioners/heartbeat``. Runs in a daemon thread; never crashes the
+    listener on failure (logs warnings + continues), mirroring the listener
+    ``HeartbeatEmitter`` lifecycle.
+
+    Lifecycle::
+
+        emitter = PractitionerHeartbeatEmitter()
+        emitter.start()           # spawn the daemon thread
+        ...                       # listener body runs
+        emitter.stop(timeout=2)   # signal + join
+
+    Test injection (all optional, kwargs only):
+        _post_fn: replaces HTTP POST — pass a Mock that records calls.
+        _resolve_creds_fn: replaces credentials resolution — return (url, key).
+        _list_fn: replaces the local-presence read — return a list of records.
+    """
+
+    def __init__(
+        self,
+        *,
+        machine: str | None = None,
+        interval_sec: float = _DEFAULT_INTERVAL_SEC,
+        timeout_sec: float = _DEFAULT_TIMEOUT_SEC,
+        _post_fn: Callable[[str, bytes, dict, float], int] = _default_post,
+        _resolve_creds_fn: Callable[[], tuple] = _default_resolve_creds,
+        _list_fn: Callable[[], list] | None = None,
+    ):
+        self.machine = machine or socket.gethostname() or "unknown-host"
+        self.interval_sec = interval_sec
+        self.timeout_sec = timeout_sec
+        self._post_fn = _post_fn
+        self._resolve_creds_fn = _resolve_creds_fn
+        self._list_fn = _list_fn or self._default_list
+        self._stop_event = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    @staticmethod
+    def _default_list() -> list[dict]:
+        """Read local non-stale practitioner presence records."""
+        from empirica.core.practitioner_presence import list_presence
+
+        return list_presence(include_stale=False)
+
+    def start(self) -> None:
+        """Start the emitter thread. Idempotent — no-op if already running."""
+        if self._thread is not None and self._thread.is_alive():
+            return
+        self._stop_event.clear()
+        self._thread = threading.Thread(
+            target=self._loop,
+            daemon=True,
+            name="practitioner-heartbeat",
+        )
+        self._thread.start()
+
+    def stop(self, timeout: float = 2.0) -> None:
+        """Signal stop + join. Idempotent."""
+        self._stop_event.set()
+        t = self._thread
+        if t is not None and t.is_alive():
+            t.join(timeout=timeout)
+        self._thread = None
+
+    def emit_once(self) -> dict[str, int]:
+        """Emit every local non-stale practitioner once.
+
+        Returns ``{claude_session_id: status_code}`` per emitted practitioner.
+        Never raises — a per-record failure records -1 and continues.
+        """
+        results: dict[str, int] = {}
+        try:
+            records = self._list_fn()
+        except Exception as e:
+            logger.warning("practitioner-heartbeat: list failed: %s: %s", type(e).__name__, e)
+            return results
+        for rec in records:
+            sid = rec.get("claude_session_id") or "?"
+            try:
+                results[sid] = emit_practitioner_heartbeat(
+                    rec,
+                    machine=self.machine,
+                    post_fn=self._post_fn,
+                    resolve_creds_fn=self._resolve_creds_fn,
+                    timeout=self.timeout_sec,
+                )
+            except Exception as e:
+                logger.warning("practitioner-heartbeat: emit failed for %s: %s", sid, e)
+                results[sid] = -1
+        return results
+
+    def _loop(self) -> None:
+        """Background loop. wait-on-event so stop() interrupts immediately."""
+        while not self._stop_event.is_set():
+            try:
+                self.emit_once()
+            except Exception as e:
+                logger.warning("practitioner-heartbeat: tick failed: %s: %s", type(e).__name__, e)
+            # Interruptible sleep — stop() sets the event and wait returns immediately.
+            self._stop_event.wait(self.interval_sec)

--- a/tests/test_practitioner_heartbeat.py
+++ b/tests/test_practitioner_heartbeat.py
@@ -1,0 +1,175 @@
+"""Tests for the practitioner-presence heartbeat emitter (B2c).
+
+The emitter forwards the LOCAL per-session presence store to cortex's
+POST /v1/practitioners/heartbeat. The load-bearing contract details (encoded as
+invariants below):
+
+- ``ai_id`` is OMITTED from the body — cortex resolves it strict-canonically, a
+  bare basename 403s, and the field isn't stored anyway (the api_key identifies
+  the writer).
+- ``machine`` + ``session_id`` are required and non-empty; ``session_id`` is the
+  durable ``claude_session_id``.
+- a ``blocked`` status surfaces ``pending_question`` as cortex's ``blocked_reason``.
+
+All HTTP / creds / local-read seams are injected, so these tests never touch the
+network or disk.
+"""
+
+from __future__ import annotations
+
+import json
+
+from empirica.core.loop_scheduler.practitioner_heartbeat import (
+    PractitionerHeartbeatEmitter,
+    _practitioner_body,
+    emit_practitioner_heartbeat,
+)
+
+CREDS = lambda: ("https://cortex.test/", "key-abc")  # noqa: E731
+NO_CREDS = lambda: (None, None)  # noqa: E731
+
+
+def _record(**over):
+    base = {
+        "claude_session_id": "cc-1",
+        "practitioner_id": None,
+        "practice_ai_id": "empirica",
+        "location": "tmux_2",
+        "status": "active",
+        "pending_question": None,
+        "active_transaction_id": "tx-9",
+        "empirica_session_id": "es-1",
+        "last_heartbeat": 1000.0,
+    }
+    base.update(over)
+    return base
+
+
+class _Recorder:
+    """A post_fn stand-in that records its call args and returns a fixed code."""
+
+    def __init__(self, code=200):
+        self.code = code
+        self.calls = []
+
+    def __call__(self, url, body, headers, timeout):
+        self.calls.append({"url": url, "body": json.loads(body.decode()), "headers": headers, "timeout": timeout})
+        return self.code
+
+
+# ---- _practitioner_body --------------------------------------------------
+
+
+def test_body_omits_ai_id():
+    body = _practitioner_body(_record(), machine="host-1")
+    assert "ai_id" not in body  # strict-canonical resolver would 403 a basename
+
+
+def test_body_maps_required_and_optional_fields():
+    body = _practitioner_body(_record(), machine="host-1")
+    assert body["machine"] == "host-1"
+    assert body["session_id"] == "cc-1"  # the durable claude_session_id
+    assert body["status"] == "active"
+    assert body["location"] == "tmux_2"
+    assert body["active_transaction_id"] == "tx-9"
+    assert body["practitioner_id"] is None
+
+
+def test_body_blocked_sets_blocked_reason():
+    body = _practitioner_body(_record(status="blocked", pending_question="need schema review"), machine="host-1")
+    assert body["status"] == "blocked"
+    assert body["blocked_reason"] == "need schema review"
+
+
+def test_body_none_without_session_id():
+    assert _practitioner_body(_record(claude_session_id=""), machine="host-1") is None
+    assert _practitioner_body(_record(claude_session_id=None), machine="host-1") is None
+
+
+def test_body_none_without_machine():
+    assert _practitioner_body(_record(), machine="") is None
+
+
+# ---- emit_practitioner_heartbeat ----------------------------------------
+
+
+def test_emit_skips_when_no_creds():
+    rec = _Recorder()
+    code = emit_practitioner_heartbeat(_record(), post_fn=rec, resolve_creds_fn=NO_CREDS)
+    assert code == 0
+    assert rec.calls == []  # never posts when cortex isn't configured
+
+
+def test_emit_skips_unmappable_record():
+    rec = _Recorder()
+    code = emit_practitioner_heartbeat(_record(claude_session_id=""), post_fn=rec, resolve_creds_fn=CREDS)
+    assert code == 0
+    assert rec.calls == []
+
+
+def test_emit_posts_to_endpoint_with_bearer():
+    rec = _Recorder(code=200)
+    code = emit_practitioner_heartbeat(_record(), machine="host-1", post_fn=rec, resolve_creds_fn=CREDS)
+    assert code == 200
+    assert len(rec.calls) == 1
+    call = rec.calls[0]
+    assert call["url"] == "https://cortex.test/v1/practitioners/heartbeat"  # rstrip('/') applied
+    assert call["headers"]["Authorization"] == "Bearer key-abc"
+    assert call["headers"]["Content-Type"] == "application/json"
+    assert call["body"]["session_id"] == "cc-1"
+    assert "ai_id" not in call["body"]
+
+
+def test_emit_propagates_error_code():
+    rec = _Recorder(code=403)
+    code = emit_practitioner_heartbeat(_record(), post_fn=rec, resolve_creds_fn=CREDS)
+    assert code == 403
+
+
+# ---- PractitionerHeartbeatEmitter ---------------------------------------
+
+
+def test_emit_once_emits_each_local_practitioner():
+    rec = _Recorder(code=200)
+    records = [_record(claude_session_id="cc-a"), _record(claude_session_id="cc-b")]
+    emitter = PractitionerHeartbeatEmitter(
+        machine="host-1",
+        _post_fn=rec,
+        _resolve_creds_fn=CREDS,
+        _list_fn=lambda: records,
+    )
+    results = emitter.emit_once()
+    assert results == {"cc-a": 200, "cc-b": 200}
+    assert len(rec.calls) == 2
+    assert {c["body"]["session_id"] for c in rec.calls} == {"cc-a", "cc-b"}
+
+
+def test_emit_once_survives_list_failure():
+    def _boom():
+        raise RuntimeError("disk gone")
+
+    emitter = PractitionerHeartbeatEmitter(_post_fn=_Recorder(), _resolve_creds_fn=CREDS, _list_fn=_boom)
+    assert emitter.emit_once() == {}  # never raises — returns empty
+
+
+def test_emit_once_empty_when_no_practitioners():
+    rec = _Recorder()
+    emitter = PractitionerHeartbeatEmitter(_post_fn=rec, _resolve_creds_fn=CREDS, _list_fn=lambda: [])
+    assert emitter.emit_once() == {}
+    assert rec.calls == []
+
+
+def test_start_stop_idempotent():
+    # Use a long interval so the loop blocks on the stop event after one tick.
+    emitter = PractitionerHeartbeatEmitter(
+        interval_sec=3600,
+        _post_fn=_Recorder(),
+        _resolve_creds_fn=NO_CREDS,
+        _list_fn=lambda: [],
+    )
+    emitter.start()
+    emitter.start()  # idempotent — no second thread
+    assert emitter._thread is not None and emitter._thread.is_alive()
+    emitter.stop(timeout=2.0)
+    emitter.stop(timeout=2.0)  # idempotent
+    assert emitter._thread is None


### PR DESCRIPTION
## What

Completes the **push side** of practitioner presence (B2c). The local store landed in B2a; the session hooks write/clear it in B2b. This PR forwards that local store to cortex's live `POST /v1/practitioners/heartbeat`, so the mesh (autonomy routing, mesh-support fleet, the extension presence pane) sees per-practitioner liveness + gate state.

## Changes

- **`practitioner_heartbeat.py`** (new) — mirrors the existing listener `HeartbeatEmitter`:
  - `_practitioner_body(record, machine)` — maps a local presence record → cortex body.
  - `emit_practitioner_heartbeat(record, …)` — posts one record; returns the HTTP code (200 / 4xx / -1 network / 0 skipped).
  - `PractitionerHeartbeatEmitter` — daemon-thread emitter; each tick globs the local **non-stale** presences and posts each. Test seams: `_post_fn`, `_resolve_creds_fn`, `_list_fn`.
- **`listener.py`** — start/stop the emitter alongside `HeartbeatEmitter` in the persistent service (machine-anchored, non-fatal on failure).
- **`practitioner_commands.py` + `cockpit_parsers.py`** — `empirica practitioner heartbeat [--session <cc>]` one-shot: the trigger the loop/hooks call on a cadence, and the live round-trip surface.

## Key contract decision — omit `ai_id`

cortex's `get_user_for_ai_id` is **strict-canonical** (`<org>.<tenant>.<project>` only); a bare basename returns `None` → the handler **403s**. `ai_id` is an optional cross-check that cortex never stores anyway (the row is keyed `user_id × machine × session_id`, and the api_key identifies the writer). So the emitter **omits `ai_id`** — correct and robust. Body maps `machine`=hostname, `session_id`=the durable `claude_session_id`, rest from the local record; a `blocked` status surfaces `pending_question` as cortex's `blocked_reason`.

## `mesh_mode` cadence

cortex documents "30s/60s/120s by `mesh_mode`", but `mesh_mode` is a cortex-side `practitioner_registrations` field — **not locally readable**. The emitter uses a fixed 60s default (~3× margin under cortex's ~180s staleness window). Coupling the cadence to the live loop band is a noted follow-on (not silently dropped).

## Validation — live round-trip against cortex production

Against `cortex.getempirica.com`:
- `POST /v1/practitioners/heartbeat` → **200**
- `GET /v1/practitioners/empirica.david.empirica/presence` → row read back (`session_id`, `status`, `location`, `machine`, server-stamped `last_heartbeat`) ✅

## Gate (local)

- ruff format/check — clean
- pyright on changed modules — 0 errors
- `pytest tests/test_practitioner_heartbeat.py` — 12 passed (body mapping omits ai_id, skip-on-no-creds, error-code propagation, emit-each, survives-list-failure, start/stop idempotent)
- `pytest tests/test_cli_lazy_imports.py` (CLI contract) — passed
- `empirica practitioner heartbeat --help` smoke + live round-trip ✅

## Note on observed cortex-side gap (separate lane)

cortex's presence row has no practice column, so `GET /presence?ai_id=X` returns all of a user's rows across every practice sharing one api_key — practices are conflated on read. The `practitioner_id` seam (user_id × practice_id × harness_class) is the intended fix. Surfacing to cortex separately; not papered over here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)