### PR TITLE
fix(sentinel): remote-ops pacing-guard deadlock — wrapper-aware ssh + recoverable rush-guard

### DIFF
--- a/empirica/plugins/claude-code-integration/hooks/sentinel-gate.py
+++ b/empirica/plugins/claude-code-integration/hooks/sentinel-gate.py
@@ -1502,6 +1502,47 @@ def _is_inert_shape(stripped: str) -> bool:
     return bool(re.match(r"^[A-Za-z_][A-Za-z0-9_]*=\S*$", stripped))
 
 
+# Benign command wrappers that prefix a real command without altering its
+# safety character (they exec the inner command, possibly with their own
+# flags/args). remote-ops recon routinely wraps ssh in `timeout` to bound SSH
+# hangs — e.g. `timeout 160 ssh -o ConnectTimeout=12 host '...'` — so the
+# ssh/scp/rsync classifier must see THROUGH the wrapper, not match only the
+# leading token, or the wrapped form falls through to the rush-guard.
+_WRAPPER_PREFIX_RE = re.compile(
+    r"^\s*(?:(?:timeout|env|time|nice|nohup|stdbuf|ionice|setsid)"
+    r"(?:\s+(?:-\S+|\d\S*|[A-Za-z_]\w*=\S*))*\s+)+"
+)
+
+
+def _unwrap_command(command: str) -> str:
+    """Peel leading benign wrapper tokens (timeout/env/nice/...) + their option
+    args, returning the inner command verbatim. Conservative: only the known
+    wrappers above are stripped, with their unambiguous args (a flag, a numeric
+    duration like timeout's 160/160s, or a VAR=val env assignment). Never
+    raises; on any oddity returns the command unchanged.
+
+    Safety: a mis-peel can only make classification MORE restrictive — the only
+    path it reaches grants the remote relaxation iff the peeled result starts
+    with ssh/scp/rsync, and is_safe_remote_command still classifies the inner
+    ssh subcommand. Dangerous-operator/redirect checks run on the ORIGINAL
+    command, so a wrapper can never smuggle a local write past them.
+    """
+    try:
+        return _WRAPPER_PREFIX_RE.sub("", command, count=1) or command
+    except Exception:
+        return command
+
+
+def _remote_prefix(command: str) -> str | None:
+    """Return the unwrapped command if it starts with ssh/rsync/scp (seeing
+    through benign wrappers like `timeout`), else None. The returned string is
+    what should be passed to is_safe_remote_command for classification."""
+    unwrapped = _unwrap_command(command).lstrip()
+    if unwrapped.startswith(("ssh ", "rsync ", "scp ", "ssh-")):
+        return unwrapped
+    return None
+
+
 def _is_segment_safe(segment: str) -> bool:
     """Check if a single command segment (from && / || / ; chain) is safe.
 
@@ -1567,8 +1608,9 @@ def _is_segment_safe(segment: str) -> bool:
         return is_safe_pipe_chain(stripped)
     if is_safe_empirica_command(stripped):
         return True
-    if stripped.startswith(("ssh ", "rsync ", "scp ", "ssh-")):
-        return is_safe_remote_command(stripped)
+    _rcmd = _remote_prefix(stripped)
+    if _rcmd is not None:
+        return is_safe_remote_command(_rcmd)
     if _matches_safe_prefix(stripped):
         return True
 
@@ -1699,8 +1741,8 @@ def is_safe_bash_command(tool_input: dict) -> bool:
     # the per-command classifier rejects. Local writes (cat > /tmp/foo)
     # stay subject to normal gating — those ARE observable.
     if _current_work_type == "remote-ops":
-        rcmd = command.lstrip()
-        if rcmd.startswith(("ssh ", "rsync ", "scp ", "ssh-")):
+        rcmd = _remote_prefix(command)
+        if rcmd is not None:
             _maybe_nudge_remote_ops(rcmd)
             return True
 
@@ -1716,9 +1758,10 @@ def is_safe_bash_command(tool_input: dict) -> bool:
     cmd = command.lstrip()
 
     # Special cases: remote, sqlite, python
-    if cmd.startswith(("ssh ", "rsync ", "scp ", "ssh-")):
-        _maybe_nudge_remote_ops(cmd)
-        return is_safe_remote_command(cmd)
+    _rcmd = _remote_prefix(cmd)
+    if _rcmd is not None:
+        _maybe_nudge_remote_ops(_rcmd)
+        return is_safe_remote_command(_rcmd)
     if cmd.startswith("sqlite3 ") and is_safe_sqlite_command(cmd):
         return True
     if cmd.startswith(("python3 -c ", "python -c ")) and is_safe_python_command(cmd):
@@ -2470,7 +2513,7 @@ def _detect_subagent(claude_session_id: str) -> bool:
         # No active_work file for this claude_session_id — likely a subagent
         # (or session-init failed / project initialized mid-session).
         #
-        # Worktree-aware signal (ecodex prop_3dih #3, David architectural flag):
+        # Worktree-aware signal (David architectural flag):
         # isolation:worktree subagents run in a LINKED git worktree where the
         # active_work lookup above fails — without this they fall through and risk
         # mis-detection as the PARENT (then get measured, polluting parent state).
@@ -2600,6 +2643,16 @@ def _check_postflight_loop_closed(
     return None
 
 
+# work_type=remote-ops is ungrounded_remote_ops by design: the Sentinel's local
+# sensors can't observe the remote box, so a CHECK window with 0 LOCAL artifacts
+# in <30s is EXPECTED, not rushed — "investigate and log locally first" is a
+# category error there. Exempt it from the rush deny entirely. Also the
+# work_type-level safety net: even if a future command shape slips the noetic
+# classifier (as timeout-wrapped ssh did), a remote-ops session can never
+# deadlock on this guard.
+RUSH_GUARD_EXEMPT_WORK_TYPES = frozenset({"remote-ops"})
+
+
 def _validate_check_record(
     cursor,
     session_id: str,
@@ -2613,7 +2666,7 @@ def _validate_check_record(
     Returns (know, uncertainty, decision, check_timestamp) on success,
     or ("deny", message) tuple on failure.
     """
-    # ── RECOVERY ESCAPE HATCH (ecodex prop_3dih #1, David-flagged) ──────────
+    # ── RECOVERY ESCAPE HATCH (David-flagged) ──────────
     # A firewall must NEVER gate its own escape hatch. Empirica's discipline /
     # recovery verbs (check/postflight-submit, *-log, note, doctor) + noetic
     # tools must ALWAYS pass — regardless of CHECK / rush / stuck state. The
@@ -2696,13 +2749,25 @@ def _validate_check_record(
         noetic_duration = check_ts - preflight_ts
         min_duration = float(os.getenv("EMPIRICA_MIN_NOETIC_DURATION", "30"))
 
-        if noetic_duration < min_duration:
+        # Fix 3: remote-ops is exempt (ungrounded by design — see
+        # RUSH_GUARD_EXEMPT_WORK_TYPES). The work_type-level safety net so a
+        # remote-ops session can never deadlock on this guard regardless of how
+        # the command was shaped.
+        if noetic_duration < min_duration and _current_work_type not in RUSH_GUARD_EXEMPT_WORK_TYPES:
+            # Fix 2: count artifacts up to NOW, not the frozen check_ts. The
+            # pre-fix window (preflight_ts, check_ts) closes the instant CHECK is
+            # recorded, so a finding logged AFTER a rushed CHECK could never
+            # count — making "log learnings first" unsatisfiable and the deny
+            # unrecoverable (the constant-Ns deadlock). Counting
+            # to now makes the guard recoverable exactly as its message promises,
+            # while still denying a genuine zero-artifact rubber-stamp CHECK.
+            now = time.time()
             cursor.execute(
                 """
                 SELECT COUNT(*) FROM project_findings
                 WHERE session_id = ? AND created_timestamp > ? AND created_timestamp < ?
             """,
-                (session_id, preflight_ts, check_ts),
+                (session_id, preflight_ts, now),
             )
             findings = cursor.fetchone()[0]
             cursor.execute(
@@ -2710,7 +2775,7 @@ def _validate_check_record(
                 SELECT COUNT(*) FROM project_unknowns
                 WHERE session_id = ? AND created_timestamp > ? AND created_timestamp < ?
             """,
-                (session_id, preflight_ts, check_ts),
+                (session_id, preflight_ts, now),
             )
             unknowns = cursor.fetchone()[0]
             if findings == 0 and unknowns == 0:

--- a/tests/test_sentinel_remote_ops_pacing.py
+++ b/tests/test_sentinel_remote_ops_pacing.py
@@ -1,0 +1,196 @@
+"""Regression: the Sentinel pacing-guard must never deadlock remote-ops Bash.
+
+A remote-ops AI doing SSH field-install over `timeout`-wrapped ssh was
+repeatedly blocked by the pacing guard. Three compounding defects in
+sentinel-gate.py, fixed together:
+
+Fix 1 — wrapper-aware ssh/scp/rsync detection. The remote-ops passthrough was
+        start-anchored (startswith "ssh "), so `timeout 160 ssh host '...'`
+        (the standard hang-bounded recon form) slipped past it and fell through
+        to the rush-guard. Now benign wrappers (timeout/env/nice/...) are peeled
+        before the leading-token check.
+
+Fix 2 — the rush-guard counted findings/unknowns in the FROZEN window
+        (preflight_ts, check_ts). Once a rushed CHECK was recorded, that window
+        was closed in the past, so a finding logged AFTER it could never count —
+        the "Investigate and log learnings first" message was unsatisfiable and
+        the deny unrecoverable (the constant-Ns deadlock). Now it counts up to
+        NOW, making the guard recoverable exactly as its message promises.
+
+Fix 3 — work_type=remote-ops is exempt from the rush deny entirely (it's
+        ungrounded_remote_ops by design; "log locally first" is a category
+        error). The work_type-level safety net: even if a future command shape
+        slips the classifier, a remote-ops session can never deadlock here.
+
+The anti-rubber-stamp value is preserved: a genuine zero-artifact rushed CHECK
+under a normal work_type still denies.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sqlite3
+import time
+from pathlib import Path
+
+import pytest
+
+_HOOK = Path(__file__).resolve().parents[1] / "empirica/plugins/claude-code-integration/hooks/sentinel-gate.py"
+
+
+def _load_hook():
+    if not _HOOK.exists():
+        pytest.skip("sentinel-gate.py not found")
+    spec = importlib.util.spec_from_file_location("sentinel_gate_remote_ops_pacing", _HOOK)
+    mod = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(mod)
+    except Exception as e:  # pragma: no cover
+        pytest.skip(f"sentinel-gate.py not importable here: {e}")
+    return mod
+
+
+sg = _load_hook()
+
+
+# ── Fix 1: wrapper-aware ssh/scp/rsync classification ───────────────────────
+
+
+def _bash_safe(monkeypatch, command, work_type=None):
+    monkeypatch.setattr(sg, "_current_work_type", work_type)
+    return sg.is_safe_bash_command({"command": command})
+
+
+def test_unwrap_sees_through_wrappers():
+    assert sg._unwrap_command("timeout 160 ssh -o X=1 host 'ls'") == "ssh -o X=1 host 'ls'"
+    assert sg._unwrap_command("env LC_ALL=C ssh host 'ls'") == "ssh host 'ls'"
+    assert sg._unwrap_command("nice -n 10 ssh host 'ls'") == "ssh host 'ls'"
+    # no wrapper → unchanged
+    assert sg._unwrap_command("ssh host 'ls'") == "ssh host 'ls'"
+    # wrapper but non-ssh inner → never raises, inner command preserved
+    assert "rm" in sg._unwrap_command("timeout 5 rm -rf /x")
+
+
+def test_remote_prefix_recognizes_wrapped_ssh():
+    assert sg._remote_prefix("timeout 160 ssh host 'ls'") == "ssh host 'ls'"
+    assert sg._remote_prefix("ssh host 'ls'") == "ssh host 'ls'"
+    # non-ssh inner → None (not routed to the remote classifier)
+    assert sg._remote_prefix("timeout 5 rm -rf /x") is None
+    assert sg._remote_prefix("ls -la") is None
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "ssh host 'ls'",  # plain ssh read (unchanged behavior)
+        "timeout 160 ssh -o ConnectTimeout=12 host 'ls'",  # the exact wrapped-ssh recon case
+        "env LC_ALL=C ssh host 'docker ps'",
+        "nice -n 10 ssh host 'ls -la'",
+        "nohup ssh host 'cat /etc/os-release'",
+    ],
+)
+def test_wrapped_ssh_read_is_noetic(monkeypatch, command):
+    # General path (no work_type declared): is_safe_remote_command classifies
+    # the inner read as noetic → safe/True. Pre-fix, the wrapped forms returned
+    # False (unrecognized) and fell through to the rush-guard.
+    assert _bash_safe(monkeypatch, command) is True
+
+
+def test_wrapped_ssh_write_still_praxic(monkeypatch):
+    # A wrapped ssh that WRITES remotely is still praxic on the general path —
+    # wrapper-awareness must not blanket-allow writes.
+    assert _bash_safe(monkeypatch, "timeout 160 ssh host 'rm -rf /data'") is False
+
+
+def test_wrapped_non_ssh_destructive_not_treated_as_remote(monkeypatch):
+    # timeout wrapping a LOCAL destructive command must NOT get the ssh pass,
+    # even under remote-ops. A wrapper can't smuggle a local write through.
+    assert _bash_safe(monkeypatch, "timeout 5 rm -rf /important", work_type="remote-ops") is False
+
+
+def test_wrapped_ssh_wholesale_under_remote_ops(monkeypatch):
+    # Under remote-ops, wrapped ssh passes wholesale (the PREFLIGHT declaration
+    # is the gate; local sensors can't observe the remote box) — incl. remote
+    # writes, matching the existing unwrapped-ssh remote-ops behavior.
+    assert _bash_safe(monkeypatch, "timeout 160 ssh host 'systemctl restart x'", work_type="remote-ops") is True
+
+
+# ── Fix 2 + Fix 3: the rush-guard itself ────────────────────────────────────
+
+# A praxic, non-safe command that reaches the rush-guard (not in any safe set,
+# so it does not short-circuit via the recovery escape-hatch).
+_PRAXIC = "mv /tmp/aaa /tmp/bbb"
+
+
+def _rush_cursor(check_offset_s, n_findings=0, n_unknowns=0):
+    """In-memory cursor with a CHECK reflex row at preflight_ts+check_offset_s,
+    and findings/unknowns logged AFTER check_ts — i.e. the frozen-window
+    deadlock case (artifacts the pre-fix guard would never count).
+    Returns (cursor, preflight_ts)."""
+    conn = sqlite3.connect(":memory:")
+    cur = conn.cursor()
+    cur.execute(
+        "CREATE TABLE reflexes (session_id TEXT, phase TEXT, transaction_id TEXT, "
+        "know REAL, uncertainty REAL, reflex_data TEXT, timestamp REAL)"
+    )
+    cur.execute("CREATE TABLE project_findings (session_id TEXT, created_timestamp REAL)")
+    cur.execute("CREATE TABLE project_unknowns (session_id TEXT, created_timestamp REAL)")
+    pf = time.time() - 100.0
+    check_ts = pf + check_offset_s
+    cur.execute(
+        "INSERT INTO reflexes VALUES (?,?,?,?,?,?,?)",
+        ("sess", "CHECK", "tx1", 0.7, 0.2, '{"decision": "proceed"}', check_ts),
+    )
+    for _ in range(n_findings):
+        cur.execute("INSERT INTO project_findings VALUES (?,?)", ("sess", check_ts + 1.0))
+    for _ in range(n_unknowns):
+        cur.execute("INSERT INTO project_unknowns VALUES (?,?)", ("sess", check_ts + 1.0))
+    return cur, pf
+
+
+def _validate(monkeypatch, cur, pf, command, work_type):
+    monkeypatch.setattr(sg, "_current_work_type", work_type)
+    return sg._validate_check_record(cur, "sess", "tx1", pf, tool_input={"command": command}, tool_name="Bash")
+
+
+def _is_deny(result):
+    return isinstance(result, tuple) and len(result) == 2 and result[0] == "deny"
+
+
+def test_rush_guard_denies_genuine_rubber_stamp(monkeypatch):
+    # Anti-rubber-stamp preserved: normal work_type, rushed (<30s), zero
+    # artifacts → deny. This is the value the guard exists for.
+    cur, pf = _rush_cursor(check_offset_s=11)
+    result = _validate(monkeypatch, cur, pf, _PRAXIC, "code")
+    assert _is_deny(result) and "Rushed assessment" in result[1]
+
+
+def test_rush_guard_recoverable_by_post_check_finding(monkeypatch):
+    # Fix 2: a finding logged AFTER a rushed CHECK now clears the guard. On the
+    # pre-fix frozen window this finding (created_timestamp > check_ts) would not
+    # count and the command would still deny — the deadlock.
+    cur, pf = _rush_cursor(check_offset_s=11, n_findings=1)
+    result = _validate(monkeypatch, cur, pf, _PRAXIC, "code")
+    assert not _is_deny(result), result
+
+
+def test_rush_guard_recoverable_by_post_check_unknown(monkeypatch):
+    cur, pf = _rush_cursor(check_offset_s=11, n_unknowns=1)
+    result = _validate(monkeypatch, cur, pf, _PRAXIC, "code")
+    assert not _is_deny(result), result
+
+
+def test_rush_guard_exempts_remote_ops_even_with_zero_artifacts(monkeypatch):
+    # Fix 3: remote-ops, rushed, zero local artifacts → never denied. The
+    # category-error case (nothing local to investigate).
+    cur, pf = _rush_cursor(check_offset_s=11)
+    result = _validate(monkeypatch, cur, pf, _PRAXIC, "remote-ops")
+    assert not _is_deny(result), result
+
+
+def test_rush_guard_still_passes_unrushed_check(monkeypatch):
+    # Long-enough noetic phase (>30s) → guard never engages, regardless of
+    # artifacts or work_type.
+    cur, pf = _rush_cursor(check_offset_s=45)
+    result = _validate(monkeypatch, cur, pf, _PRAXIC, "code")
+    assert not _is_deny(result), result


### PR DESCRIPTION
## Problem

The `Rushed assessment (Ns)` pacing guard could **deadlock** a `work_type=remote-ops` session doing SSH field-install — every Bash attempt denied at a constant `Ns`, and logging a finding between attempts did **not** clear it. Three compounding defects:

1. **Wrapper-blind ssh detection.** The remote-ops ssh/scp/rsync passthrough was start-anchored (`startswith("ssh ")`), so `timeout 160 ssh host '...'` — the standard hang-bounded recon form — slipped past it and fell through to the rush-guard.
2. **Frozen-window rush-guard.** `_validate_check_record` counted findings/unknowns only in `(preflight_ts, check_ts)`, a window that closes the instant CHECK is recorded. A finding logged *after* a rushed CHECK could never count → `"Investigate and log learnings first"` was unsatisfiable and the deny unrecoverable.
3. **remote-ops category error.** `work_type=remote-ops` is `ungrounded_remote_ops` by design (local sensors can't observe the remote box), so a 0-local-artifact CHECK window is expected, not rushed.

## Fix

- **Fix 1** — `_unwrap_command`/`_remote_prefix` peel benign wrappers (`timeout/env/time/nice/nohup/stdbuf/ionice/setsid`) + their option args before the leading-token check, at all three classifier sites. Conservative: a mis-peel only makes classification *more* restrictive; dangerous-operator/redirect checks still run on the original command; wrapped remote *writes* stay praxic on the general path.
- **Fix 2** — count artifacts up to `now()`, not the frozen `check_ts`, so the guard is recoverable exactly as its message promises. The anti-rubber-stamp value is preserved: a genuine zero-artifact rushed CHECK still denies.
- **Fix 3** — exempt `work_type=remote-ops` from the rush deny (`RUSH_GUARD_EXEMPT_WORK_TYPES`). Also the work_type-level safety net: a remote-ops session can never deadlock here regardless of how a future command is shaped.

## Tests

`tests/test_sentinel_remote_ops_pacing.py` — 15 regression tests pinning all three (wrapper-aware classification incl. the write-stays-praxic + non-ssh-stays-local cases; rush-guard recoverable-by-logging; remote-ops exempt; anti-rubber-stamp preserved). Full sentinel/classifier suite (166 tests) green; ruff + pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)