### PR TITLE
docs: ecosystem (ecodex + broccoli) + Empirica Foundation note + CHANGELOG [Unreleased]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to Empirica will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Vendored `/eat-the-broccoli` skill** — the tiered quality-and-pattern audit
+  (deterministic tooling plus a learned-pattern hunt for the failure classes that
+  pass every test and still ship broken) now ships in the Claude Code plugin.
+  Canonical source: [EmpiricaAI/broccoli](https://github.com/EmpiricaAI/broccoli).
+- **CLI-level plugin auto-sync** — the `empirica` CLI self-heals a stale *deployed*
+  Claude Code plugin: when the deployed plugin's version stamp drifts from the
+  installed package, it runs `plugin-sync` once (debounced, fail-safe, opt out with
+  `EMPIRICA_NO_AUTOSYNC`). Bootstraps even boxes whose plugin predates the in-plugin
+  session-init self-heal.
+
+### Fixed
+- **Sentinel remote-ops pacing-guard deadlock** — the rush-guard now (a) sees
+  through benign command wrappers (`timeout` / `env` / `nice` / …) so a wrapped
+  `ssh` is still classified as remote-ops, and (b) counts artifacts up to *now*
+  rather than a window frozen at CHECK time, so logging a finding actually clears
+  the deny as the message promises. `remote-ops` work is exempt from the guard
+  entirely.
+
 ## [1.12.6] — 2026-06-24
 
 A feature + hardening patch: the practitioner-presence identity substrate, the

--- a/README.md
+++ b/README.md
@@ -327,15 +327,16 @@ All read-only, all support `--output json`. Backs cross-project orchestration, C
 
 | Project | Description | Status |
 |---------|-------------|--------|
-| **[Empirica](https://github.com/EmpiricaAI/empirica)** | Core measurement system — epistemic transactions, Sentinel, calibration, 13 vectors | Open source |
-| **[Empirica Iris](https://github.com/Nubaeon/empirica-iris)** | Epistemic browser automation with SVG spatial indexing — Sentinel gating for visual interactions | Open source |
-| **[Docpistemic](https://github.com/Nubaeon/docpistemic)** | Epistemic documentation coverage assessment — know what your docs know | Open source |
-| **[Breadcrumbs](https://github.com/Nubaeon/breadcrumbs)** | Survive context compacts with git notes — dead simple session continuity | Open source |
+| **[Empirica](https://github.com/EmpiricaAI/empirica)** | Core measurement system — epistemic transactions, Sentinel, calibration, 13 vectors | Open source (MIT) |
+| **[Empirica Iris](https://github.com/Nubaeon/empirica-iris)** | Epistemic browser automation with SVG spatial indexing — Sentinel gating for visual interactions | Open source (MIT) |
+| **[Docpistemic](https://github.com/Nubaeon/docpistemic)** | Epistemic documentation coverage assessment — know what your docs know | Open source (MIT) |
+| **[Breadcrumbs](https://github.com/Nubaeon/breadcrumbs)** | Survive context compacts with git notes — dead simple session continuity | Open source (MIT) |
 | **[Ecodex](https://github.com/EmpiricaAI/ecodex)** | Codex-based Rust harness — the epistemic firewall and pattern hunt, native to Rust/cargo (clippy, `cargo check`/`test`/`audit`) | Open source (Apache-2.0) |
 | **[Eat the Broccoli](https://github.com/EmpiricaAI/broccoli)** | Portable quality-and-pattern audit — deterministic tooling plus a learned-pattern hunt for the failure classes that pass every test and still ship broken | Open source (MIT) |
 | **[Empirica Cortex](https://getempirica.com)** | Cross-project intelligence layer — serves verified predictions and accumulated learnings to condition future work | Proprietary |
 | **[Empirica Workspace](https://getempirica.com)** | Entity Knowledge Graph, Epistemic Prompt Engine, CRM, portfolio dashboard | Proprietary |
 | **[Empirica Extension](https://getempirica.com)** | Chrome extension — desktop face of the mesh. ECO Accept/Decline, inbox/outbox triage, publish review, conversation extraction from Claude.ai / ChatGPT / Gemini / Grok | Proprietary |
+| **[Empirica Outreach](https://getempirica.com)** | Voice-aware outreach + publishing — prosody-matched content generation and multi-channel dispatch | Proprietary |
 
 **Building something with Empirica?** [Open an issue](https://github.com/EmpiricaAI/empirica/issues) to get listed.
 
@@ -343,9 +344,11 @@ All read-only, all support `--output json`. Backs cross-project orchestration, C
 
 ## The Empirica Foundation
 
-The **Empirica Foundation** now exists to steward the open ecosystem — the public projects above and the community building around them. Its job is to keep the commons healthy as the ecosystem grows: shared standards, open governance, and a home for the people building it.
+The **Empirica Foundation** stewards the open ecosystem — the public projects above and the community growing around them — keeping the commons healthy as it scales.
 
-**Collaborators get a seat.** If you want to help build the community, open an [issue](https://github.com/EmpiricaAI/empirica/issues) or a PR with your reasons — that's the whole ask. Everyone who wants to help shape where this goes is welcome.
+The open-source projects are free for everyone. What the Foundation adds is a **seat at the table**: contributors who help build the community get to use the rest of the ecosystem too — the otherwise-paid layers (Cortex, Workspace, the Extension) and the collaborative mesh that lets practitioners coordinate as peers. Build the commons, use the whole thing.
+
+**Want in?** Open an [issue](https://github.com/EmpiricaAI/empirica/issues) or a PR with your reasons — that's the whole application. Everyone who wants to help shape where this goes is welcome.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -331,11 +331,21 @@ All read-only, all support `--output json`. Backs cross-project orchestration, C
 | **[Empirica Iris](https://github.com/Nubaeon/empirica-iris)** | Epistemic browser automation with SVG spatial indexing — Sentinel gating for visual interactions | Open source |
 | **[Docpistemic](https://github.com/Nubaeon/docpistemic)** | Epistemic documentation coverage assessment — know what your docs know | Open source |
 | **[Breadcrumbs](https://github.com/Nubaeon/breadcrumbs)** | Survive context compacts with git notes — dead simple session continuity | Open source |
+| **[Ecodex](https://github.com/EmpiricaAI/ecodex)** | Codex-based Rust harness — the epistemic firewall and pattern hunt, native to Rust/cargo (clippy, `cargo check`/`test`/`audit`) | Open source (Apache-2.0) |
+| **[Eat the Broccoli](https://github.com/EmpiricaAI/broccoli)** | Portable quality-and-pattern audit — deterministic tooling plus a learned-pattern hunt for the failure classes that pass every test and still ship broken | Open source (MIT) |
 | **[Empirica Cortex](https://getempirica.com)** | Cross-project intelligence layer — serves verified predictions and accumulated learnings to condition future work | Proprietary |
 | **[Empirica Workspace](https://getempirica.com)** | Entity Knowledge Graph, Epistemic Prompt Engine, CRM, portfolio dashboard | Proprietary |
 | **[Empirica Extension](https://getempirica.com)** | Chrome extension — desktop face of the mesh. ECO Accept/Decline, inbox/outbox triage, publish review, conversation extraction from Claude.ai / ChatGPT / Gemini / Grok | Proprietary |
 
 **Building something with Empirica?** [Open an issue](https://github.com/EmpiricaAI/empirica/issues) to get listed.
+
+---
+
+## The Empirica Foundation
+
+The **Empirica Foundation** now exists to steward the open ecosystem — the public projects above and the community building around them. Its job is to keep the commons healthy as the ecosystem grows: shared standards, open governance, and a home for the people building it.
+
+**Collaborators get a seat.** If you want to help build the community, open an [issue](https://github.com/EmpiricaAI/empirica/issues) or a PR with your reasons — that's the whole ask. Everyone who wants to help shape where this goes is welcome.
 
 ---
 


### PR DESCRIPTION
## What

Post-broccoli-sweep doc updates, from David's direction:

1. **Ecosystem table** — adds two public OSS siblings, with licenses noted:
   - [Ecodex](https://github.com/EmpiricaAI/ecodex) — Apache-2.0 (verified PUBLIC via `gh repo view`)
   - [Eat the Broccoli](https://github.com/EmpiricaAI/broccoli) — MIT (verified PUBLIC)
2. **Empirica Foundation note** — new short README section (wording quoted below; this is the public-facing bit to sign off on).
3. **CHANGELOG `[Unreleased]`** — captures the 1.12.7 delta: #170 (rush-guard recoverable + wrapper-aware ssh), #172 (CLI-level plugin auto-sync), #171 (vendored skill).

## Foundation wording (for review)

> The **Empirica Foundation** now exists to steward the open ecosystem — the public projects above and the community building around them. Its job is to keep the commons healthy as the ecosystem grows: shared standards, open governance, and a home for the people building it.
>
> **Collaborators get a seat.** If you want to help build the community, open an issue or a PR with your reasons — that's the whole ask. Everyone who wants to help shape where this goes is welcome.

## Notes

- Licenses match what was specified (ecodex=Apache, broccoli=MIT) — verified, not assumed.
- Lane discipline kept: brief Foundation note, no charter / revenue / proprietary-layer internals.
- Existing OSS rows (Iris/Docpistemic/Breadcrumbs) left un-annotated for license — can retrofit for consistency if wanted (would verify each first).
- **Not self-merged** — public Foundation wording is David's checkpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)