### PR TITLE
feat(sentinel): transaction file resolves by durable claude_session_id (B3 slice 1)

### DIFF
--- a/empirica/cli/command_handlers/_workflow_preflight.py
+++ b/empirica/cli/command_handlers/_workflow_preflight.py
@@ -239,6 +239,7 @@ def _preflight_write_transaction_file(session_id, transaction_id, parsed):
         preflight_timestamp=time.time(),
         status="open",
         project_path=resolved_project_path,
+        claude_session_id=claude_session_id,
     )
 
     _preflight_enrich_transaction_file(resolved_project_path, parsed)

--- a/empirica/plugins/claude-code-integration/hooks/post-compact.py
+++ b/empirica/plugins/claude-code-integration/hooks/post-compact.py
@@ -71,7 +71,10 @@ def _temporal_trail_section(project_path: str | Path | None) -> str:
 
 
 def _write_active_transaction_for_new_conversation(
-    active_transaction: dict, project_path: str, instance_id: str | None = None
+    active_transaction: dict,
+    project_path: str,
+    instance_id: str | None = None,
+    claude_session_id: str | None = None,
 ) -> bool:
     """
     Write active_transaction file for the NEW conversation after compaction.
@@ -97,10 +100,15 @@ def _write_active_transaction_for_new_conversation(
 
         tx_file.parent.mkdir(parents=True, exist_ok=True)
 
-        # Update timestamp but preserve original transaction data
+        # Update timestamp but preserve original transaction data. Carry the
+        # DURABLE claude_session_id (B3) so the firewall can resolve this
+        # transaction even though the ephemeral instance suffix / empirica
+        # session_id may have rotated across the compaction boundary. Prefer the
+        # caller's value; fall back to whatever the snapshot captured.
         tx_data = {
             "transaction_id": active_transaction.get("transaction_id"),
             "session_id": active_transaction.get("session_id"),
+            "claude_session_id": claude_session_id or active_transaction.get("claude_session_id"),
             "preflight_timestamp": active_transaction.get("preflight_timestamp"),
             "status": active_transaction.get("status", "open"),
             "project_path": project_path,
@@ -411,7 +419,10 @@ def _handle_open_transaction(
         instance_id=instance_id,
     )
     _write_active_transaction_for_new_conversation(
-        active_transaction=active_transaction, project_path=str(project_root), instance_id=instance_id
+        active_transaction=active_transaction,
+        project_path=str(project_root),
+        instance_id=instance_id,
+        claude_session_id=claude_session_id,
     )
     _restore_hook_counters(hook_counters, project_root)
     return recovery_prompt, "CONTINUE_TRANSACTION", tx_session_id

--- a/empirica/plugins/claude-code-integration/hooks/sentinel-gate.py
+++ b/empirica/plugins/claude-code-integration/hooks/sentinel-gate.py
@@ -806,15 +806,23 @@ _file_relevance_nudge = ""  # Module-level: set when artifacts reference an Edit
 _last_read_count = 0  # Module-level: how many times current file was read this tx
 
 
-def _find_transaction_file(empirica_dir: Path, suffix: str, session_id: str | None = None) -> Path | None:
+def _find_transaction_file(
+    empirica_dir: Path,
+    suffix: str,
+    session_id: str | None = None,
+    claude_session_id: str | None = None,
+) -> Path | None:
     """Find the active transaction file, with suffix-mismatch fallback.
 
     Primary: exact file matching the current instance suffix.
-    Fallback: when exact file doesn't exist (e.g., hook context where
-    TMUX_PANE is not inherited), scan for any active_transaction_*.json
-    matching the given session_id.
+    Fallback: when exact file doesn't exist (hook context where TMUX_PANE is not
+    inherited, OR the ephemeral tmux_N rotated across compaction), scan for any
+    active_transaction_*.json matching — preferring the DURABLE
+    claude_session_id, then the (rotating) empirica session_id.
 
-    Safe because it's scoped by session_id — no cross-instance talk.
+    Safe because the scan is scoped by a durable/session key — no cross-instance
+    talk. This is the firewall's transaction-resolution path; it must stay in
+    sync with empirica/utils/session_resolver.py:_find_transaction_file.
     See: docs/architecture/instance_isolation/KNOWN_ISSUES.md (11.21)
     """
     # Primary: exact suffix match
@@ -822,19 +830,23 @@ def _find_transaction_file(empirica_dir: Path, suffix: str, session_id: str | No
     if exact.exists():
         return exact
 
-    # Fallback: scan for suffix-mismatched files matching this session
-    if session_id:
-        try:
-            for tx_file in sorted(empirica_dir.glob("active_transaction*.json")):
-                try:
-                    with open(tx_file) as f:
-                        tx_data = json.load(f)
-                    if tx_data.get("session_id") == session_id:
-                        return tx_file
-                except Exception:
-                    continue
-        except Exception:
-            pass
+    # Fallback: scan suffix-mismatched files. Prefer the durable
+    # claude_session_id (survives compaction); fall back to empirica session_id.
+    if not claude_session_id and not session_id:
+        return None
+    try:
+        for tx_file in sorted(empirica_dir.glob("active_transaction*.json")):
+            try:
+                with open(tx_file) as f:
+                    tx_data = json.load(f)
+            except Exception:
+                continue
+            if claude_session_id and tx_data.get("claude_session_id") == claude_session_id:
+                return tx_file
+            if session_id and tx_data.get("session_id") == session_id:
+                return tx_file
+    except Exception:
+        pass
 
     return None
 
@@ -870,7 +882,7 @@ def _locate_transaction_file(
                 with open(aw_file) as f:
                     pp = json.load(f).get("project_path")
                 if pp:
-                    tx = _find_transaction_file(Path(pp) / ".empirica", suffix, empirica_session_id)
+                    tx = _find_transaction_file(Path(pp) / ".empirica", suffix, empirica_session_id, claude_session_id)
                     if tx:
                         return tx
             except Exception:
@@ -879,12 +891,12 @@ def _locate_transaction_file(
     # Try 2: project_resolver canonical path
     pp = get_active_project_path(claude_session_id)
     if pp:
-        tx = _find_transaction_file(Path(pp) / ".empirica", suffix, empirica_session_id)
+        tx = _find_transaction_file(Path(pp) / ".empirica", suffix, empirica_session_id, claude_session_id)
         if tx:
             return tx
 
     # Try 3: global fallback
-    return _find_transaction_file(Path.home() / ".empirica", suffix, empirica_session_id)
+    return _find_transaction_file(Path.home() / ".empirica", suffix, empirica_session_id, claude_session_id)
 
 
 def _is_empirica_mcp_tool(tool_name: str) -> bool:

--- a/empirica/utils/session_resolver.py
+++ b/empirica/utils/session_resolver.py
@@ -137,6 +137,7 @@ class InstanceResolver:
         preflight_timestamp: float | None = None,
         status: str = "open",
         project_path: str | None = None,
+        claude_session_id: str | None = None,
     ) -> None:
         """Write (create or update) the active transaction file."""
         write_active_transaction(
@@ -145,6 +146,7 @@ class InstanceResolver:
             preflight_timestamp=preflight_timestamp,
             status=status,
             project_path=project_path,
+            claude_session_id=claude_session_id,
         )
 
     @staticmethod
@@ -1037,6 +1039,7 @@ def write_active_transaction(
     preflight_timestamp: float | None = None,
     status: str = "open",
     project_path: str | None = None,
+    claude_session_id: str | None = None,
 ) -> None:
     """Atomically write the active transaction state to JSON file.
 
@@ -1047,12 +1050,20 @@ def write_active_transaction(
     IMPORTANT: Uses instance suffix for multi-instance isolation. Each Claude
     instance writes to its own transaction file (e.g., active_transaction_pts-6.json).
 
+    Dual-key (B3): the file also carries ``claude_session_id`` — the DURABLE
+    practitioner key. The empirica ``session_id`` rotates per compact window, so
+    resolving a transaction by it breaks across compaction; ``claude_session_id``
+    survives. ``_find_transaction_file`` prefers the claude_session_id match.
+    When ``claude_session_id`` is None on a status-update write (e.g. POSTFLIGHT),
+    the existing field is preserved so the durable key isn't dropped mid-cutover.
+
     Args:
         transaction_id: UUID of the epistemic transaction
         session_id: Session that opened this transaction (for PREFLIGHT lookup)
         preflight_timestamp: When PREFLIGHT was submitted
         status: "open" or "closed"
         project_path: Absolute path to the project (git root) this transaction belongs to
+        claude_session_id: Durable practitioner key (survives compaction)
     """
     import os
     import tempfile
@@ -1076,9 +1087,19 @@ def write_active_transaction(
 
     path.parent.mkdir(parents=True, exist_ok=True)
 
+    # Preserve an existing claude_session_id when this write doesn't supply one
+    # (status-update writes like POSTFLIGHT mustn't drop the durable key).
+    if claude_session_id is None and path.exists():
+        try:
+            with open(path) as existing_f:
+                claude_session_id = json.load(existing_f).get("claude_session_id")
+        except Exception:
+            pass
+
     tx_data = {
         "transaction_id": transaction_id,
         "session_id": session_id,
+        "claude_session_id": claude_session_id,  # durable key (B3 dual-key)
         "preflight_timestamp": preflight_timestamp or time.time(),
         "status": status,
         "project_path": project_path,  # Essential for cross-CWD operations
@@ -1112,14 +1133,27 @@ def increment_transaction_tool_count(claude_session_id: str | None = None) -> di
 
     suffix = _get_instance_suffix()
 
-    # Find the transaction file
-    project_path = get_active_project_path(claude_session_id)
-    if project_path:
-        tx_path = Path(project_path) / ".empirica" / f"active_transaction{suffix}.json"
-    else:
-        tx_path = Path.home() / ".empirica" / f"active_transaction{suffix}.json"
+    # Resolve the empirica session_id for the suffix-mismatch fallback scan.
+    session_id = None
+    if claude_session_id:
+        try:
+            aw_file = Path.home() / ".empirica" / f"active_work_{claude_session_id}.json"
+            if aw_file.exists():
+                with open(aw_file) as f:
+                    session_id = json.load(f).get("empirica_session_id")
+        except Exception:
+            pass
 
-    if not tx_path.exists():
+    # Find the transaction file with dual-key resilience (durable
+    # claude_session_id preferred, so the counter survives suffix rotation).
+    project_path = get_active_project_path(claude_session_id)
+    tx_path = None
+    if project_path:
+        tx_path = _find_transaction_file(Path(project_path) / ".empirica", suffix, session_id, claude_session_id)
+    if tx_path is None:
+        tx_path = _find_transaction_file(Path.home() / ".empirica", suffix, session_id, claude_session_id)
+
+    if tx_path is None or not tx_path.exists():
         return None
 
     try:
@@ -1151,28 +1185,39 @@ def increment_transaction_tool_count(claude_session_id: str | None = None) -> di
         return None
 
 
-def _find_transaction_file(empirica_dir: "Path", suffix: str, session_id: str | None = None) -> "Path | None":
+def _find_transaction_file(
+    empirica_dir: "Path",
+    suffix: str,
+    session_id: str | None = None,
+    claude_session_id: str | None = None,
+) -> "Path | None":
     """Find the active transaction file, with suffix-mismatch fallback.
 
     Primary: Look for the exact file matching the current instance suffix.
     Fallback: When the exact file doesn't exist (e.g., hook context where
-    TMUX_PANE is not inherited), scan for any active_transaction_*.json that
-    matches the given session_id.
+    TMUX_PANE is not inherited, OR the ephemeral tmux_N rotated across
+    compaction), scan for any active_transaction_*.json matching — preferring
+    the DURABLE claude_session_id, then the (rotating) empirica session_id.
 
     This handles the environment-mismatch scenario where:
     - CLI writes active_transaction_tmux_5.json (TMUX_PANE available)
     - Hook looks for active_transaction.json (no TMUX_PANE in hook context)
 
-    The fallback is safe because it's scoped by session_id — it won't
-    cross-talk between instances. If session_id is None, only exact
-    suffix match is attempted (no scan).
+    And the compaction scenario (B3) where:
+    - The empirica session_id rotated, so a session_id scan no longer matches,
+      but claude_session_id (the practitioner key) is stable across the rotation.
+
+    The scan is safe because it's scoped by a durable/session key — it won't
+    cross-talk between instances. With neither key, only the exact suffix match
+    is attempted (no scan).
 
     See: docs/architecture/instance_isolation/KNOWN_ISSUES.md (11.21)
 
     Args:
         empirica_dir: The .empirica directory to search in
         suffix: The instance suffix from _get_instance_suffix()
-        session_id: Optional session_id to match against when scanning
+        session_id: Optional empirica session_id to match (rotates on compaction)
+        claude_session_id: Optional durable practitioner key (preferred match)
 
     Returns:
         Path to the transaction file, or None
@@ -1182,25 +1227,34 @@ def _find_transaction_file(empirica_dir: "Path", suffix: str, session_id: str | 
     if exact.exists():
         return exact
 
-    # Fallback: scan for suffix-mismatched files matching this session
-    # Only when we have a session_id to scope the search (prevents cross-talk)
-    if session_id:
-        try:
-            for tx_file in sorted(empirica_dir.glob("active_transaction*.json")):
-                try:
-                    with open(tx_file) as f:
-                        tx_data = json.load(f)
-                    if tx_data.get("session_id") == session_id:
-                        logger.debug(
-                            f"Transaction suffix mismatch resolved: "
-                            f"expected '{suffix}', found '{tx_file.name}' "
-                            f"(session={session_id[:8]})"
-                        )
-                        return tx_file
-                except Exception:
-                    continue
-        except Exception:
-            pass
+    # Fallback: scan for suffix-mismatched files. Prefer the durable
+    # claude_session_id (survives compaction); fall back to the empirica
+    # session_id (may have rotated). Either key scopes the scan to prevent
+    # cross-instance cross-talk.
+    if not claude_session_id and not session_id:
+        return None
+    try:
+        for tx_file in sorted(empirica_dir.glob("active_transaction*.json")):
+            try:
+                with open(tx_file) as f:
+                    tx_data = json.load(f)
+            except Exception:
+                continue
+            if claude_session_id and tx_data.get("claude_session_id") == claude_session_id:
+                logger.debug(
+                    f"Transaction resolved by durable claude_session_id: "
+                    f"expected suffix '{suffix}', found '{tx_file.name}'"
+                )
+                return tx_file
+            if session_id and tx_data.get("session_id") == session_id:
+                logger.debug(
+                    f"Transaction suffix mismatch resolved: "
+                    f"expected '{suffix}', found '{tx_file.name}' "
+                    f"(session={session_id[:8]})"
+                )
+                return tx_file
+    except Exception:
+        pass
 
     return None
 
@@ -1237,7 +1291,7 @@ def read_active_transaction_full(claude_session_id: str | None = None) -> dict |
     project_path = get_active_project_path(claude_session_id)
     if project_path:
         empirica_dir = Path(project_path) / ".empirica"
-        tx_file = _find_transaction_file(empirica_dir, suffix, session_id)
+        tx_file = _find_transaction_file(empirica_dir, suffix, session_id, claude_session_id)
         if tx_file:
             try:
                 with open(tx_file) as f:
@@ -1247,7 +1301,7 @@ def read_active_transaction_full(claude_session_id: str | None = None) -> dict |
 
     # Fallback: Global ~/.empirica/
     global_dir = Path.home() / ".empirica"
-    tx_file = _find_transaction_file(global_dir, suffix, session_id)
+    tx_file = _find_transaction_file(global_dir, suffix, session_id, claude_session_id)
     if tx_file:
         try:
             with open(tx_file) as f:

--- a/tests/test_transaction_dual_key.py
+++ b/tests/test_transaction_dual_key.py
@@ -1,0 +1,152 @@
+"""B3: transaction-file dual-key resolution (instance suffix → durable claude_session_id).
+
+The sentinel firewall resolves the active transaction from
+``active_transaction{suffix}.json`` to decide whether a praxic action is gated.
+The suffix (tmux_N / pts-N) is EPHEMERAL — it rotates across compaction and
+isn't always inherited. The empirica ``session_id`` fallback ALSO rotates per
+compact window. ``claude_session_id`` is the durable practitioner key.
+
+These tests assert the dual-key cutover: writers store ``claude_session_id``,
+and ``_find_transaction_file`` resolves by it (preferred), so a transaction
+stays resolvable across suffix/session rotation — and the exact-suffix primary
+path is unchanged, so the firewall never regresses.
+
+The firewall hook (sentinel-gate.py) carries its own standalone copy of
+``_find_transaction_file``; ``test_hook_resolver_mirrors_package`` asserts that
+copy has identical dual-key behaviour.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+from empirica.utils import session_resolver as sr
+from empirica.utils.session_resolver import _find_transaction_file, write_active_transaction
+
+
+def _write_tx(empirica_dir: Path, suffix: str, **fields):
+    """Write a transaction file directly (bypassing the writer) for resolver tests."""
+    empirica_dir.mkdir(parents=True, exist_ok=True)
+    path = empirica_dir / f"active_transaction{suffix}.json"
+    path.write_text(json.dumps(fields))
+    return path
+
+
+# ---- write_active_transaction: stores + preserves the durable key -------
+
+
+def test_write_stores_claude_session_id(tmp_path, monkeypatch):
+    monkeypatch.setattr(sr, "_get_instance_suffix", lambda: "_tmux_1")
+    proj = tmp_path / "proj"
+    (proj / ".empirica").mkdir(parents=True)
+    write_active_transaction("tx-1", session_id="es-1", project_path=str(proj), claude_session_id="cc-1")
+
+    data = json.loads((proj / ".empirica" / "active_transaction_tmux_1.json").read_text())
+    assert data["claude_session_id"] == "cc-1"
+    assert data["transaction_id"] == "tx-1"
+
+
+def test_write_preserves_cc_when_none(tmp_path, monkeypatch):
+    """A status-update write (e.g. POSTFLIGHT) with no claude_session_id must
+    not drop the durable key established at PREFLIGHT."""
+    monkeypatch.setattr(sr, "_get_instance_suffix", lambda: "_tmux_1")
+    proj = tmp_path / "proj"
+    (proj / ".empirica").mkdir(parents=True)
+    write_active_transaction("tx-1", session_id="es-1", project_path=str(proj), claude_session_id="cc-1")
+    # Re-write with status update, no claude_session_id supplied
+    write_active_transaction("tx-1", session_id="es-1", status="closed", project_path=str(proj))
+
+    data = json.loads((proj / ".empirica" / "active_transaction_tmux_1.json").read_text())
+    assert data["claude_session_id"] == "cc-1"  # preserved
+    assert data["status"] == "closed"
+
+
+# ---- _find_transaction_file: dual-key resolution ------------------------
+
+
+def test_find_exact_suffix_unchanged(tmp_path):
+    """Primary path: exact suffix match still wins (firewall must not regress)."""
+    ed = tmp_path / ".empirica"
+    p = _write_tx(ed, "_tmux_1", transaction_id="tx-1", claude_session_id="cc-1")
+    assert _find_transaction_file(ed, "_tmux_1", None, "cc-1") == p
+
+
+def test_find_by_claude_session_after_suffix_rotation(tmp_path):
+    """The core B3 win: the suffix rotated (tmux_1 → tmux_9) but the durable
+    claude_session_id still resolves the transaction."""
+    ed = tmp_path / ".empirica"
+    p = _write_tx(ed, "_tmux_1", transaction_id="tx-1", session_id="es-1", claude_session_id="cc-1")
+    # Current instance is now tmux_9 (rotated); resolve by the durable key.
+    assert _find_transaction_file(ed, "_tmux_9", None, "cc-1") == p
+
+
+def test_find_prefers_cc_when_empirica_session_rotated(tmp_path):
+    """The empirica session_id rotated across compaction; the cc field still
+    resolves it where a pure session_id scan would miss."""
+    ed = tmp_path / ".empirica"
+    p = _write_tx(ed, "_tmux_1", transaction_id="tx-1", session_id="es-OLD", claude_session_id="cc-1")
+    # session_id we know now is es-NEW (rotated) — only cc-1 matches.
+    assert _find_transaction_file(ed, "_tmux_9", "es-NEW", "cc-1") == p
+
+
+def test_find_backward_compat_session_id(tmp_path):
+    """A pre-B3 transaction file (no claude_session_id field) still resolves by
+    the empirica session_id fallback — no regression for in-flight transactions."""
+    ed = tmp_path / ".empirica"
+    p = _write_tx(ed, "_tmux_1", transaction_id="tx-1", session_id="es-1")  # no cc field
+    assert _find_transaction_file(ed, "_tmux_9", "es-1", None) == p
+
+
+def test_find_no_keys_returns_none(tmp_path):
+    ed = tmp_path / ".empirica"
+    _write_tx(ed, "_tmux_1", transaction_id="tx-1", claude_session_id="cc-1")
+    # Suffix mismatch + no keys to scope the scan → no match (no cross-talk).
+    assert _find_transaction_file(ed, "_tmux_9", None, None) is None
+
+
+def test_find_no_crosstalk_between_practitioners(tmp_path):
+    """The scan is scoped by the key — another practitioner's file is not returned."""
+    ed = tmp_path / ".empirica"
+    _write_tx(ed, "_tmux_1", transaction_id="tx-other", claude_session_id="cc-OTHER")
+    assert _find_transaction_file(ed, "_tmux_9", None, "cc-MINE") is None
+
+
+# ---- firewall hook copy mirrors the package -----------------------------
+
+
+def _load_hook_module():
+    """Import sentinel-gate.py (hyphenated → importlib) for the firewall-path test.
+
+    main() is guarded behind ``if __name__ == '__main__'`` so import is
+    side-effect-free. If the hook's plugin-lib imports can't resolve in the test
+    env, skip — the package copy above is the authoritative logic and the hook
+    copy is a literal mirror.
+    """
+    hook_path = Path(__file__).resolve().parents[1] / "empirica/plugins/claude-code-integration/hooks/sentinel-gate.py"
+    if not hook_path.exists():
+        pytest.skip("sentinel-gate.py not found")
+    spec = importlib.util.spec_from_file_location("sentinel_gate_under_test", hook_path)
+    module = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(module)
+    except Exception as e:  # plugin-lib import path not available in this env
+        pytest.skip(f"sentinel-gate.py not importable here: {e}")
+    return module
+
+
+def test_hook_resolver_mirrors_package(tmp_path):
+    """The firewall's own _find_transaction_file resolves by the durable
+    claude_session_id after suffix rotation, identically to the package."""
+    hook = _load_hook_module()
+    ed = tmp_path / ".empirica"
+    p = _write_tx(ed, "_tmux_1", transaction_id="tx-1", session_id="es-OLD", claude_session_id="cc-1")
+    # Rotated suffix + rotated empirica session — only the durable cc matches.
+    assert hook._find_transaction_file(ed, "_tmux_9", "es-NEW", "cc-1") == p
+    # Exact-suffix primary path still wins.
+    assert hook._find_transaction_file(ed, "_tmux_1", None, "cc-1") == p
+    # No keys → no cross-talk.
+    assert hook._find_transaction_file(ed, "_tmux_9", None, None) is None


### PR DESCRIPTION
## What

First slice of **B3** — re-key the firewall-critical control-plane file (`active_transaction{suffix}.json`) from the ephemeral instance suffix toward the durable `claude_session_id`, via an **additive dual-key cutover** (write both, resolve-either). Scope is the transaction file only; `instance_projects` / counters / `sentinel_pause` are follow-on slices (the incremental, smallest-blast-radius approach chosen for the firewall-critical path).

## Why

The sentinel firewall resolves the active transaction to decide whether a praxic action is gated. The suffix (`tmux_N`/`pts-N`) is **ephemeral** — it rotates across compaction and isn't always inherited. The existing empirica `session_id` fallback **also rotates** per compact window. So a transaction can become unresolvable after compaction → the firewall fails **open** (praxic without CHECK) or **closed** (blocks all praxic). `claude_session_id` is the durable practitioner key (anchors `active_work_*`, survives compaction).

## Changes

- **`write_active_transaction`** — stores `claude_session_id`; **preserves** it on status-update writes that don't supply one (POSTFLIGHT must not drop the durable key).
- **`_find_transaction_file` (package)** — after an exact-suffix miss, scans preferring the durable `claude_session_id`, then the rotating empirica `session_id`. The exact-suffix primary path is **byte-unchanged**, so the firewall never regresses on the common case.
- **`sentinel-gate.py`** — the firewall's standalone copy of `_find_transaction_file` + `_locate_transaction_file` gets the same dual-key resolution. Kept in sync with the package; a **mirror test** asserts identical behaviour. (The duplication is inherent to the stdlib-only hook architecture.)
- **Writers thread `claude_session_id`** — `_workflow_preflight` (PREFLIGHT create) and `post-compact._write_active_transaction_for_new_conversation` (the compaction rewrite, where the durable key matters most). `increment_transaction_tool_count` also resolves dual-key so the per-tool counter survives rotation.

## Tests

`tests/test_transaction_dual_key.py` — 9 tests: stores + preserves the key, resolution after suffix rotation (the core win), prefers `cc` when the empirica session rotated, backward-compat for pre-B3 files (no regression), no cross-practitioner cross-talk, and the **firewall-hook copy mirrors the package**.

## Gate (local)

- ruff format/check — clean
- pyright on changed modules — 0 errors
- `pytest test_transaction_dual_key` (9) + `test_session_resolver` + `test_open_transaction_guard` + `test_chat_compact` + `test_sentinel_target_resolve` + `test_sentinel_recovery_escape` — **79 passed, no regressions**
- Both hooks `py_compile` clean

## Safety note

This is intentionally additive — the firewall's exact-suffix primary path is unchanged, so the common case behaves identically to before. The durable key is purely an added fallback that closes the compaction-rotation gap. A future slice can flip writes to a `claude_session_id`-named filename once this has soaked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)