### PR TITLE
feat(api): GET /api/v1/engagements feed + support.resolved terminal stage (CCR-1)

### DIFF
--- a/empirica/api/routes/engagements.py
+++ b/empirica/api/routes/engagements.py
@@ -1,0 +1,75 @@
+"""Engagements list endpoint — daemon HTTP feed for the X2 board.
+
+GET /api/v1/engagements?org=&domain=&lifecycle= returns the EngagementMin
+projection per row: the engagement sidecar fields (stage / lifecycle / domain /
+outcome), counts (member / goal / linked-artifact), and synthesized metadata
+(org_display via the ticket_of edge + severity/assignee pass-through). The
+extension X2 board is a Chrome MV3 worker with no filesystem/sqlite access — it
+speaks HTTP to the daemon only, and its listEngagements already hits this route.
+
+Auth + loopback boundary are identical to the entities route (shared
+``verify_mint_bearer`` dependency). CCR prop_kiamoy5z, ratified by David.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from empirica.api.entity_mint_auth import verify_mint_bearer
+
+router = APIRouter(prefix="/api/v1", tags=["engagements"])
+
+
+@router.get("/engagements", dependencies=[Depends(verify_mint_bearer)])
+async def list_engagements(
+    org: str | None = Query(None, description="Filter to engagements ticket_of this organization id"),
+    domain: str | None = Query(None, description="Filter by engagement domain (support, sales, ...)"),
+    lifecycle: str | None = Query(None, description="Filter by lifecycle_state (open, in_progress, blocked, closed)"),
+    limit: int = Query(100, ge=1, le=500),
+):
+    """List engagements as EngagementMin[] for the board daemon feed.
+
+    Per row: sidecar fields (id, title, engagement_type, domain, stage,
+    lifecycle_state, status, outcome, started_at, ended_at, updated_at), counts
+    (member_count, goal_count, linked_artifact_count), and a ``metadata`` object
+    (org_display synthesized via the ticket_of edge + pass-through severity /
+    assignee_id / assignee_display from the engagement entity's registry
+    metadata).
+    """
+    from empirica.data.repositories.workspace_db import WorkspaceDBRepository
+
+    out: list[dict] = []
+    with WorkspaceDBRepository.open() as repo:
+        try:
+            rows = repo.list_engagements(org_id=org, domain=domain, lifecycle_state=lifecycle, limit=limit)
+        except ValueError as e:
+            # invalid lifecycle_state — surface as a 422, never a 500.
+            raise HTTPException(status_code=422, detail=str(e)) from e
+        for e in rows:
+            eid = e["engagement_id"]
+            proj = repo.get_engagement_projection(eid)
+            out.append(
+                {
+                    "id": eid,
+                    "title": e.get("title"),
+                    "engagement_type": e.get("engagement_type"),
+                    "domain": e.get("domain"),
+                    "stage": e.get("stage"),
+                    "lifecycle_state": e.get("lifecycle_state"),
+                    "status": e.get("status"),
+                    "outcome": e.get("outcome"),
+                    "started_at": e.get("started_at"),
+                    "ended_at": e.get("ended_at"),
+                    "updated_at": e.get("updated_at"),
+                    "member_count": proj["member_count"],
+                    "goal_count": proj["goal_count"],
+                    "linked_artifact_count": proj["linked_artifact_count"],
+                    "metadata": {
+                        "org_display": proj["org_display"],
+                        "severity": proj["severity"],
+                        "assignee_id": proj["assignee_id"],
+                        "assignee_display": proj["assignee_display"],
+                    },
+                }
+            )
+    return {"ok": True, "count": len(out), "engagements": out}

--- a/empirica/api/serve_app.py
+++ b/empirica/api/serve_app.py
@@ -223,6 +223,12 @@ def create_serve_app() -> FastAPI:
 
     app.include_router(entities_router)
 
+    # Engagements list feed (EngagementMin) — the daemon HTTP source for the
+    # extension X2 board (MV3, HTTP-only).
+    from empirica.api.routes.engagements import router as engagements_router
+
+    app.include_router(engagements_router)
+
     @app.get("/api/v1/health", response_model=HealthResponse)
     async def health():  # pyright: ignore[reportUnusedFunction]
         """Health check — reports integrations, active project info, and

--- a/empirica/data/repositories/workspace_db.py
+++ b/empirica/data/repositories/workspace_db.py
@@ -13,6 +13,7 @@ Usage:
         repo.upsert_project(project_id, name, trajectory_path, ...)
 """
 
+import json
 import logging
 import os
 import sqlite3
@@ -223,6 +224,10 @@ _DEFAULT_ENGAGEMENT_STAGES = [
     ("support.triaged", "support", "Triaged", 20),
     ("support.in_progress", "support", "In progress", 30),
     ("support.waiting_customer", "support", "Waiting customer", 40),
+    # Terminal stage (5-tuple: trailing is_terminal=1). The X2 board's 'resolved'
+    # column shows terminal cards with their outcome badge. Lockstep with
+    # empirica-workspace canonical seed (parity drift-guard).
+    ("support.resolved", "support", "Resolved", 50, 1),
     ("security.reported", "security", "Reported", 10),
     ("security.triaged", "security", "Triaged", 20),
     ("security.mitigating", "security", "Mitigating", 30),
@@ -252,11 +257,13 @@ def _seed_engagement_domains(cursor: sqlite3.Cursor) -> None:
             "(domain_id, display_name, description, visibility, created_at) VALUES (?, ?, ?, ?, ?)",
             (did, dn, desc, "public", now),
         )
-    for sid, dom, dn, ordi in _DEFAULT_ENGAGEMENT_STAGES:
+    for stage in _DEFAULT_ENGAGEMENT_STAGES:
+        sid, dom, dn, ordi = stage[0], stage[1], stage[2], stage[3]
+        is_terminal = stage[4] if len(stage) > 4 else 0  # optional 5th elem
         cursor.execute(
             "INSERT OR IGNORE INTO stage_definitions "
-            "(stage_id, domain, display_name, ordinal, created_at) VALUES (?, ?, ?, ?, ?)",
-            (sid, dom, dn, ordi, now),
+            "(stage_id, domain, display_name, ordinal, is_terminal, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+            (sid, dom, dn, ordi, is_terminal, now),
         )
 
 
@@ -1013,6 +1020,72 @@ class WorkspaceDBRepository(BaseRepository):
             tuple(params),
         )
         return [dict(row) for row in cursor.fetchall()]
+
+    def get_engagement_projection(self, engagement_id: str) -> dict[str, Any]:
+        """Daemon-side EngagementMin enrichment: counts + synthesized metadata.
+
+        ``member_count`` (entity_memberships where the engagement is the group),
+        ``linked_artifact_count`` (entity_artifacts by engagement) and
+        ``goal_count`` are all read from workspace.db; ``org_display`` resolves
+        the ``ticket_of`` edge → organization ``display_name``; severity/assignee
+        pass through from the engagement's ``entity_registry.metadata`` JSON.
+
+        NOTE: ``goal_count`` here is the daemon-LOCAL artifact→goal→engagement
+        linkage (entity_artifacts with artifact_type='goal'). The OPERATIONAL
+        ``goals.engagement_id`` count (migration 051) lives in the per-project
+        empirica.db — cross-db from the daemon's workspace.db — and is deferred.
+        """
+
+        def _count(sql: str, params: tuple) -> int:
+            row = self._execute(sql, params).fetchone()
+            return int(row["n"]) if row else 0
+
+        member_count = _count(
+            "SELECT COUNT(*) AS n FROM entity_memberships "
+            "WHERE group_type = 'engagement' AND group_id = ? AND left_at IS NULL",
+            (engagement_id,),
+        )
+        linked_artifact_count = _count(
+            "SELECT COUNT(*) AS n FROM entity_artifacts WHERE engagement_id = ?",
+            (engagement_id,),
+        )
+        goal_count = _count(
+            "SELECT COUNT(*) AS n FROM entity_artifacts WHERE engagement_id = ? AND artifact_type = 'goal'",
+            (engagement_id,),
+        )
+
+        org_row = self._execute(
+            "SELECT r.display_name AS org_display FROM entity_memberships m "
+            "JOIN entity_registry r ON r.entity_type = 'organization' AND r.entity_id = m.group_id "
+            "WHERE m.entity_type = 'engagement' AND m.entity_id = ? "
+            "AND m.group_type = 'organization' AND m.role = 'ticket_of' AND m.left_at IS NULL "
+            "LIMIT 1",
+            (engagement_id,),
+        ).fetchone()
+        org_display = org_row["org_display"] if org_row else None
+
+        reg = self._execute(
+            "SELECT metadata FROM entity_registry WHERE entity_type = 'engagement' AND entity_id = ?",
+            (engagement_id,),
+        ).fetchone()
+        meta: dict[str, Any] = {}
+        if reg and reg["metadata"]:
+            try:
+                parsed = json.loads(reg["metadata"])
+                if isinstance(parsed, dict):
+                    meta = parsed
+            except (ValueError, TypeError):
+                meta = {}
+
+        return {
+            "member_count": member_count,
+            "goal_count": goal_count,
+            "linked_artifact_count": linked_artifact_count,
+            "org_display": org_display,
+            "severity": meta.get("severity"),
+            "assignee_id": meta.get("assignee_id"),
+            "assignee_display": meta.get("assignee_display"),
+        }
 
     def update_engagement(
         self,

--- a/tests/test_engagement_repository.py
+++ b/tests/test_engagement_repository.py
@@ -144,7 +144,10 @@ def test_list_stages_for_domain_ordered(repo):
         "support.triaged",
         "support.in_progress",
         "support.waiting_customer",
+        "support.resolved",  # CCR-1 terminal stage (ordinal 50)
     ]
+    # the terminal stage carries is_terminal=1
+    assert stages[-1]["is_terminal"] == 1
 
 
 def test_join_practice_domain_idempotent(repo):

--- a/tests/test_engagement_substrate_schema.py
+++ b/tests/test_engagement_substrate_schema.py
@@ -50,13 +50,27 @@ def test_engagements_has_e1_cols_and_no_contacts_fk():
     assert conn.execute("PRAGMA foreign_key_list(engagements)").fetchall() == []
 
 
-def test_seeds_six_domains_twentyfour_stages():
+def test_seeds_six_domains_twentyfive_stages():
     conn = _fresh_db()
     wdb._apply_engagement_substrate(conn.cursor())
     conn.commit()
     domains = {r[0] for r in conn.execute("SELECT domain_id FROM domain_definitions").fetchall()}
     assert domains == {"outreach", "sales", "support", "security", "infra", "onboarding"}
-    assert conn.execute("SELECT COUNT(*) FROM stage_definitions").fetchone()[0] == 24
+    # 25 = 24 + support.resolved (CCR-1 terminal stage). Lockstep with the
+    # empirica-workspace canonical seed + its parity drift-guard.
+    assert conn.execute("SELECT COUNT(*) FROM stage_definitions").fetchone()[0] == 25
+
+
+def test_support_resolved_is_terminal():
+    conn = _fresh_db()
+    wdb._apply_engagement_substrate(conn.cursor())
+    conn.commit()
+    row = conn.execute(
+        "SELECT ordinal, is_terminal FROM stage_definitions WHERE stage_id = 'support.resolved'"
+    ).fetchone()
+    assert row is not None, "support.resolved must be seeded"
+    assert row[0] == 50  # ordinal
+    assert row[1] == 1  # is_terminal
 
 
 def test_apply_is_idempotent():
@@ -66,7 +80,7 @@ def test_apply_is_idempotent():
     wdb._apply_engagement_substrate(cur)  # second run must not raise or duplicate
     conn.commit()
     assert conn.execute("SELECT COUNT(*) FROM domain_definitions").fetchone()[0] == 6
-    assert conn.execute("SELECT COUNT(*) FROM stage_definitions").fetchone()[0] == 24
+    assert conn.execute("SELECT COUNT(*) FROM stage_definitions").fetchone()[0] == 25
 
 
 def test_ensure_workspace_schema_creates_substrate():
@@ -126,8 +140,8 @@ def test_drift_guard_definition_tables_match_canonical():
 
 def test_vendored_seed_ids_are_the_documented_canonical_set():
     """Guards the vendored seed constants against accidental edits. The canonical
-    set (6 domains + 24 stage ids) is documented in empirica-workspace
-    WorkspaceDatabase._seed_engagement_domains."""
+    set (6 domains + 25 stage ids, incl. support.resolved) is documented in
+    empirica-workspace WorkspaceDatabase._seed_engagement_domains."""
     assert {d[0] for d in wdb._DEFAULT_ENGAGEMENT_DOMAINS} == {
         "outreach",
         "sales",
@@ -137,8 +151,9 @@ def test_vendored_seed_ids_are_the_documented_canonical_set():
         "onboarding",
     }
     stage_ids = [s[0] for s in wdb._DEFAULT_ENGAGEMENT_STAGES]
-    assert len(stage_ids) == 24
-    assert len(set(stage_ids)) == 24  # no dupes
+    assert len(stage_ids) == 25
+    assert len(set(stage_ids)) == 25  # no dupes
+    assert "support.resolved" in stage_ids
     # every stage namespaced under one of the 6 domains
     domains = {d[0] for d in wdb._DEFAULT_ENGAGEMENT_DOMAINS}
     assert all(sid.split(".", 1)[0] in domains for sid in stage_ids)

--- a/tests/test_engagements_endpoint.py
+++ b/tests/test_engagements_endpoint.py
@@ -1,0 +1,183 @@
+"""CCR-1 (prop_kiamoy5z): GET /api/v1/engagements EngagementMin feed.
+
+Two layers:
+- get_engagement_projection() — the daemon-side enrichment (counts + synthesized
+  metadata). This is the load-bearing logic; tested directly against an
+  in-memory workspace.db.
+- the route — a TestClient smoke confirming the EngagementMin shape + filters
+  wire through (workspace.db pointed at a temp file via EMPIRICA_WORKSPACE_DB).
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+
+import pytest
+
+from empirica.data.repositories.workspace_db import WorkspaceDBRepository, _ensure_workspace_schema
+
+
+@pytest.fixture
+def repo() -> WorkspaceDBRepository:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    _ensure_workspace_schema(conn)
+    return WorkspaceDBRepository(conn)
+
+
+def _membership(repo, etype, eid, gtype, gid, role=None):
+    now = time.time()
+    repo._execute(
+        """INSERT INTO entity_memberships
+           (entity_type, entity_id, group_type, group_id, role, joined_at, created_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?)""",
+        (etype, eid, gtype, gid, role, now, now),
+    )
+
+
+def _registry(repo, etype, eid, name, metadata=None):
+    now = time.time()
+    repo._execute(
+        """INSERT INTO entity_registry
+           (entity_type, entity_id, display_name, source_db, source_table, created_at, metadata)
+           VALUES (?, ?, ?, 'test', 'test', ?, ?)""",
+        (etype, eid, name, now, json.dumps(metadata) if metadata else None),
+    )
+
+
+def _artifact(repo, artifact_type, artifact_id, engagement_id):
+    now = time.time()
+    repo._execute(
+        """INSERT INTO entity_artifacts
+           (id, artifact_type, artifact_id, entity_type, entity_id, engagement_id, created_at)
+           VALUES (?, ?, ?, 'engagement', ?, ?, ?)""",
+        (f"{artifact_type}-{artifact_id}", artifact_type, artifact_id, engagement_id, engagement_id, now),
+    )
+
+
+# ── get_engagement_projection ────────────────────────────────────────────────
+
+
+def test_projection_zero_when_bare(repo):
+    repo.create_engagement("e1", "Ticket", domain="support", stage="support.new")
+    p = repo.get_engagement_projection("e1")
+    assert p["member_count"] == 0
+    assert p["goal_count"] == 0
+    assert p["linked_artifact_count"] == 0
+    assert p["org_display"] is None
+    assert p["severity"] is None
+    assert p["assignee_id"] is None
+
+
+def test_projection_counts(repo):
+    repo.create_engagement("e1", "Ticket", domain="support", stage="support.new")
+    # 2 members of the engagement
+    _membership(repo, "contact", "c1", "engagement", "e1", role="member")
+    _membership(repo, "contact", "c2", "engagement", "e1", role="member")
+    # 3 linked artifacts, 2 of which are goals
+    _artifact(repo, "finding", "f1", "e1")
+    _artifact(repo, "goal", "g1", "e1")
+    _artifact(repo, "goal", "g2", "e1")
+    p = repo.get_engagement_projection("e1")
+    assert p["member_count"] == 2
+    assert p["linked_artifact_count"] == 3
+    assert p["goal_count"] == 2  # daemon-local artifact→goal linkage
+
+
+def test_projection_org_display_via_ticket_of(repo):
+    repo.create_engagement("e1", "Ticket", domain="support", stage="support.new")
+    _registry(repo, "organization", "o1", "Acme Corp")
+    _membership(repo, "engagement", "e1", "organization", "o1", role="ticket_of")
+    p = repo.get_engagement_projection("e1")
+    assert p["org_display"] == "Acme Corp"
+
+
+def test_projection_org_display_ignores_non_ticket_of(repo):
+    repo.create_engagement("e1", "Ticket", domain="support", stage="support.new")
+    _registry(repo, "organization", "o1", "Acme Corp")
+    # a non-ticket_of edge must not resolve as the org_display
+    _membership(repo, "engagement", "e1", "organization", "o1", role="watching")
+    assert repo.get_engagement_projection("e1")["org_display"] is None
+
+
+def test_projection_severity_assignee_passthrough(repo):
+    repo.create_engagement("e1", "Ticket", domain="support", stage="support.new")
+    _registry(
+        repo,
+        "engagement",
+        "e1",
+        "Ticket",
+        metadata={"severity": "high", "assignee_id": "u-7", "assignee_display": "Sam"},
+    )
+    p = repo.get_engagement_projection("e1")
+    assert p["severity"] == "high"
+    assert p["assignee_id"] == "u-7"
+    assert p["assignee_display"] == "Sam"
+
+
+def test_projection_tolerates_garbage_metadata(repo):
+    repo.create_engagement("e1", "Ticket", domain="support", stage="support.new")
+    repo._execute(
+        """INSERT INTO entity_registry
+           (entity_type, entity_id, display_name, source_db, source_table, created_at, metadata)
+           VALUES ('engagement', 'e1', 'Ticket', 'test', 'test', ?, '{not json')""",
+        (time.time(),),
+    )
+    # must not raise — severity/assignee just resolve to None
+    p = repo.get_engagement_projection("e1")
+    assert p["severity"] is None
+
+
+# ── route smoke (TestClient + temp workspace.db) ─────────────────────────────
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    from fastapi.testclient import TestClient
+
+    db = tmp_path / "workspace.db"
+    monkeypatch.setenv("EMPIRICA_WORKSPACE_DB", str(db))
+    # Seed the temp workspace.db with one support engagement + org + metadata.
+    conn = sqlite3.connect(str(db))
+    conn.row_factory = sqlite3.Row
+    _ensure_workspace_schema(conn)
+    r = WorkspaceDBRepository(conn)
+    r.create_engagement("e1", "Login broken", domain="support", stage="support.resolved")
+    r._execute("UPDATE engagements SET outcome = 'resolved' WHERE engagement_id = 'e1'", ())
+    _registry(r, "organization", "o1", "Acme Corp")
+    _registry(r, "engagement", "e1", "Login broken", metadata={"severity": "high"})
+    _membership(r, "engagement", "e1", "organization", "o1", role="ticket_of")
+    conn.commit()
+    conn.close()
+
+    from empirica.api.serve_app import create_serve_app
+
+    return TestClient(create_serve_app())
+
+
+def test_route_returns_engagement_min(client):
+    r = client.get("/api/v1/engagements")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["ok"] is True
+    assert body["count"] == 1
+    e = body["engagements"][0]
+    assert e["id"] == "e1"
+    assert e["domain"] == "support"
+    assert e["stage"] == "support.resolved"
+    assert e["outcome"] == "resolved"
+    assert e["metadata"]["org_display"] == "Acme Corp"
+    assert e["metadata"]["severity"] == "high"
+    assert e["member_count"] == 0
+
+
+def test_route_domain_filter(client):
+    assert client.get("/api/v1/engagements?domain=support").json()["count"] == 1
+    assert client.get("/api/v1/engagements?domain=sales").json()["count"] == 0
+
+
+def test_route_invalid_lifecycle_422(client):
+    r = client.get("/api/v1/engagements?lifecycle=not_a_state")
+    assert r.status_code == 422


### PR DESCRIPTION
## What

The X2 board daemon feed (extension is Chrome MV3, HTTP-only — no sqlite). Two changes per mesh-support's CCR `prop_kiamoy5z`, ratified by David.

### (1) New endpoint — `GET /api/v1/engagements?org=&domain=&lifecycle=` → `EngagementMin[]`
- Sidecar fields from `repo.list_engagements` (id, title, engagement_type, domain, stage, lifecycle_state, status, outcome, started/ended/updated_at).
- **Counts**: `member_count` (entity_memberships group=engagement), `linked_artifact_count` (entity_artifacts by engagement), `goal_count`.
- **Synthesized metadata**: `org_display` via the `ticket_of` edge → `organization.display_name`; `severity`/`assignee_id`/`assignee_display` pass-through from the engagement entity's `entity_registry.metadata`.
- New repo helper `get_engagement_projection()` bundles the enrichment; invalid `lifecycle` → 422 (never 500). Registered in `serve_app` alongside `entities`.

### (2) Seed — `support.resolved` (ordinal 50, `is_terminal=1`)
Added to core's mirror stage seed. The seed insert now writes `is_terminal` (optional 5th tuple element — **no diff to the 24 existing rows**). The board's 'resolved' column shows terminal cards with their outcome badge.

## ⚠️ Cross-repo lockstep (workspace)

The seed parity drift-guard asserts core's mirror == workspace's canonical. This PR adds `support.resolved` to **core's mirror** + bumps **core's own** parity test 24→25. **@workspace**: land the canonical seed (`support.resolved` + `is_terminal`) + bump your drift-guard `24→25` in the same window so your CI stays green — pinging you with this link.

## Note — goal_count semantics

`goal_count` here is the daemon-**local** artifact→goal linkage (`entity_artifacts artifact_type='goal'`). The **operational** `goals.engagement_id` count (migration 051) lives in the per-project `empirica.db` — cross-db from the daemon's `workspace.db` — and is **deferred**. `member_count` + `linked_artifact_count` are accurate workspace.db reads. Flagged to mesh-support to confirm whether the board needs the operational count.

## Gate (local)

- `tests/test_engagements_endpoint.py` — projection enrichment (counts, org_display, severity passthrough, garbage-metadata tolerance) + route smoke (EngagementMin shape, domain filter, 422).
- substrate + repository stage tests updated 24→25 + terminal-flag assertion.
- 50 engagement-suite tests pass; ruff + pyright clean; route registers in the serve app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)