### PR TITLE
fix(cli): make GAP1 plugin auto-sync failures legible

### DIFF
--- a/empirica/cli/cli_core.py
+++ b/empirica/cli/cli_core.py
@@ -603,13 +603,26 @@ def _maybe_autosync_plugin(command: str) -> None:
         except Exception:
             cli_ver = None
         if cli_ver and stamp != cli_ver:  # None (ancient plugin) also drifts → sync
-            subprocess.run(
+            failed_marker = marker.parent / ".plugin_autosync_failed"
+            proc = subprocess.run(
                 ["empirica", "plugin-sync"],
                 stdin=subprocess.DEVNULL,
                 capture_output=True,
                 timeout=60,
                 check=False,
             )
+            if proc.returncode != 0:
+                # Make a failing self-heal legible. Without this the box silently
+                # keeps running stale hooks while the debounce marker reads
+                # "checked" — doctor/diagnose (and a human) surface this breadcrumb.
+                err = (proc.stderr or b"").decode("utf-8", "replace").strip()[-500:]
+                failed_marker.write_text(f"{now}\trc={proc.returncode}\t{err}\n")
+                sys.stderr.write(
+                    f"[empirica] plugin auto-sync failed (rc={proc.returncode}); "
+                    "run 'empirica plugin-sync' or 'empirica doctor' to retry.\n"
+                )
+            else:
+                failed_marker.unlink(missing_ok=True)  # recovered → clear breadcrumb
     except Exception:
         return  # self-heal must never break the user's command
 

--- a/tests/test_plugin_autosync.py
+++ b/tests/test_plugin_autosync.py
@@ -28,7 +28,12 @@ def harness(tmp_path, monkeypatch):
     monkeypatch.setattr("empirica.__version__", "9.9.9")
     monkeypatch.delenv("EMPIRICA_NO_AUTOSYNC", raising=False)
     calls: list = []
-    monkeypatch.setattr(subprocess, "run", lambda *a, **k: calls.append((a, k)))
+
+    def _run(*a, **k):
+        calls.append((a, k))
+        return subprocess.CompletedProcess(a[0] if a else [], 0, b"", b"")
+
+    monkeypatch.setattr(subprocess, "run", _run)
     return {"home": home, "plugin": plugin, "calls": calls}
 
 
@@ -96,3 +101,26 @@ def test_sync_failure_never_breaks_command(harness, monkeypatch):
     monkeypatch.setattr(subprocess, "run", boom)
     _stamp(harness["plugin"], "1.0.0")
     cli_core._maybe_autosync_plugin("finding-log")  # swallowed; must not raise
+
+
+def test_sync_failure_writes_breadcrumb(harness, monkeypatch):
+    # a non-zero plugin-sync leaves a legible failure breadcrumb — not a silent swallow
+    def _fail(*a, **k):
+        return subprocess.CompletedProcess(a[0] if a else [], 1, b"", b"permission denied")
+
+    monkeypatch.setattr(subprocess, "run", _fail)
+    _stamp(harness["plugin"], "1.0.0")  # drift -> sync runs, fails
+    cli_core._maybe_autosync_plugin("finding-log")
+    failed = harness["home"] / ".empirica" / ".plugin_autosync_failed"
+    assert failed.exists()
+    body = failed.read_text()
+    assert "rc=1" in body and "permission denied" in body
+
+
+def test_sync_success_clears_stale_breadcrumb(harness):
+    # a recovered box clears a prior failure breadcrumb on the next successful sync
+    failed = harness["home"] / ".empirica" / ".plugin_autosync_failed"
+    failed.write_text("stale failure from a previous run")
+    _stamp(harness["plugin"], "1.0.0")  # drift -> harness sync returns rc=0
+    cli_core._maybe_autosync_plugin("finding-log")
+    assert not failed.exists()


### PR DESCRIPTION
The broccoli sweep's one YELLOW: `_maybe_autosync_plugin` swallowed `plugin-sync` failures entirely (discarded result, `check=False`, blind outer except), so a persistently-failing self-heal was invisible — the box kept running stale hooks while the debounce marker read "checked".

**Fix:** capture the returncode; on failure write `~/.empirica/.plugin_autosync_failed` (rc + stderr snippet) + one stderr line so `doctor`/`diagnose` (and a human) can see it; clear the breadcrumb on a successful sync. Debounce concurrency guard + outer fail-safe unchanged — a failed sync still can't break the user's command, it's just no longer silent.

**Tests:** +2 (failure→breadcrumb, success→clears stale breadcrumb); harness mock now returns a `CompletedProcess`. 14 pass, ruff clean.

Closes the failure-visibility follow-up (goal `d051ae9f`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)