### PR TITLE
fix(cli): assumption-log --confidence silently dropped (stored 0.5)

### DIFF
--- a/empirica/cli/command_handlers/artifact_log_commands.py
+++ b/empirica/cli/command_handlers/artifact_log_commands.py
@@ -1508,7 +1508,10 @@ def handle_assumption_log_command(args):
 
         # Extract assumption-specific fields
         assumption = (config_data or {}).get("assumption") or getattr(args, "assumption", None)
-        confidence = (config_data or {}).get("confidence", 0.5) or getattr(args, "confidence", 0.5)
+        # Use .get's default as the fallback chain (NOT `or`): a truthy default
+        # like 0.5 would make `x or args.confidence` short-circuit and silently
+        # drop the CLI flag. This form also preserves an explicit 0.0.
+        confidence = (config_data or {}).get("confidence", getattr(args, "confidence", 0.5))
         domain = (config_data or {}).get("domain") or getattr(args, "domain", None)
         description = (config_data or {}).get("description") or getattr(args, "description", None)
         epistemic_source = (config_data or {}).get("epistemic_source") or getattr(args, "epistemic_source", None)

--- a/tests/test_assumption_log_confidence.py
+++ b/tests/test_assumption_log_confidence.py
@@ -1,0 +1,58 @@
+"""Regression: assumption-log must thread --confidence through to storage.
+
+Bug: the handler resolved confidence as
+``(config or {}).get("confidence", 0.5) or getattr(args, "confidence", 0.5)``.
+In CLI mode ``config`` is empty, so ``.get(..., 0.5)`` returns the *truthy* 0.5
+and the ``or`` short-circuits — the actual ``--confidence`` was silently dropped
+(every CLI assumption stored 0.5). A "default masks dropped intent" failure.
+"""
+
+from __future__ import annotations
+
+import argparse
+from unittest.mock import MagicMock
+
+from empirica.cli.command_handlers import artifact_log_commands as alc
+
+
+def _ctx(db):
+    return {
+        "db": db, "project_id": "p", "session_id": "s", "ai_id": "test",
+        "goal_id": None, "transaction_id": None,
+        "entity_type": None, "entity_id": None,
+        "visibility": "shared", "via": None, "output_format": "text",
+    }
+
+
+def _stored_confidence(monkeypatch, *, args_confidence, config_data=None):
+    db = MagicMock()
+    db.log_assumption.return_value = "assump-1"
+    monkeypatch.setattr(alc, "_parse_config_input", lambda args: config_data)
+    monkeypatch.setattr(alc, "_resolve_artifact_context", lambda *a, **k: _ctx(db))
+    monkeypatch.setattr(alc, "_warn_unsourced_citations_if_needed", lambda *a, **k: None)
+    monkeypatch.setattr(alc, "_collect_edges_from_args", lambda *a, **k: [])
+    monkeypatch.setattr(alc, "_suggest_links_safe", lambda *a, **k: [])
+    args = argparse.Namespace(
+        assumption="x", confidence=args_confidence, domain=None,
+        description=None, epistemic_source=None, config=None,
+    )
+    alc.handle_assumption_log_command(args)
+    return db.log_assumption.call_args.kwargs["confidence"]
+
+
+def test_cli_confidence_is_stored(monkeypatch):
+    # the bug stored 0.5 regardless of the flag
+    assert _stored_confidence(monkeypatch, args_confidence=0.7) == 0.7
+
+
+def test_cli_confidence_zero_preserved(monkeypatch):
+    # explicit 0.0 is a valid confidence — must not be clobbered to the default
+    assert _stored_confidence(monkeypatch, args_confidence=0.0) == 0.0
+
+
+def test_stdin_confidence_overrides_args(monkeypatch):
+    # AI-first (stdin JSON) mode: config_data wins over the argparse default
+    got = _stored_confidence(
+        monkeypatch, args_confidence=0.5, config_data={"assumption": "x", "confidence": 0.9}
+    )
+    assert got == 0.9


### PR DESCRIPTION
`assumption-log` ignored `--confidence` and always stored the `0.5` default — a "default masks dropped intent" bug.

**Root cause** (`artifact_log_commands.py:1511`):
```python
confidence = (config or {}).get("confidence", 0.5) or getattr(args, "confidence", 0.5)
```
In CLI mode `config` is empty, so `.get("confidence", 0.5)` returns the truthy `0.5` and the `or` short-circuits — `args.confidence` is never read.

**Fix:** use `.get`'s default-arg as the fallback chain (no `or`), which also preserves an explicit `0.0`:
```python
confidence = (config or {}).get("confidence", getattr(args, "confidence", 0.5))
```

**Tests:** +3 (CLI value stored, explicit 0.0 preserved, stdin-JSON overrides args). Grep confirmed this truthy-default-`or` idiom is isolated to this one line. Closes goal `264b0073`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)