### PR TITLE
feat(practitioner): emitter sends canonical ai_id → cortex practice_id (B2d)

### DIFF
--- a/empirica/core/loop_scheduler/practitioner_heartbeat.py
+++ b/empirica/core/loop_scheduler/practitioner_heartbeat.py
@@ -75,12 +75,86 @@ def _default_resolve_creds() -> tuple[str | None, str | None]:
         return None, None
 
 
-def _practitioner_body(record: dict[str, Any], *, machine: str) -> dict[str, Any] | None:
+def _default_get(url: str, api_key: str, timeout: float) -> dict[str, Any]:
+    """HTTP GET → parsed JSON dict. Raises on error (callers wrap defensively)."""
+    req = urllib.request.Request(url, method="GET", headers={"Authorization": f"Bearer {api_key}"})
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+# Cached slug → canonical-3-form map (bootstrap-once; the canonical id is stable
+# for the process lifetime — it only changes on org/tenant/project rename, which
+# would require a restart anyway). Only a NON-empty fetch is cached, so a
+# transient failure retries on the next heartbeat.
+_CANONICAL_MAP: dict[str, str] | None = None
+
+
+def _reset_canonical_cache() -> None:
+    """Test seam — clear the cached canonical map."""
+    global _CANONICAL_MAP
+    _CANONICAL_MAP = None
+
+
+def _fetch_canonical_map(
+    resolve_creds_fn: Callable[[], tuple],
+    get_fn: Callable[[str, str, float], dict],
+    timeout: float,
+) -> dict[str, str]:
+    """slug → ai_id_canonical from cortex's GET /v1/users/me/projects.
+
+    cortex composes ai_id_canonical server-side (the strict-canonical 3-form), so
+    the emitter never assembles the string itself. Defensive — {} on any failure.
+    """
+    url, api_key = resolve_creds_fn()
+    if not url or not api_key:
+        return {}
+    try:
+        body = get_fn(f"{url.rstrip('/')}/v1/users/me/projects", api_key, timeout)
+        out: dict[str, str] = {}
+        for proj in body.get("projects") or []:
+            slug, canonical = proj.get("slug"), proj.get("ai_id_canonical")
+            if slug and canonical:
+                out[slug] = canonical
+        return out
+    except Exception:
+        return {}
+
+
+def resolve_canonical_ai_id(
+    practice_basename: str | None,
+    *,
+    resolve_creds_fn: Callable[[], tuple] = _default_resolve_creds,
+    get_fn: Callable[[str, str, float], dict] = _default_get,
+    timeout: float = _DEFAULT_TIMEOUT_SEC,
+) -> str | None:
+    """Resolve a practice basename (e.g. 'empirica') → its canonical 3-form.
+
+    ai_id is the PRACTICE ANCHOR cortex stores as practice_id; a bare basename
+    fails cortex's strict-canonical resolver, so the emitter must send the
+    canonical 3-form. Returns None when unresolvable → the emitter omits ai_id
+    (graceful NULL practice_id, the back-compat path).
+    """
+    global _CANONICAL_MAP
+    if not practice_basename:
+        return None
+    if _CANONICAL_MAP is None:
+        fetched = _fetch_canonical_map(resolve_creds_fn, get_fn, timeout)
+        if fetched:  # cache only a successful (non-empty) fetch
+            _CANONICAL_MAP = fetched
+        return fetched.get(practice_basename)
+    return _CANONICAL_MAP.get(practice_basename)
+
+
+def _practitioner_body(
+    record: dict[str, Any], *, machine: str, canonical_ai_id: str | None = None
+) -> dict[str, Any] | None:
     """Map a local presence record → cortex heartbeat body. None if unmappable.
 
-    ``ai_id`` is intentionally omitted (see module docstring). ``machine`` and
-    ``session_id`` are cortex-required and non-empty; a record without a
-    ``claude_session_id`` cannot be emitted and returns None.
+    ``machine`` and ``session_id`` are cortex-required and non-empty; a record
+    without a ``claude_session_id`` cannot be emitted and returns None.
+    ``ai_id`` is the canonical 3-form (the practice anchor cortex resolves to
+    practice_id) — included only when resolvable; omitted otherwise (cortex then
+    leaves practice_id NULL, the back-compat path).
     """
     session_id = (record.get("claude_session_id") or "").strip()
     if not session_id or not machine:
@@ -95,6 +169,8 @@ def _practitioner_body(record: dict[str, Any], *, machine: str) -> dict[str, Any
         "practitioner_id": record.get("practitioner_id"),
         "pending_question": record.get("pending_question"),
     }
+    if canonical_ai_id:
+        body["ai_id"] = canonical_ai_id
     # When blocked, surface the reason in cortex's blocked_reason column too.
     if status == "blocked" and record.get("pending_question"):
         body["blocked_reason"] = record["pending_question"]
@@ -107,9 +183,13 @@ def emit_practitioner_heartbeat(
     machine: str | None = None,
     post_fn: Callable[[str, bytes, dict, float], int] = _default_post,
     resolve_creds_fn: Callable[[], tuple] = _default_resolve_creds,
+    get_fn: Callable[[str, str, float], dict] = _default_get,
     timeout: float = _DEFAULT_TIMEOUT_SEC,
 ) -> int:
     """Emit one local presence record to cortex's practitioners/heartbeat.
+
+    Resolves the practice basename → canonical 3-form (so cortex populates
+    practice_id) and sends it as ``ai_id``; omits ai_id when unresolvable.
 
     Returns the HTTP status code: 200 on success, 4xx/5xx on cortex error, -1 on
     network failure, 0 when skipped (cortex creds unconfigured, or the record is
@@ -118,7 +198,12 @@ def emit_practitioner_heartbeat(
     url, api_key = resolve_creds_fn()
     if not url or not api_key:
         return 0  # SKIP — cortex not configured
-    body = _practitioner_body(record, machine=machine or socket.gethostname() or "unknown-host")
+    canonical = resolve_canonical_ai_id(
+        record.get("practice_ai_id"), resolve_creds_fn=resolve_creds_fn, get_fn=get_fn, timeout=timeout
+    )
+    body = _practitioner_body(
+        record, machine=machine or socket.gethostname() or "unknown-host", canonical_ai_id=canonical
+    )
     if body is None:
         return 0  # SKIP — unmappable record
     endpoint = f"{url.rstrip('/')}{_HEARTBEAT_ENDPOINT_PATH}"
@@ -160,6 +245,7 @@ class PractitionerHeartbeatEmitter:
         timeout_sec: float = _DEFAULT_TIMEOUT_SEC,
         _post_fn: Callable[[str, bytes, dict, float], int] = _default_post,
         _resolve_creds_fn: Callable[[], tuple] = _default_resolve_creds,
+        _get_fn: Callable[[str, str, float], dict] = _default_get,
         _list_fn: Callable[[], list] | None = None,
     ):
         self.machine = machine or socket.gethostname() or "unknown-host"
@@ -167,6 +253,7 @@ class PractitionerHeartbeatEmitter:
         self.timeout_sec = timeout_sec
         self._post_fn = _post_fn
         self._resolve_creds_fn = _resolve_creds_fn
+        self._get_fn = _get_fn
         self._list_fn = _list_fn or self._default_list
         self._stop_event = threading.Event()
         self._thread: threading.Thread | None = None
@@ -218,6 +305,7 @@ class PractitionerHeartbeatEmitter:
                     machine=self.machine,
                     post_fn=self._post_fn,
                     resolve_creds_fn=self._resolve_creds_fn,
+                    get_fn=self._get_fn,
                     timeout=self.timeout_sec,
                 )
             except Exception as e:

--- a/tests/test_practitioner_heartbeat.py
+++ b/tests/test_practitioner_heartbeat.py
@@ -19,14 +19,31 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
 from empirica.core.loop_scheduler.practitioner_heartbeat import (
     PractitionerHeartbeatEmitter,
     _practitioner_body,
+    _reset_canonical_cache,
     emit_practitioner_heartbeat,
+    resolve_canonical_ai_id,
 )
 
 CREDS = lambda: ("https://cortex.test/", "key-abc")  # noqa: E731
 NO_CREDS = lambda: (None, None)  # noqa: E731
+
+# A fake projects-endpoint GET resolving the test practice → canonical 3-form.
+PROJECTS_BODY = {"projects": [{"slug": "empirica", "ai_id_canonical": "empirica.david.empirica"}]}
+GET_PROJECTS = lambda url, key, timeout: PROJECTS_BODY  # noqa: E731
+GET_EMPTY = lambda url, key, timeout: {"projects": []}  # noqa: E731
+
+
+@pytest.fixture(autouse=True)
+def _clear_canonical_cache():
+    """The slug→canonical map is a module-level cache; reset it around each test."""
+    _reset_canonical_cache()
+    yield
+    _reset_canonical_cache()
 
 
 def _record(**over):
@@ -60,9 +77,15 @@ class _Recorder:
 # ---- _practitioner_body --------------------------------------------------
 
 
-def test_body_omits_ai_id():
+def test_body_omits_ai_id_when_unresolved():
+    # No canonical passed → ai_id omitted (cortex leaves practice_id NULL).
     body = _practitioner_body(_record(), machine="host-1")
-    assert "ai_id" not in body  # strict-canonical resolver would 403 a basename
+    assert "ai_id" not in body
+
+
+def test_body_includes_canonical_ai_id():
+    body = _practitioner_body(_record(), machine="host-1", canonical_ai_id="empirica.david.empirica")
+    assert body["ai_id"] == "empirica.david.empirica"  # the practice anchor
 
 
 def test_body_maps_required_and_optional_fields():
@@ -102,27 +125,35 @@ def test_emit_skips_when_no_creds():
 
 def test_emit_skips_unmappable_record():
     rec = _Recorder()
-    code = emit_practitioner_heartbeat(_record(claude_session_id=""), post_fn=rec, resolve_creds_fn=CREDS)
+    code = emit_practitioner_heartbeat(
+        _record(claude_session_id=""), post_fn=rec, resolve_creds_fn=CREDS, get_fn=GET_EMPTY
+    )
     assert code == 0
     assert rec.calls == []
 
 
-def test_emit_posts_to_endpoint_with_bearer():
+def test_emit_posts_with_canonical_ai_id():
     rec = _Recorder(code=200)
-    code = emit_practitioner_heartbeat(_record(), machine="host-1", post_fn=rec, resolve_creds_fn=CREDS)
+    code = emit_practitioner_heartbeat(
+        _record(), machine="host-1", post_fn=rec, resolve_creds_fn=CREDS, get_fn=GET_PROJECTS
+    )
     assert code == 200
-    assert len(rec.calls) == 1
     call = rec.calls[0]
     assert call["url"] == "https://cortex.test/v1/practitioners/heartbeat"  # rstrip('/') applied
     assert call["headers"]["Authorization"] == "Bearer key-abc"
-    assert call["headers"]["Content-Type"] == "application/json"
     assert call["body"]["session_id"] == "cc-1"
-    assert "ai_id" not in call["body"]
+    assert call["body"]["ai_id"] == "empirica.david.empirica"  # resolved practice anchor
+
+
+def test_emit_omits_ai_id_when_canonical_unresolved():
+    rec = _Recorder(code=200)
+    emit_practitioner_heartbeat(_record(), machine="host-1", post_fn=rec, resolve_creds_fn=CREDS, get_fn=GET_EMPTY)
+    assert "ai_id" not in rec.calls[0]["body"]  # graceful — back-compat NULL practice_id
 
 
 def test_emit_propagates_error_code():
     rec = _Recorder(code=403)
-    code = emit_practitioner_heartbeat(_record(), post_fn=rec, resolve_creds_fn=CREDS)
+    code = emit_practitioner_heartbeat(_record(), post_fn=rec, resolve_creds_fn=CREDS, get_fn=GET_PROJECTS)
     assert code == 403
 
 
@@ -136,12 +167,15 @@ def test_emit_once_emits_each_local_practitioner():
         machine="host-1",
         _post_fn=rec,
         _resolve_creds_fn=CREDS,
+        _get_fn=GET_PROJECTS,
         _list_fn=lambda: records,
     )
     results = emitter.emit_once()
     assert results == {"cc-a": 200, "cc-b": 200}
     assert len(rec.calls) == 2
     assert {c["body"]["session_id"] for c in rec.calls} == {"cc-a", "cc-b"}
+    # canonical ai_id resolved + attached on each
+    assert all(c["body"]["ai_id"] == "empirica.david.empirica" for c in rec.calls)
 
 
 def test_emit_once_survives_list_failure():
@@ -173,3 +207,45 @@ def test_start_stop_idempotent():
     emitter.stop(timeout=2.0)
     emitter.stop(timeout=2.0)  # idempotent
     assert emitter._thread is None
+
+
+# ---- resolve_canonical_ai_id (slug → canonical 3-form, cached) ---------------
+
+
+def test_resolve_canonical_hit():
+    canon = resolve_canonical_ai_id("empirica", resolve_creds_fn=CREDS, get_fn=GET_PROJECTS)
+    assert canon == "empirica.david.empirica"
+
+
+def test_resolve_canonical_unknown_basename():
+    assert resolve_canonical_ai_id("not-a-practice", resolve_creds_fn=CREDS, get_fn=GET_PROJECTS) is None
+
+
+def test_resolve_canonical_none_inputs():
+    assert resolve_canonical_ai_id(None, resolve_creds_fn=CREDS, get_fn=GET_PROJECTS) is None
+    assert resolve_canonical_ai_id("empirica", resolve_creds_fn=NO_CREDS, get_fn=GET_PROJECTS) is None
+
+
+def test_resolve_canonical_caches_successful_fetch():
+    calls = {"n": 0}
+
+    def _counting_get(url, key, timeout):
+        calls["n"] += 1
+        return PROJECTS_BODY
+
+    resolve_canonical_ai_id("empirica", resolve_creds_fn=CREDS, get_fn=_counting_get)
+    resolve_canonical_ai_id("empirica", resolve_creds_fn=CREDS, get_fn=_counting_get)
+    assert calls["n"] == 1  # second lookup hits the cache, no re-fetch
+
+
+def test_resolve_canonical_retries_after_empty_fetch():
+    # An empty (failed) fetch must NOT be cached — the next call retries.
+    calls = {"n": 0}
+
+    def _flaky_get(url, key, timeout):
+        calls["n"] += 1
+        return {"projects": []} if calls["n"] == 1 else PROJECTS_BODY
+
+    assert resolve_canonical_ai_id("empirica", resolve_creds_fn=CREDS, get_fn=_flaky_get) is None
+    assert resolve_canonical_ai_id("empirica", resolve_creds_fn=CREDS, get_fn=_flaky_get) == "empirica.david.empirica"
+    assert calls["n"] == 2


### PR DESCRIPTION
## What

The heartbeat emitter now resolves the practice basename → its canonical 3-form and sends it as `ai_id`, so cortex populates `practice_id` (and the row appears in practice-scoped `GET /presence` reads). Closes the B2c omit-`ai_id` gap after cortex made `ai_id` the practice anchor + shipped `ai_id_canonical` (cortex `47bbc80`).

## Changes

- **`resolve_canonical_ai_id(basename)`** — cached `slug → ai_id_canonical` map from cortex's `GET /v1/users/me/projects`. cortex composes the strict-canonical 3-form server-side, so the emitter never assembles the string. Bootstrap-once; **only a non-empty fetch is cached** so transient failures retry on the next heartbeat.
- **`_practitioner_body` / `emit_practitioner_heartbeat`** — include `ai_id` when resolvable, omit otherwise (graceful NULL `practice_id` — the back-compat path). `get_fn` seam threaded through the emitter for testing.
- **Status** — no change needed; local `active`/`idle`/`paused`/`blocked` are all valid in cortex's enum now that it added `paused` (the sentinel-paused state).

## Validated against cortex prod

- basename `empirica` → `empirica.david.empirica` (via `/v1/users/me/projects`, 35 projects).
- POST response shows `practice_id` populated (`748a81a2-…` = the empirica project UUID).
- practice-scoped `GET /v1/practitioners/empirica.david.empirica/presence` returns the row (NULL-`practice_id` rows excluded). CLI path + direct POST both confirmed.

## Gate

- 17 emitter tests (canonical hit/miss, cache, retry-after-empty, ai_id-in-body, graceful omit) + CLI tests pass; ruff + pyright clean.

## Scope note

The **live instance-detection refresh** (re-resolve `presence.location` per heartbeat) is a **separate session-side slice** — the persistent-service emitter can't detect a session's tmux pane (it'd stamp its own). Per David's "separate controller" framing; tracked under goal 29c3f06b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)