### PR TITLE
feat(api): parent_org_id on GET /api/v1/entities org rows (CCR-2)

### DIFF
--- a/empirica/api/routes/entities.py
+++ b/empirica/api/routes/entities.py
@@ -120,19 +120,27 @@ async def list_entities(
 
     out: list[dict] = []
     with WorkspaceDBRepository.open() as repo:
+        # Org→org parentage for the org-tree render (extension). One query for
+        # the whole org set (small: umbrella + brands), not per-row — preserves
+        # the single-query intent that deferred the broader v1.1 enrichment.
+        org_parents = repo.get_org_parent_map()
         for row in repo.list_entities(entity_type=type, status=status, limit=limit):
             et, eid = row["entity_type"], row["entity_id"]
             meta = _parse_metadata(row.get("metadata"))
-            out.append(
-                {
-                    "id": eid,
-                    "type": et,
-                    "name": row.get("display_name"),
-                    "subtitle": _list_subtitle(row, meta),
-                    "status": row.get("status"),
-                    "health": meta.get("health"),
-                    "linked_artifact_count": repo.count_entity_artifacts(et, eid),
-                    "updated_at": row.get("updated_at"),
-                }
-            )
+            entry = {
+                "id": eid,
+                "type": et,
+                "name": row.get("display_name"),
+                "subtitle": _list_subtitle(row, meta),
+                "status": row.get("status"),
+                "health": meta.get("health"),
+                "linked_artifact_count": repo.count_entity_artifacts(et, eid),
+                "updated_at": row.get("updated_at"),
+            }
+            # Org rows carry their parent org (null for umbrella roots). Only
+            # organization rows get the field — the extension tree-builder keys
+            # off it; non-org rows omit it.
+            if et == "organization":
+                entry["parent_org_id"] = org_parents.get(eid)
+            out.append(entry)
     return {"ok": True, "count": len(out), "entities": out}

--- a/empirica/data/repositories/workspace_db.py
+++ b/empirica/data/repositories/workspace_db.py
@@ -843,6 +843,28 @@ class WorkspaceDBRepository(BaseRepository):
         members = [dict(row) for row in in_cursor.fetchall()]
         return {"member_of": member_of, "members": members}
 
+    def get_org_parent_map(self) -> dict[str, str]:
+        """Map child_org_id → parent_org_id from active org→org membership edges.
+
+        Org→org parentage is an active ``entity_membership`` where both ends are
+        organizations (the child org is member_of the parent org). The ``role``
+        column is a free-text verb in ``entity-link`` (existing edges use
+        'member', 'context', 'ticket_of'), so parentage keys on the STRUCTURAL
+        org→org edge, not a brittle role string — a role filter would miss real
+        parentage. One row per child (the most recent active edge wins). Single
+        query; the org set (umbrella + brands) is small, so this preserves the
+        list endpoint's single-query intent (the org-parent slice of the
+        deferred v1.1 membership enrichment).
+        """
+        cursor = self._execute(
+            """SELECT entity_id, group_id FROM entity_memberships
+               WHERE entity_type = 'organization' AND group_type = 'organization'
+                 AND left_at IS NULL
+               ORDER BY joined_at ASC"""
+        )
+        # ASC + dict overwrite → the most recent (latest joined_at) edge wins.
+        return {row["entity_id"]: row["group_id"] for row in cursor.fetchall()}
+
     def upsert_entity_membership(
         self,
         entity_type: str,

--- a/tests/test_org_parent_map.py
+++ b/tests/test_org_parent_map.py
@@ -1,0 +1,78 @@
+"""CCR-2 (prop_kgrbsvrnfvab): org→org parentage for GET /api/v1/entities.
+
+get_org_parent_map() resolves each org's parent org from active org→org
+membership edges, so the extension org-tree can render live parents. Parentage
+keys on the STRUCTURAL org→org edge (both ends organization, active) — NOT a
+role string, because role is a free-text verb in entity-link (verified: existing
+edges use 'member' / 'context' / 'ticket_of', no 'member_of' convention).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+
+import pytest
+
+from empirica.data.repositories.workspace_db import WorkspaceDBRepository, _ensure_workspace_schema
+
+
+@pytest.fixture
+def repo() -> WorkspaceDBRepository:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    _ensure_workspace_schema(conn)
+    return WorkspaceDBRepository(conn)
+
+
+def _membership(repo, etype, eid, gtype, gid, role="member_of", joined=None, left_at=None):
+    """Insert a membership edge directly (lets us set joined_at / left_at for tests)."""
+    now = joined if joined is not None else time.time()
+    repo._execute(
+        """INSERT INTO entity_memberships
+           (entity_type, entity_id, group_type, group_id, role, joined_at, left_at, created_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+        (etype, eid, gtype, gid, role, now, left_at, now),
+    )
+
+
+def test_empty_when_no_org_edges(repo):
+    assert repo.get_org_parent_map() == {}
+
+
+def test_maps_active_org_to_parent(repo):
+    _membership(repo, "organization", "brand-a", "organization", "umbrella")
+    assert repo.get_org_parent_map() == {"brand-a": "umbrella"}
+
+
+def test_ignores_non_org_edges(repo):
+    # contact→engagement and engagement→org are not org→org parentage.
+    _membership(repo, "contact", "c1", "engagement", "e1", role="member")
+    _membership(repo, "engagement", "e1", "organization", "umbrella", role="ticket_of")
+    assert repo.get_org_parent_map() == {}
+
+
+def test_ignores_closed_edges(repo):
+    # A soft-closed edge (left_at set) must not resolve as a live parent.
+    _membership(repo, "organization", "brand-a", "organization", "old-parent", left_at=time.time())
+    assert repo.get_org_parent_map() == {}
+
+
+def test_structural_not_role_filtered(repo):
+    # role is a free-text verb — parentage resolves regardless of the role value.
+    _membership(repo, "organization", "brand-a", "organization", "umbrella", role="subsidiary")
+    assert repo.get_org_parent_map() == {"brand-a": "umbrella"}
+
+
+def test_most_recent_edge_wins(repo):
+    # If an org somehow has two active parent edges, the latest joined_at wins.
+    _membership(repo, "organization", "brand-a", "organization", "old", joined=100.0)
+    _membership(repo, "organization", "brand-a", "organization", "new", joined=200.0)
+    assert repo.get_org_parent_map()["brand-a"] == "new"
+
+
+def test_multiple_orgs(repo):
+    _membership(repo, "organization", "brand-a", "organization", "umbrella")
+    _membership(repo, "organization", "brand-b", "organization", "umbrella")
+    m = repo.get_org_parent_map()
+    assert m == {"brand-a": "umbrella", "brand-b": "umbrella"}


### PR DESCRIPTION
## What

Adds `parent_org_id` to **organization rows** in the `GET /api/v1/entities` projection, so the extension org-tree (commit `0668a3c`, already consuming the flat field, degrading graceful on absence) can render live parents. **Option A** per mesh-support's CCR `prop_kgrbsvrnfvab` — ratified by David.

## Changes

- **`workspace_db.get_org_parent_map()`** — single query → `{child_org_id: parent_org_id}` from active org→org membership edges. One row per child (most recent wins). The org set (umbrella + brands) is small, so this preserves the list endpoint's single-query intent.
- **`entities.list_entities`** — one `get_org_parent_map()` call before the loop (not per-row N+1); org rows get `parent_org_id` (null for umbrella roots), non-org rows omit it.

## Design note — structural, not role-filtered

The CCR spec'd `role='member_of'`, but I keyed parentage on the **structural** org→org edge (`entity_type=organization AND group_type=organization AND left_at IS NULL`) instead. Reason, verified against `workspace.db`: `role` is a free-text verb in `entity-link` (existing edges use `member`/`context`/`ticket_of`), there's **no `member_of` convention**, and 0 org→org edges exist yet — so a `role='member_of'` filter would match nothing. Structural keying is the robust "org belongs to parent org" semantic. **Flagged to mesh-support** (projection-spec owner) for confirmation.

## Tests / gate

- `tests/test_org_parent_map.py` — 7 tests: active mapping, ignores non-org + soft-closed edges, structural-not-role, most-recent-wins, multi-org.
- ruff + pyright clean; live smoke against the real `workspace.db` returns `{}` (no edges → graceful, nothing breaks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)