### PR TITLE
fix(sentinel): universal recovery/measurement pre-gate (release-path invariant)

### DIFF
--- a/empirica/plugins/claude-code-integration/hooks/sentinel-gate.py
+++ b/empirica/plugins/claude-code-integration/hooks/sentinel-gate.py
@@ -794,6 +794,86 @@ def is_transition_command(command: str) -> bool:
     return False
 
 
+# Recovery + measurement verbs that must be ALWAYS-OPEN, before every gate.
+# The release-path invariant: a gate must never block the action that clears it.
+# This set = the measurement-cycle gate-releases (preflight/check/postflight),
+# the epistemic-logging remedy that gates demand ("investigate and log"), the
+# self-heal verbs (a stale-gated box must run its own fix), and the manual
+# sentinel/listener controls. Curated subset of the Tier-1/Tier-2 whitelists.
+_RECOVERY_MEASUREMENT_PREFIXES = (
+    # Measurement-cycle gate releases (+ documented short aliases).
+    "empirica preflight-submit",
+    "empirica check-submit",
+    "empirica postflight-submit",
+    "empirica preflight",
+    "empirica postflight",
+    # Epistemic logging — the "investigate and log learnings first" remedy.
+    "empirica finding-log",
+    "empirica unknown-log",
+    "empirica deadend-log",
+    "empirica mistake-log",
+    "empirica log-mistake",
+    "empirica assumption-log",
+    "empirica decision-log",
+    "empirica log-artifacts",
+    "empirica resolve-artifacts",
+    "empirica delete-artifacts",
+    "empirica source-add",
+    "empirica note",
+    "empirica unknown-resolve",
+    # Recovery / self-heal — must run even from a stale-gated box.
+    "empirica doctor",
+    "empirica diagnose",
+    "empirica setup-claude-code",
+    "empirica plugin-sync",
+    # Sentinel / listener control — manual override + liveness.
+    "empirica sentinel",
+    "empirica listener",
+    "empirica loop",
+)
+
+
+def _is_recovery_or_measurement_action(tool_name: str, tool_input: dict | None) -> bool:
+    """Release-path invariant: recovery + measurement actions are ALWAYS allowed,
+    before every gate, so no gate (present or future) can trap a practitioner by
+    blocking the very action that clears it.
+
+    Robust to command shape. The failure that motivated this: a ``cd <path>``
+    followed by a NEWLINE then an ``empirica <verb> - <<EOF`` heredoc is
+    mis-parsed as praxic by is_safe_bash_command (only the ``&&`` form parsed) —
+    so the heredoc forms of check-submit / postflight-submit fell through to the
+    authorization pipeline and the rush-guard trapped them. We normalize ONLY a
+    leading ``cd <path>\\n`` to ``cd <path> && `` (leaving heredoc-body newlines
+    intact), then reuse is_safe_bash_command's segment-safety (which correctly
+    rejects chained praxic like ``&& rm -rf`` and allows benign ``| tail``),
+    and finally require that a recovery/measurement VERB is actually present so
+    the universal exemption stays narrow.
+    """
+    # Empirica MCP tools are epistemic workflow — always allowed.
+    if tool_name.startswith(EMPIRICA_MCP_PREFIX):
+        return True
+    if tool_name != "Bash" or not tool_input:
+        return False
+    command = tool_input.get("command") or ""
+    if not command.strip():
+        return False
+    # The sentinel pause/unpause toggle is a manual recovery override.
+    if is_toggle_command(command.strip()):
+        return True
+    # Normalize a leading `cd <path>\n` → `cd <path> && ` (the one shape
+    # is_safe_bash_command mis-parses); heredoc-body newlines are untouched.
+    normalized = re.sub(r"\A(\s*cd\s+[^\n&;|]+)\n", r"\1 && ", command, count=1)
+    # Reuse battle-tested segment-safety: rejects chained praxic, allows pipes
+    # to read-only filters. A command that isn't fully safe is never exempted.
+    if not is_safe_bash_command({"command": normalized}):
+        return False
+    # Narrow to the recovery/measurement set: strip a leading `cd … &&`, then
+    # take the leading token before any heredoc / pipe.
+    after_cd = re.sub(r"\A\s*cd\s+[^\n&;|]+\s*&&\s*", "", normalized, count=1)
+    leading = after_cd.split("<<", 1)[0].split("|", 1)[0].strip()
+    return any(leading.startswith(prefix) for prefix in _RECOVERY_MEASUREMENT_PREFIXES)
+
+
 # --- AUTONOMY CALIBRATION LOOP ---
 # Tracks tool call count per transaction and nudges at adaptive thresholds.
 # The nudge is informational — Claude decides when to POSTFLIGHT based on
@@ -3456,6 +3536,17 @@ def main():
 
     _track_tool_usage(hook_input, tool_name, tool_input)
     _set_file_relevance_nudge(tool_name, tool_input, hook_input.get("session_id"))
+
+    # Release-path invariant (universal pre-gate): recovery + measurement actions
+    # are ALWAYS-OPEN, evaluated BEFORE every other gate. No gate — rush-guard,
+    # proportionality, stale-detection, transaction-enforcer, or any future one —
+    # may block the action that clears it (check/postflight to release the
+    # measurement gates, *-log/note to satisfy "investigate and log first",
+    # doctor/setup-claude-code to self-heal a stale box, sentinel pause/resume to
+    # override). One chokepoint → parity-by-construction, not per-gate discipline.
+    if _is_recovery_or_measurement_action(tool_name, tool_input):
+        respond("allow", "Release-path exemption: recovery/measurement action (always-open)")
+        sys.exit(0)
 
     # Tx-AG: investigation-proportionality budget enforcement. When
     # tool-router.py armed the budget on a hypothesis-bearing prompt,

--- a/tests/test_sentinel_release_path.py
+++ b/tests/test_sentinel_release_path.py
@@ -1,0 +1,114 @@
+"""Release-path invariant: the Sentinel's universal recovery/measurement pre-gate.
+
+A gate must never block the action that clears it. _is_recovery_or_measurement_action
+is main()'s first check — recovery + measurement actions are always-open before any
+gate. These tests pin both halves of the contract:
+- the trapped shapes are now exempt (the cd-newline-heredoc check-submit that the
+  rush-guard caught), across single-line / && / newline / pipe forms;
+- the exemption does NOT open a chained-praxic hole (`empirica check-submit && rm`
+  or a pipe to a destructive command is NOT exempt).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+def _load_hook():
+    hook_path = Path(__file__).resolve().parents[1] / "empirica/plugins/claude-code-integration/hooks/sentinel-gate.py"
+    if not hook_path.exists():
+        pytest.skip("sentinel-gate.py not found")
+    spec = importlib.util.spec_from_file_location("sentinel_gate_release_path", hook_path)
+    module = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(module)
+    except Exception as e:
+        pytest.skip(f"sentinel-gate.py not importable here: {e}")
+    return module
+
+
+@pytest.fixture(scope="module")
+def sg():
+    return _load_hook()
+
+
+def _bash(sg, command):
+    return sg._is_recovery_or_measurement_action("Bash", {"command": command})
+
+
+# ---- exempt: the trapped recovery shapes --------------------------------
+
+
+def test_exempt_single_line_check_submit(sg):
+    assert _bash(sg, "empirica check-submit --session x") is True
+
+
+def test_exempt_cd_newline_heredoc_check_submit(sg):
+    # THE bug: cd<newline>empirica <verb> - <<EOF — was mis-parsed as praxic.
+    cmd = "cd /home/u/proj\nempirica check-submit - <<'EOF'\n{\"vectors\": {}}\nEOF"
+    assert _bash(sg, cmd) is True
+
+
+def test_exempt_cd_amp_heredoc_postflight(sg):
+    cmd = "cd /home/u/proj && empirica postflight-submit - <<'EOF'\n{}\nEOF"
+    assert _bash(sg, cmd) is True
+
+
+def test_exempt_preflight_heredoc(sg):
+    cmd = "cd /x\nempirica preflight-submit - <<'EOF'\n{}\nEOF"
+    assert _bash(sg, cmd) is True
+
+
+def test_exempt_finding_log_piped_to_tail(sg):
+    # The common form: a benign read-only pipe filter is allowed.
+    assert _bash(sg, "cd /x\nempirica finding-log --finding y | tail -1") is True
+
+
+def test_exempt_note_and_logs(sg):
+    assert _bash(sg, "empirica note 'check later'") is True
+    assert _bash(sg, "empirica decision-log --choice a --rationale b") is True
+    assert _bash(sg, "empirica mistake-log --mistake a --why-wrong b") is True
+
+
+def test_exempt_self_heal_and_control(sg):
+    assert _bash(sg, "empirica doctor") is True
+    assert _bash(sg, "empirica setup-claude-code --force") is True
+    assert _bash(sg, "empirica listener off") is True
+
+
+def test_exempt_empirica_mcp_tool(sg):
+    assert sg._is_recovery_or_measurement_action("mcp__empirica__noetic_batch", {}) is True
+
+
+# ---- NOT exempt: the security boundary ----------------------------------
+
+
+def test_not_exempt_chained_praxic(sg):
+    # A recovery verb chained with a praxic command must NOT be exempted.
+    assert _bash(sg, "empirica check-submit x && rm -rf /tmp/foo") is False
+
+
+def test_not_exempt_pipe_to_destructive(sg):
+    assert _bash(sg, "empirica finding-log --finding y | rm -rf /tmp") is False
+
+
+def test_not_exempt_non_recovery_empirica(sg):
+    # goals-create is workflow but not a gate-release/recovery verb — it goes
+    # through the normal path, not the universal exemption.
+    assert _bash(sg, "empirica goals-create --objective x") is False
+
+
+def test_not_exempt_plain_praxic_bash(sg):
+    assert _bash(sg, "rm -rf /tmp/foo") is False
+    assert _bash(sg, "git commit -m x") is False
+
+
+def test_not_exempt_non_bash_praxic_tool(sg):
+    assert (
+        sg._is_recovery_or_measurement_action("Edit", {"file_path": "/x", "old_string": "a", "new_string": "b"})
+        is False
+    )
+    assert sg._is_recovery_or_measurement_action("Write", {"file_path": "/x", "content": "y"}) is False


### PR DESCRIPTION
## The invariant

**A gate must never block the action that clears it.** This session hit the class **three times**: a stale gate self-blocking `setup-claude-code --force`; the postflight rush-block gating `postflight-submit`; and the rush-guard gating `check-submit` (the CHECK that releases it — David had to manually pause the Sentinel to unblock me). Per-gate exemptions don't kill the class; the next gate forgets. The fix is **parity-by-construction**: one universal pre-gate.

## The fix

`_is_recovery_or_measurement_action()` runs as `main()`'s **first** check, before every gate (proportionality → noetic-firewall → exemptions → authorization-pipeline+rush-guard). Recovery + measurement actions are always-open:
- **gate releases**: `preflight`/`check`/`postflight-submit`
- **the "investigate and log learnings first" remedy**: `*-log`, `note`, `source-add`, `unknown-resolve`, `{log,resolve,delete}-artifacts`
- **self-heal**: `doctor`, `diagnose`, `setup-claude-code`, `plugin-sync`
- **manual control**: sentinel pause/resume toggle, `listener`, `loop`
- all `empirica` MCP tools

## Robust to command shape (the actual trap)

The trapped case was `cd <path>` + **newline** + `empirica <verb> - <<EOF` — which `is_safe_bash_command` mis-parses as praxic (only the `&&` form parsed), so heredoc `check`/`postflight` fell through to the pipeline and the rush-guard caught them. The pre-gate normalizes **only** a leading `cd\n` → `cd && ` (heredoc bodies untouched), then **reuses** `is_safe_bash_command`'s segment-safety (rejects chained praxic like `&& rm -rf`, allows benign `| tail`), and finally requires a recovery verb so the exemption stays narrow.

## Tests — both halves of the contract

`tests/test_sentinel_release_path.py` (13): the trapped shapes are now exempt (single-line / `&&` / cd-newline-heredoc / pipe-to-tail), **and** the security boundary holds — chained praxic, pipe-to-destructive, non-recovery verbs (`goals-create`), and non-Bash tools (Edit/Write) are **not** exempt. ruff + pyright clean.

## Lanes

`sentinel-gate.py` is my lane; the **exempt-set is flagged to autonomy** (control-model/gating-semantics lane) for ratification — adjust by review comment.

Separate from #165 (the resolver prefer-open fix — different bug, already merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)