### PR TITLE
fix(sentinel): transaction resolver must prefer OPEN over stale CLOSED (B3 regression)

### DIFF
--- a/empirica/plugins/claude-code-integration/hooks/sentinel-gate.py
+++ b/empirica/plugins/claude-code-integration/hooks/sentinel-gate.py
@@ -830,10 +830,17 @@ def _find_transaction_file(
     if exact.exists():
         return exact
 
-    # Fallback: scan suffix-mismatched files. Prefer the durable
-    # claude_session_id (survives compaction); fall back to empirica session_id.
+    # Fallback: scan suffix-mismatched files. Rank candidates and return the best
+    # rather than the first sorted match — claude_session_id is stable across the
+    # whole CC session, so many files (one per past transaction, each
+    # POSTFLIGHT-closed) share it; returning the first would resolve a STALE
+    # CLOSED transaction and make this firewall block praxic after a valid CHECK.
+    # Rank by (cc_match, is_open, updated_at) descending. Kept in sync with
+    # empirica/utils/session_resolver.py:_find_transaction_file.
     if not claude_session_id and not session_id:
         return None
+    best_rank = None
+    best_file = None
     try:
         for tx_file in sorted(empirica_dir.glob("active_transaction*.json")):
             try:
@@ -841,14 +848,17 @@ def _find_transaction_file(
                     tx_data = json.load(f)
             except Exception:
                 continue
-            if claude_session_id and tx_data.get("claude_session_id") == claude_session_id:
-                return tx_file
-            if session_id and tx_data.get("session_id") == session_id:
-                return tx_file
+            cc_match = bool(claude_session_id and tx_data.get("claude_session_id") == claude_session_id)
+            sess_match = bool(session_id and tx_data.get("session_id") == session_id)
+            if not (cc_match or sess_match):
+                continue
+            rank = (cc_match, tx_data.get("status") == "open", tx_data.get("updated_at") or 0.0)
+            if best_rank is None or rank > best_rank:
+                best_rank, best_file = rank, tx_file
     except Exception:
-        pass
+        return None
 
-    return None
+    return best_file
 
 
 def _resolve_empirica_session_id(claude_session_id: str | None) -> str | None:

--- a/empirica/utils/session_resolver.py
+++ b/empirica/utils/session_resolver.py
@@ -1227,12 +1227,19 @@ def _find_transaction_file(
     if exact.exists():
         return exact
 
-    # Fallback: scan for suffix-mismatched files. Prefer the durable
-    # claude_session_id (survives compaction); fall back to the empirica
-    # session_id (may have rotated). Either key scopes the scan to prevent
-    # cross-instance cross-talk.
+    # Fallback: scan for suffix-mismatched files. Rank candidates and return the
+    # best rather than the first sorted match — claude_session_id is stable
+    # across the whole CC session, so many files (one per past transaction, each
+    # POSTFLIGHT-closed) share it; returning the first would resolve a STALE
+    # CLOSED transaction and make the firewall block praxic after a valid CHECK.
+    # Rank by (cc_match, is_open, updated_at) descending: prefer the durable
+    # claude_session_id over the (rotating) empirica session_id, an OPEN
+    # transaction over a closed one, and the most recent over the old. Either
+    # key scopes the scan to prevent cross-instance cross-talk.
     if not claude_session_id and not session_id:
         return None
+    best_rank: tuple | None = None
+    best_file: Path | None = None
     try:
         for tx_file in sorted(empirica_dir.glob("active_transaction*.json")):
             try:
@@ -1240,23 +1247,21 @@ def _find_transaction_file(
                     tx_data = json.load(f)
             except Exception:
                 continue
-            if claude_session_id and tx_data.get("claude_session_id") == claude_session_id:
-                logger.debug(
-                    f"Transaction resolved by durable claude_session_id: "
-                    f"expected suffix '{suffix}', found '{tx_file.name}'"
-                )
-                return tx_file
-            if session_id and tx_data.get("session_id") == session_id:
-                logger.debug(
-                    f"Transaction suffix mismatch resolved: "
-                    f"expected '{suffix}', found '{tx_file.name}' "
-                    f"(session={session_id[:8]})"
-                )
-                return tx_file
+            cc_match = bool(claude_session_id and tx_data.get("claude_session_id") == claude_session_id)
+            sess_match = bool(session_id and tx_data.get("session_id") == session_id)
+            if not (cc_match or sess_match):
+                continue
+            rank = (cc_match, tx_data.get("status") == "open", tx_data.get("updated_at") or 0.0)
+            if best_rank is None or rank > best_rank:
+                best_rank, best_file = rank, tx_file
     except Exception:
-        pass
-
-    return None
+        return None
+    if best_file is not None:
+        logger.debug(
+            f"Transaction resolved by scan: expected suffix '{suffix}', "
+            f"found '{best_file.name}' (rank cc/open/recent={best_rank})"
+        )
+    return best_file
 
 
 def read_active_transaction_full(claude_session_id: str | None = None) -> dict | None:

--- a/tests/test_transaction_dual_key.py
+++ b/tests/test_transaction_dual_key.py
@@ -115,6 +115,36 @@ def test_find_no_crosstalk_between_practitioners(tmp_path):
     assert _find_transaction_file(ed, "_tmux_9", None, "cc-MINE") is None
 
 
+# ---- prefer OPEN over stale CLOSED (the B3-slice-1 regression) -----------
+
+
+def test_find_prefers_open_over_closed_same_cc(tmp_path):
+    """The bug: a CC session accumulates one tx file per past (closed) transaction
+    plus the current open one, all sharing claude_session_id. The resolver must
+    NOT return the stale closed file just because it sorts first."""
+    ed = tmp_path / ".empirica"
+    # 'aaa' sorts before 'zzz' — the closed file is encountered first.
+    _write_tx(ed, "_aaa", transaction_id="T-CLOSED", claude_session_id="cc-1", status="closed")
+    open_p = _write_tx(ed, "_zzz", transaction_id="T-OPEN", claude_session_id="cc-1", status="open")
+    assert _find_transaction_file(ed, "_tmux_9", None, "cc-1") == open_p
+
+
+def test_find_returns_closed_when_only_closed(tmp_path):
+    """Read-of-closed is preserved: if the only cc-match is closed (no open
+    transaction), it's still resolvable (read_active_transaction_full needs it)."""
+    ed = tmp_path / ".empirica"
+    closed_p = _write_tx(ed, "_aaa", transaction_id="T-CLOSED", claude_session_id="cc-1", status="closed")
+    assert _find_transaction_file(ed, "_tmux_9", None, "cc-1") == closed_p
+
+
+def test_find_prefers_most_recent_open(tmp_path):
+    """Among open cc-matches, the most recently updated wins."""
+    ed = tmp_path / ".empirica"
+    _write_tx(ed, "_aaa", transaction_id="T-OLD", claude_session_id="cc-1", status="open", updated_at=100.0)
+    new_p = _write_tx(ed, "_bbb", transaction_id="T-NEW", claude_session_id="cc-1", status="open", updated_at=200.0)
+    assert _find_transaction_file(ed, "_tmux_9", None, "cc-1") == new_p
+
+
 # ---- firewall hook copy mirrors the package -----------------------------
 
 


### PR DESCRIPTION
## The bug (firewall-correctness regression from B3 slice 1 / #161)

B3 made `claude_session_id` a match key in `_find_transaction_file`, but the fallback scan returned the **first** sorted glob match **regardless of open/closed status**. `claude_session_id` is stable across the *whole* CC session, so a session accumulates many transaction files (one per past transaction, each POSTFLIGHT-closed), all sharing the `cc`. The scan readily resolved a **stale closed** file → the firewall read `status: closed` → blocked praxic **right after a valid CHECK** (`Epistemic loop closed`).

Hit live during B2d: an edit was blocked mid-praxic. **Reproduced** deterministically: two files sharing a `cc` (closed sorting first, one open) → resolver returned the closed one.

## The fix

Both copies — `session_resolver.py` and the standalone `sentinel-gate.py` hook (firewall path) — now **rank** candidates by `(cc_match, is_open, updated_at)` descending and return the best, instead of the first match:
- prefers the durable `claude_session_id` over the (rotating) empirica `session_id` (preserves B3 intent),
- prefers an **OPEN** transaction over a closed one (fixes the bug),
- most-recent over old.

**Read-of-closed preserved:** when the only `cc`-match is closed (no open transaction), it's still returned — `read_active_transaction_full` needs that for cross-compact continuity. Verified safe across all three consumers (firewall, `read_active_transaction_full`, `increment_transaction_tool_count`).

## Gate

- `tests/test_transaction_dual_key.py` — +3 regression tests (prefers-open-over-closed-same-cc, returns-closed-when-only-closed, prefers-most-recent-open).
- **65** resolver/sentinel/compact tests pass; ruff + pyright clean; hook `py_compile` clean.
- **Verified live**: the resolver now returns this session's OPEN transaction, not the stale closed one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)