### PR TITLE
fix(cli): CLI-level plugin auto-sync — bootstrap the deploy-staleness self-heal (GAP 1)

### DIFF
--- a/empirica/cli/cli_core.py
+++ b/empirica/cli/cli_core.py
@@ -556,6 +556,64 @@ def _handle_command_result(result, parsed_args) -> int:
     return 0
 
 
+# Self-heal verbs that must NOT trigger the plugin auto-sync (they'd re-invoke
+# it → infinite loop), plus cheap/help paths.
+_PLUGIN_AUTOSYNC_EXEMPT = frozenset(
+    {"plugin-sync", "setup-claude-code", "plugin-version", "doctor", "diagnose", "help"}
+)
+
+
+def _maybe_autosync_plugin(command: str) -> None:
+    """GAP 1: self-heal a stale *deployed* Claude Code plugin from the CLI.
+
+    The deployed plugin (``~/.claude/plugins/local/empirica``) is a copy; ``pip
+    install -U`` upgrades the package but not the copy, so a box silently runs
+    old hooks. The session-init auto-heal lives *inside* that plugin, so a box
+    whose plugin predates it never self-heals (chicken-and-egg). The CLI is
+    always current after the upgrade, so we check skew here and run
+    ``plugin-sync`` once when it drifts — bootstrapping even ancient boxes.
+
+    Fail-safe (never breaks the user's command), debounced (once / 10 min via a
+    marker), re-entrancy-guarded (exempt verbs above). Opt out with
+    ``EMPIRICA_NO_AUTOSYNC=1``. The rush-guard already whitelists plugin-sync, so
+    the sync won't self-deadlock even with a stale sentinel-gate live mid-heal.
+    """
+    import os
+    import subprocess
+    import time as _time
+    from pathlib import Path
+
+    if command in _PLUGIN_AUTOSYNC_EXEMPT or os.environ.get("EMPIRICA_NO_AUTOSYNC"):
+        return
+    try:
+        marker = Path.home() / ".empirica" / ".plugin_autosync_checked"
+        now = _time.time()
+        if marker.exists() and now - marker.stat().st_mtime < 600:
+            return
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        marker.write_text(str(now))  # stamp first so concurrent CLI calls debounce
+
+        plugin_dir = Path.home() / ".claude" / "plugins" / "local" / "empirica"
+        if not plugin_dir.exists():
+            return  # not a Claude Code box — nothing to heal
+        stamp_file = plugin_dir / ".plugin-version"
+        stamp = stamp_file.read_text().strip() if stamp_file.exists() else None
+        try:
+            from empirica import __version__ as cli_ver
+        except Exception:
+            cli_ver = None
+        if cli_ver and stamp != cli_ver:  # None (ancient plugin) also drifts → sync
+            subprocess.run(
+                ["empirica", "plugin-sync"],
+                stdin=subprocess.DEVNULL,
+                capture_output=True,
+                timeout=60,
+                check=False,
+            )
+    except Exception:
+        return  # self-heal must never break the user's command
+
+
 def main(args=None):
     """Main CLI entry point"""
     start_time = time.time()
@@ -582,6 +640,11 @@ def main(args=None):
     if parsed_args.command == "help":
         _handle_help_command(parsed_args)
         sys.exit(0)
+
+    # GAP 1: self-heal a stale deployed plugin from the CLI (always current after
+    # `pip -U`), bootstrapping boxes whose plugin predates the session-init
+    # auto-heal. Fail-safe + debounced + re-entrancy-guarded (see helper).
+    _maybe_autosync_plugin(parsed_args.command)
 
     # Normalize --project-id: resolve names to UUIDs via workspace.db
     if hasattr(parsed_args, "project_id") and parsed_args.project_id:

--- a/tests/test_plugin_autosync.py
+++ b/tests/test_plugin_autosync.py
@@ -1,0 +1,98 @@
+"""GAP 1: cli_core._maybe_autosync_plugin self-heals a stale deployed plugin.
+
+The deployed Claude Code plugin is a copy; ``pip install -U`` upgrades the
+package but not the copy. This check runs from the (always-current) CLI and
+shells out to ``plugin-sync`` on drift, bootstrapping even a box whose plugin
+predates the in-plugin session-init auto-heal. The tests pin: it fires on drift
+(including a missing/pre-stamp version), never fires for exempt verbs / opt-out /
+within the debounce window, and never raises.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from empirica.cli import cli_core
+
+
+@pytest.fixture
+def harness(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    plugin = home / ".claude" / "plugins" / "local" / "empirica"
+    plugin.mkdir(parents=True)
+    (home / ".empirica").mkdir(parents=True)
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: home))
+    monkeypatch.setattr("empirica.__version__", "9.9.9")
+    monkeypatch.delenv("EMPIRICA_NO_AUTOSYNC", raising=False)
+    calls: list = []
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: calls.append((a, k)))
+    return {"home": home, "plugin": plugin, "calls": calls}
+
+
+def _stamp(plugin: Path, version: str) -> None:
+    (plugin / ".plugin-version").write_text(version + "\n")
+
+
+def test_drift_triggers_sync(harness):
+    _stamp(harness["plugin"], "1.0.0")  # != 9.9.9
+    cli_core._maybe_autosync_plugin("finding-log")
+    assert len(harness["calls"]) == 1
+    assert harness["calls"][0][0][0] == ["empirica", "plugin-sync"]
+
+
+def test_current_version_no_sync(harness):
+    _stamp(harness["plugin"], "9.9.9")  # matches CLI
+    cli_core._maybe_autosync_plugin("finding-log")
+    assert harness["calls"] == []
+
+
+def test_missing_stamp_triggers_sync(harness):
+    # pre-stamp plugin (no .plugin-version) reads None -> drift -> sync (the bootstrap case)
+    cli_core._maybe_autosync_plugin("finding-log")
+    assert len(harness["calls"]) == 1
+
+
+@pytest.mark.parametrize("verb", ["plugin-sync", "setup-claude-code", "plugin-version", "doctor", "help"])
+def test_exempt_verb_never_syncs(harness, verb):
+    _stamp(harness["plugin"], "1.0.0")  # drift present...
+    cli_core._maybe_autosync_plugin(verb)  # ...but the verb is exempt (no re-entrancy)
+    assert harness["calls"] == []
+
+
+def test_optout_env_no_sync(harness, monkeypatch):
+    monkeypatch.setenv("EMPIRICA_NO_AUTOSYNC", "1")
+    _stamp(harness["plugin"], "1.0.0")
+    cli_core._maybe_autosync_plugin("finding-log")
+    assert harness["calls"] == []
+
+
+def test_debounced_recent_marker_no_sync(harness):
+    # a fresh marker (mtime ~now, within the 600s TTL) suppresses the check
+    (harness["home"] / ".empirica" / ".plugin_autosync_checked").write_text("x")
+    _stamp(harness["plugin"], "1.0.0")
+    cli_core._maybe_autosync_plugin("finding-log")
+    assert harness["calls"] == []
+
+
+def test_no_plugin_dir_is_safe(tmp_path, monkeypatch):
+    # not a Claude Code box (no deployed plugin) -> no sync, no error
+    home = tmp_path / "h2"
+    (home / ".empirica").mkdir(parents=True)
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: home))
+    monkeypatch.delenv("EMPIRICA_NO_AUTOSYNC", raising=False)
+    calls: list = []
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: calls.append(1))
+    cli_core._maybe_autosync_plugin("finding-log")  # must not raise
+    assert calls == []
+
+
+def test_sync_failure_never_breaks_command(harness, monkeypatch):
+    def boom(*a, **k):
+        raise RuntimeError("plugin-sync blew up")
+
+    monkeypatch.setattr(subprocess, "run", boom)
+    _stamp(harness["plugin"], "1.0.0")
+    cli_core._maybe_autosync_plugin("finding-log")  # swallowed; must not raise


### PR DESCRIPTION
## Problem

The deployed Claude Code plugin (`~/.claude/plugins/local/empirica`) is a copy. `pip install -U` upgrades the package but **not** the deployed copy, so a box silently runs old hooks. The session-init auto-heal that's supposed to fix this lives *inside* that plugin, so a box whose plugin predates the feature never fires it (chicken-and-egg). Verified across two boxes by mesh-support, and the root cause of plugin fixes (e.g. the rush-guard #170) not reaching boxes until a manual `plugin-sync --force`.

## Fix

`cli_core.main()` now runs a skew check from the CLI (always current after `pip -U`): when the deployed `.plugin-version` differs from the package version, it shells out to `plugin-sync` once. So **any** `empirica` command on a stale box self-heals — even ancient boxes (a missing stamp also counts as drift) — and the manual `--force` workaround disappears.

- **Fail-safe** — a sync error never breaks the user's command.
- **Debounced** — once per 10 min via a marker, so the dozen `empirica` calls the hooks fire don't race.
- **Re-entrancy-guarded** — self-heal verbs (`plugin-sync`/`setup-claude-code`/`plugin-version`/`doctor`/…) are exempt, so it can't recurse.
- **Opt-out** — `EMPIRICA_NO_AUTOSYNC=1`.
- The rush-guard already whitelists `plugin-sync`, so it won't self-deadlock with a stale sentinel-gate live mid-heal.

## Tests

`tests/test_plugin_autosync.py` — 12 cases (drift / current / missing-stamp-bootstrap / exempt verbs / opt-out / debounce / no-plugin-dir / sync-failure). ruff + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)