### PR TITLE
fix(hooks): refresh practitioner presence each turn (live-heartbeat unlock)

### DIFF
--- a/empirica/plugins/claude-code-integration/hooks/context-shift-tracker.py
+++ b/empirica/plugins/claude-code-integration/hooks/context-shift-tracker.py
@@ -291,9 +291,41 @@ def _get_goal_hint(tx_id):
     return ""
 
 
+def _refresh_presence(claude_session_id):
+    """Best-effort per-turn presence refresh: re-stamp last_heartbeat=now so the
+    persistent-service heartbeat emitter keeps forwarding a NON-STALE record to
+    cortex.
+
+    session-init writes presence once at session start; without a per-turn
+    refresh the record goes stale after DEFAULT_STALE_AFTER_S (180s) and a live
+    session stops emitting — the mesh's busy/free/blocked active-state signal
+    goes dark on any session older than 3 minutes. `practitioner write` resolves
+    ai_id / location / empirica-session / active-transaction from the running
+    context, so only --session is needed. Fire-and-forget (detached Popen) so it
+    never adds latency to — or fails — the user turn.
+    """
+    if not claude_session_id:
+        return
+    try:
+        import subprocess
+
+        subprocess.Popen(
+            ["empirica", "practitioner", "write", "--session", claude_session_id, "--output", "json"],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    except Exception:
+        pass
+
+
 def main():
     hook_input = json.loads(sys.stdin.read() or "{}")
     claude_session_id = hook_input.get("session_id")
+
+    # Keep practitioner presence fresh each turn (the mesh active-state signal) —
+    # best-effort, non-blocking. See _refresh_presence.
+    _refresh_presence(claude_session_id)
 
     # Context window monitoring
     output = _build_context_usage_output(claude_session_id)


### PR DESCRIPTION
**Priority (David-flagged, autonomy `prop_fun66vjd`):** get the ② practitioner-presence heartbeat actually emitting from live fleet sessions.

**Root cause** (grounded, not guessed): the B2 chain shipped, but session-init writes presence **once** (`last_heartbeat=now`), **nothing refreshed it mid-session**, and the persistent-service emitter forwards only NON-stale records (`list_presence(include_stale=False)`, `DEFAULT_STALE_AFTER_S=180`). So any session >3min old went dark — only stale `b2d-*` smoke rows remained.

**Fix:** the `context-shift-tracker` UserPromptSubmit hook now re-stamps presence each turn — best-effort, **detached `Popen` (zero turn latency)** — via `practitioner write --session <claude_session_id>` (resolves ai_id/location/empirica-session/active-transaction from context, re-stamps `last_heartbeat`, refreshes the `active_transaction_id` busy-signal). Stays fresh during active work; goes stale only when genuinely idle >3min (correct liveness). The daemon (already wired) forwards it.

Modifies an **already-registered** UserPromptSubmit hook → ships via plugin-sync, no new settings.json entry (deploy-robust). Smoke-verified: hook run → presence written + `last_heartbeat` stamped. ruff + pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)