### PR TITLE
feat(api): POST + PATCH /api/v1/engagements — create + triage (C3)

### DIFF
--- a/empirica/api/routes/engagements.py
+++ b/empirica/api/routes/engagements.py
@@ -1,23 +1,39 @@
-"""Engagements list endpoint — daemon HTTP feed for the X2 board.
+"""Engagements routes — the daemon HTTP family for the X2 board.
 
-GET /api/v1/engagements?org=&domain=&lifecycle= returns the EngagementMin
-projection per row: the engagement sidecar fields (stage / lifecycle / domain /
-outcome), counts (member / goal / linked-artifact), and synthesized metadata
-(org_display via the ticket_of edge + severity/assignee pass-through). The
-extension X2 board is a Chrome MV3 worker with no filesystem/sqlite access — it
-speaks HTTP to the daemon only, and its listEngagements already hits this route.
+- GET   /api/v1/engagements          — EngagementMin list feed (CCR prop_kiamoy5z)
+- POST  /api/v1/engagements          — create a ticket (CCR prop_lp2t5gph / C3)
+- PATCH /api/v1/engagements/{id}      — triage: lifecycle/stage + metadata (C3)
+
+The extension X2 board is a Chrome MV3 worker with no filesystem/sqlite access —
+it speaks HTTP to the daemon only. GET feeds the board; POST is its create form;
+PATCH is the metadata-update path mesh-support's triage (M1) needs.
 
 Auth + loopback boundary are identical to the entities route (shared
-``verify_mint_bearer`` dependency). CCR prop_kiamoy5z, ratified by David.
+``verify_mint_bearer`` dependency). Contract: mesh-support prop_lp2t5gph.
 """
 
 from __future__ import annotations
 
+import json
+import uuid
+from datetime import datetime, timezone
+
 from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, Field
 
 from empirica.api.entity_mint_auth import verify_mint_bearer
 
 router = APIRouter(prefix="/api/v1", tags=["engagements"])
+
+# Severity vocab (metadata, validated route-side — not a sidecar column).
+_SEVERITY = frozenset({"critical", "high", "normal", "low"})
+
+
+def _require_severity(severity: str | None) -> None:
+    if severity is not None and severity not in _SEVERITY:
+        raise HTTPException(
+            status_code=422, detail=f"invalid severity {severity!r} — must be one of {sorted(_SEVERITY)}"
+        )
 
 
 @router.get("/engagements", dependencies=[Depends(verify_mint_bearer)])
@@ -73,3 +89,128 @@ async def list_engagements(
                 }
             )
     return {"ok": True, "count": len(out), "engagements": out}
+
+
+def _synthesize_title(severity: str | None, org_display: str | None) -> str:
+    """Support fallback (mesh-support convention) when the form omits title —
+    title is NOT NULL at the schema level, so the endpoint must always set one."""
+    date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    return f"{severity or 'support'} · {org_display or 'unassigned'} · {date}"
+
+
+class EngagementCreateRequest(BaseModel):
+    domain: str = Field(description="Engagement domain — one of the 6 (support, sales, …)")
+    title: str | None = Field(default=None, description="Ticket title; synthesized if omitted (NOT NULL in schema)")
+    stage: str | None = Field(default=None, description="Full stage_id; validated against the domain")
+    lifecycle_state: str | None = Field(default=None, description="open|in_progress|blocked|closed (default open)")
+    engagement_type: str = Field(default="support")
+    description: str | None = None
+    org: str | None = Field(default=None, description="Organization id — sets the ticket_of edge atomically")
+    # Writable metadata bag — NO org_display (that's read-synthesized from ticket_of).
+    severity: str | None = None
+    assignee_display: str | None = None
+    assignee_id: str | None = None
+
+
+@router.post("/engagements", dependencies=[Depends(verify_mint_bearer)])
+async def create_engagement(req: EngagementCreateRequest):
+    """Create a ticket: the engagements sidecar row + the entity_registry row
+    (display_name + writable metadata bag) + the ticket_of edge, atomically.
+    ``title`` is NOT NULL — synthesized when the form omits it."""
+    from empirica.data.repositories.workspace_db import WorkspaceDBRepository
+
+    _require_severity(req.severity)
+    eid = f"e-{uuid.uuid4().hex[:12]}"
+    with WorkspaceDBRepository.open() as repo:
+        # org_display for the synthesized title is READ from the org entity — never
+        # stored on the engagement (it stays read-synthesized per the GET spec).
+        org_display = None
+        if req.org:
+            row = repo._execute(
+                "SELECT display_name FROM entity_registry WHERE entity_type = 'organization' AND entity_id = ?",
+                (req.org,),
+            ).fetchone()
+            org_display = row["display_name"] if row else None
+        title = req.title or _synthesize_title(req.severity, org_display)
+        try:
+            eng = repo.create_engagement(
+                eid,
+                title,
+                domain=req.domain,
+                stage=req.stage,
+                engagement_type=req.engagement_type,
+                description=req.description,
+            )
+            if req.lifecycle_state and req.lifecycle_state != "open":
+                eng = repo.update_engagement(eid, lifecycle_state=req.lifecycle_state) or eng
+        except ValueError as e:  # unknown domain/stage/lifecycle → 422
+            raise HTTPException(status_code=422, detail=str(e)) from e
+
+        meta = {
+            k: v
+            for k, v in {
+                "severity": req.severity,
+                "assignee_display": req.assignee_display,
+                "assignee_id": req.assignee_id,
+            }.items()
+            if v is not None
+        }
+        repo.upsert_entity(
+            "engagement",
+            eid,
+            display_name=title,
+            source_db="workspace",
+            source_table="engagements",
+            metadata=json.dumps(meta) if meta else None,
+        )
+        if req.org:
+            repo.upsert_entity_membership("engagement", eid, "organization", req.org, role="ticket_of")
+    return {"ok": True, "engagement_id": eid, "engagement": eng}
+
+
+class EngagementPatchRequest(BaseModel):
+    lifecycle_state: str | None = None
+    stage: str | None = None
+    outcome: str | None = None
+    title: str | None = None
+    description: str | None = None
+    # metadata triage bag (merge; org_display excluded — read-synthesized).
+    severity: str | None = None
+    assignee_display: str | None = None
+    assignee_id: str | None = None
+
+
+@router.patch("/engagements/{engagement_id}", dependencies=[Depends(verify_mint_bearer)])
+async def patch_engagement(engagement_id: str, req: EngagementPatchRequest):
+    """Triage: transition lifecycle/stage/outcome + merge the metadata bag on an
+    existing engagement. 404 if it doesn't exist. This is the metadata-UPDATE
+    path the board's triage (mesh-support M1) needs."""
+    from empirica.data.repositories.workspace_db import WorkspaceDBRepository
+
+    _require_severity(req.severity)
+    with WorkspaceDBRepository.open() as repo:
+        try:
+            updated = repo.update_engagement(
+                engagement_id,
+                lifecycle_state=req.lifecycle_state,
+                stage=req.stage,
+                outcome=req.outcome,
+                title=req.title,
+                description=req.description,
+            )
+        except ValueError as e:
+            raise HTTPException(status_code=422, detail=str(e)) from e
+        if updated is None:
+            raise HTTPException(status_code=404, detail=f"engagement {engagement_id!r} not found")
+        patch = {
+            k: v
+            for k, v in {
+                "severity": req.severity,
+                "assignee_display": req.assignee_display,
+                "assignee_id": req.assignee_id,
+            }.items()
+            if v is not None
+        }
+        if patch:
+            repo.update_entity_metadata("engagement", engagement_id, patch)
+    return {"ok": True, "engagement_id": engagement_id, "engagement": updated}

--- a/empirica/data/repositories/workspace_db.py
+++ b/empirica/data/repositories/workspace_db.py
@@ -776,6 +776,41 @@ class WorkspaceDBRepository(BaseRepository):
         )
         self.commit()
 
+    def update_entity_metadata(self, entity_type: str, entity_id: str, patch: dict[str, Any]) -> bool:
+        """Merge ``patch`` into an entity's metadata JSON (read-merge-write).
+
+        Keys with a None value are removed; others overwrite. Returns False if
+        the entity doesn't exist. Used by the engagements PATCH triage path
+        (severity / assignee writes on an existing engagement). Does NOT touch
+        org_display — that stays read-synthesized from the ticket_of edge.
+        """
+        cur = self._execute(
+            "SELECT metadata FROM entity_registry WHERE entity_type = ? AND entity_id = ?",
+            (entity_type, entity_id),
+        )
+        row = cur.fetchone()
+        if row is None:
+            return False
+        meta: dict[str, Any] = {}
+        if row["metadata"]:
+            try:
+                parsed = json.loads(row["metadata"])
+                if isinstance(parsed, dict):
+                    meta = parsed
+            except (ValueError, TypeError):
+                meta = {}
+        for key, val in patch.items():
+            if val is None:
+                meta.pop(key, None)
+            else:
+                meta[key] = val
+        self._execute(
+            "UPDATE entity_registry SET metadata = ?, updated_at = ? WHERE entity_type = ? AND entity_id = ?",
+            (json.dumps(meta), time.time(), entity_type, entity_id),
+        )
+        self.commit()
+        return True
+
     def mark_entity_status(
         self,
         entity_type: str,

--- a/tests/test_engagements_endpoint.py
+++ b/tests/test_engagements_endpoint.py
@@ -181,3 +181,80 @@ def test_route_domain_filter(client):
 def test_route_invalid_lifecycle_422(client):
     r = client.get("/api/v1/engagements?lifecycle=not_a_state")
     assert r.status_code == 422
+
+
+# ---- POST /api/v1/engagements (C3 create) ----------------------------------
+
+
+def test_create_minimal(client):
+    r = client.post("/api/v1/engagements", json={"domain": "support", "title": "Disk full"})
+    assert r.status_code == 200
+    eid = r.json()["engagement_id"]
+    # shows up in the GET feed
+    feed = client.get("/api/v1/engagements?domain=support").json()
+    assert any(e["id"] == eid and e["domain"] == "support" for e in feed["engagements"])
+
+
+def test_create_synthesizes_title_when_omitted(client):
+    # title is NOT NULL — omitting it must synthesize, never hit a DB null.
+    r = client.post("/api/v1/engagements", json={"domain": "support", "severity": "high", "org": "o1"})
+    assert r.status_code == 200
+    eid = r.json()["engagement_id"]
+    e = next(x for x in client.get("/api/v1/engagements").json()["engagements"] if x["id"] == eid)
+    assert e["title"].startswith("high · Acme Corp · ")  # severity · org_display · date
+    assert e["metadata"]["org_display"] == "Acme Corp"  # via the ticket_of edge, not stored
+
+
+def test_create_sets_ticket_of_and_metadata(client):
+    r = client.post(
+        "/api/v1/engagements",
+        json={"domain": "support", "title": "X", "org": "o1", "severity": "critical", "assignee_display": "Sam"},
+    )
+    eid = r.json()["engagement_id"]
+    e = next(x for x in client.get("/api/v1/engagements?org=o1").json()["engagements"] if x["id"] == eid)
+    assert e["metadata"]["org_display"] == "Acme Corp"  # ticket_of resolved
+    assert e["metadata"]["severity"] == "critical"
+    assert e["metadata"]["assignee_display"] == "Sam"
+    # org_display must NOT be stored in the raw metadata bag (read-synthesized only)
+    assert e["metadata"]["assignee_id"] is None
+
+
+def test_create_invalid_domain_422(client):
+    assert client.post("/api/v1/engagements", json={"domain": "not_a_domain", "title": "X"}).status_code == 422
+
+
+def test_create_invalid_severity_422(client):
+    r = client.post("/api/v1/engagements", json={"domain": "support", "title": "X", "severity": "nuclear"})
+    assert r.status_code == 422
+
+
+# ---- PATCH /api/v1/engagements/{id} (C3 triage) ----------------------------
+
+
+def test_patch_lifecycle_and_metadata(client):
+    eid = client.post("/api/v1/engagements", json={"domain": "support", "title": "Y", "severity": "low"}).json()[
+        "engagement_id"
+    ]
+    r = client.patch(f"/api/v1/engagements/{eid}", json={"lifecycle_state": "in_progress", "severity": "high"})
+    assert r.status_code == 200
+    e = next(x for x in client.get("/api/v1/engagements").json()["engagements"] if x["id"] == eid)
+    assert e["lifecycle_state"] == "in_progress"
+    assert e["metadata"]["severity"] == "high"  # merged over the create-time 'low'
+
+
+def test_patch_stage_transition(client):
+    eid = client.post("/api/v1/engagements", json={"domain": "support", "title": "Z"}).json()["engagement_id"]
+    r = client.patch(f"/api/v1/engagements/{eid}", json={"stage": "support.resolved", "outcome": "resolved"})
+    assert r.status_code == 200
+    e = next(x for x in client.get("/api/v1/engagements").json()["engagements"] if x["id"] == eid)
+    assert e["stage"] == "support.resolved"
+    assert e["outcome"] == "resolved"
+
+
+def test_patch_missing_404(client):
+    assert client.patch("/api/v1/engagements/e-nonexistent", json={"severity": "high"}).status_code == 404
+
+
+def test_patch_invalid_lifecycle_422(client):
+    eid = client.post("/api/v1/engagements", json={"domain": "support", "title": "Q"}).json()["engagement_id"]
+    assert client.patch(f"/api/v1/engagements/{eid}", json={"lifecycle_state": "nope"}).status_code == 422


### PR DESCRIPTION
The write siblings to CCR-1's GET feed — completing the engagements-routes family the X2 board needs. Contract: mesh-support `prop_lp2t5gph`, ratified by David.

### `POST /api/v1/engagements` — create a ticket atomically
- **`title` is NOT NULL**: synthesized when the form omits it (support fallback `'{severity|support} · {org_display} · YYYY-MM-DD'`) — never hits a DB null (the correction mesh-support flagged).
- `create_engagement` (sidecar) + `upsert_entity` (registry row: `display_name` + the **writable metadata bag** `{severity, assignee_display, assignee_id}` only — `org_display` is read-synthesized from the `ticket_of` edge, **never stored**) + the **`ticket_of` edge** (engagement → org), in one create.
- Validation: domain/stage/lifecycle via the repo (`ValueError → 422`); `severity ∈ {critical,high,normal,low}` route-side.

### `PATCH /api/v1/engagements/{id}` — triage (the flagged gap)
The metadata-UPDATE path mesh-support's **M1 triage** needs (was missing). `update_engagement` (lifecycle/stage/outcome/title, enum+domain validated) + `update_entity_metadata` (merge the severity/assignee bag). **404** if the engagement doesn't exist.

New repo helper `update_entity_metadata` (read-merge-write; `None` removes a key; leaves `org_display` untouched).

### Gate
`tests/test_engagements_endpoint.py` +9 (create minimal / synthesized-title / ticket_of+metadata / invalid-domain / invalid-severity; patch lifecycle+metadata / stage-transition / 404 / invalid-lifecycle). 18 endpoint + 32 engagement-suite tests pass; ruff + pyright clean; GET+POST+PATCH all registered.

**Deploy:** rides the same stale-install blocker as the GET — lights up on the `1.12.x` release + daemon restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)