### PR TITLE
fix(presence): daemon liveness-refresh keeps blocked-while-idle sessions on the mesh

### DIFF
--- a/empirica/cli/command_handlers/practitioner_commands.py
+++ b/empirica/cli/command_handlers/practitioner_commands.py
@@ -56,6 +56,7 @@ def handle_practitioner_write_command(args) -> int:
                 pending_question=getattr(args, "pending_question", None),
                 active_transaction_id=tx,
                 empirica_session_id=empirica_sid,
+                session_pid=getattr(args, "session_pid", None),
             )
         except ValueError as ve:
             return _emit_user_error(args, str(ve))

--- a/empirica/cli/parsers/cockpit_parsers.py
+++ b/empirica/cli/parsers/cockpit_parsers.py
@@ -82,6 +82,12 @@ def _add_practitioner_group(subparsers):
     write.add_argument("--session", required=True, help="claude_session_id (the durable practitioner key)")
     write.add_argument("--status", default="active", help="active | idle | paused | blocked (default: active)")
     write.add_argument("--pending-question", dest="pending_question", help="Blocked-reason (emit-and-park signal)")
+    write.add_argument(
+        "--session-pid",
+        dest="session_pid",
+        type=int,
+        help="Claude Code parent PID (os.getppid() at session-init) — the daemon's liveness anchor",
+    )
     write.add_argument("--ai-id", dest="ai_id", help="Practice ai_id (default: resolve from project context)")
     write.add_argument("--location", help="Location/instance_id (default: resolve from current process)")
     write.add_argument("--empirica-session", dest="empirica_session", help="Empirica session id (default: resolve)")

--- a/empirica/core/loop_scheduler/practitioner_heartbeat.py
+++ b/empirica/core/loop_scheduler/practitioner_heartbeat.py
@@ -235,6 +235,8 @@ class PractitionerHeartbeatEmitter:
         _post_fn: replaces HTTP POST — pass a Mock that records calls.
         _resolve_creds_fn: replaces credentials resolution — return (url, key).
         _list_fn: replaces the local-presence read — return a list of records.
+        _refresh_fn: replaces the liveness re-stamp — pass a no-op in tests so
+            emit_once never touches the real ~/.empirica presence files.
     """
 
     def __init__(
@@ -247,6 +249,7 @@ class PractitionerHeartbeatEmitter:
         _resolve_creds_fn: Callable[[], tuple] = _default_resolve_creds,
         _get_fn: Callable[[str, str, float], dict] = _default_get,
         _list_fn: Callable[[], list] | None = None,
+        _refresh_fn: Callable[[], dict] | None = None,
     ):
         self.machine = machine or socket.gethostname() or "unknown-host"
         self.interval_sec = interval_sec
@@ -255,6 +258,7 @@ class PractitionerHeartbeatEmitter:
         self._resolve_creds_fn = _resolve_creds_fn
         self._get_fn = _get_fn
         self._list_fn = _list_fn or self._default_list
+        self._refresh_fn = _refresh_fn or self._default_refresh
         self._stop_event = threading.Event()
         self._thread: threading.Thread | None = None
 
@@ -264,6 +268,14 @@ class PractitionerHeartbeatEmitter:
         from empirica.core.practitioner_presence import list_presence
 
         return list_presence(include_stale=False)
+
+    @staticmethod
+    def _default_refresh() -> dict:
+        """Re-stamp alive-PID presence so blocked/idle-but-alive sessions stay
+        non-stale (the daemon liveness keep-alive). See refresh_live_presence."""
+        from empirica.core.practitioner_presence import refresh_live_presence
+
+        return refresh_live_presence()
 
     def start(self) -> None:
         """Start the emitter thread. Idempotent — no-op if already running."""
@@ -292,6 +304,14 @@ class PractitionerHeartbeatEmitter:
         Never raises — a per-record failure records -1 and continues.
         """
         results: dict[str, int] = {}
+        # Liveness keep-alive FIRST: re-stamp alive-PID sessions so a session
+        # that's alive but quiet (blocked on a user question, idling) is fresh
+        # when we list/forward below — otherwise it would have gone stale and
+        # been dropped, going dark on the mesh despite being alive.
+        try:
+            self._refresh_fn()
+        except Exception as e:
+            logger.warning("practitioner-heartbeat: refresh failed: %s: %s", type(e).__name__, e)
         try:
             records = self._list_fn()
         except Exception as e:

--- a/empirica/core/practitioner_presence.py
+++ b/empirica/core/practitioner_presence.py
@@ -26,6 +26,7 @@ See docs/architecture/instance_isolation/PRACTITIONER_IDENTITY.md §5.
 from __future__ import annotations
 
 import json
+import os
 import time
 from pathlib import Path
 from typing import Any
@@ -37,6 +38,37 @@ _PREFIX = "practitioner_presence_"
 # heartbeat. ~3× the default 60s cadence — past the realtime (30s) / default
 # (60s) bands with margin; the spec's "stale-after-2N → unreachable" rule.
 DEFAULT_STALE_AFTER_S = 180.0
+
+# Status-aware staleness: a session BLOCKED on a user question (or paused) is
+# alive but deliberately quiet — no UserPromptSubmit fires to refresh it, so the
+# per-turn hook can't keep it warm and the active window would mark it dead even
+# though it's just waiting. The daemon's refresh_live_presence() re-stamps any
+# alive-PID session each tick (the PRIMARY keep-alive); this longer window is the
+# FALLBACK grace for records the daemon can't PID-verify (no session_pid, or the
+# gap between PID-death and the next tick). Tunable via the env var.
+_DEFAULT_BLOCKED_STALE_S = 1800.0
+
+
+def _blocked_stale_after() -> float:
+    """Stale window for blocked/paused sessions (env-tunable, default 30min)."""
+    raw = os.environ.get("EMPIRICA_PRESENCE_BLOCKED_STALE_S")
+    if raw:
+        try:
+            v = float(raw)
+            if v > 0:
+                return v
+        except ValueError:
+            pass
+    return _DEFAULT_BLOCKED_STALE_S
+
+
+def _stale_after_for_status(status: str | None) -> float:
+    """Per-status stale threshold. Blocked + paused get the longer grace window;
+    everything else uses the default active cadence-derived window."""
+    if status in ("blocked", "paused"):
+        return _blocked_stale_after()
+    return DEFAULT_STALE_AFTER_S
+
 
 VALID_STATUS = ("active", "idle", "paused", "blocked")
 
@@ -60,16 +92,30 @@ def write_presence(
     active_transaction_id: str | None = None,
     empirica_session_id: str | None = None,
     practitioner_id: str | None = None,
+    session_pid: int | None = None,
 ) -> dict[str, Any]:
     """Upsert the practitioner's presence record (stamps ``last_heartbeat``=now).
 
     Idempotent register + heartbeat in one call. ``status`` must be a valid
     state. The stable key is ``claude_session_id``; ``empirica_session_id`` +
     ``active_transaction_id`` are the churning measurement-cycle attributes.
+
+    ``session_pid`` is the Claude Code parent PID — captured at session-init,
+    where ``os.getppid()`` reliably resolves to it. It is the liveness anchor the
+    daemon's :func:`refresh_live_presence` probes to keep an alive-but-quiet
+    session (e.g. one blocked on a user question) non-stale. Writers that don't
+    re-supply it pass ``None`` — an existing record's ``session_pid`` is then
+    PRESERVED rather than clobbered, so the anchor survives high-churn rewrites
+    (the per-turn refresh, a daemon touch).
     """
     if status not in VALID_STATUS:
         raise ValueError(f"invalid status {status!r} — must be one of {VALID_STATUS}")
     EMPIRICA_DIR.mkdir(parents=True, exist_ok=True)
+    # Preserve the liveness anchor across rewrites that don't re-supply it.
+    if session_pid is None:
+        prior = read_presence(claude_session_id)
+        if prior is not None and isinstance(prior.get("session_pid"), int):
+            session_pid = prior["session_pid"]
     record: dict[str, Any] = {
         "claude_session_id": claude_session_id,
         # nullable seam — becomes user_id × practice_id × harness_class when the
@@ -81,6 +127,7 @@ def write_presence(
         "pending_question": pending_question,
         "active_transaction_id": active_transaction_id,
         "empirica_session_id": empirica_session_id,
+        "session_pid": session_pid,
         "last_heartbeat": time.time(),
     }
     path = presence_path(claude_session_id)
@@ -119,14 +166,19 @@ def list_presence(
     practice_ai_id: str | None = None,
     *,
     include_stale: bool = False,
-    stale_after: float = DEFAULT_STALE_AFTER_S,
+    stale_after: float | None = None,
 ) -> list[dict[str, Any]]:
     """Resolve practitioners → presence records.
 
     With ``practice_ai_id`` set, scopes to that practice's practitioners (the
     "practice → its active practitioner(s)" resolver). Each returned record gets
-    a derived ``stale`` flag (``last_heartbeat`` older than ``stale_after``, or
+    a derived ``stale`` flag (``last_heartbeat`` older than the threshold, or
     missing); stale records are excluded unless ``include_stale``.
+
+    The threshold is STATUS-AWARE by default (``stale_after=None``): blocked /
+    paused sessions get the longer :func:`_blocked_stale_after` grace, everything
+    else the default active window. Pass an explicit ``stale_after`` to force a
+    single flat threshold for all records.
     """
     now = time.time()
     out: list[dict[str, Any]] = []
@@ -137,13 +189,71 @@ def list_presence(
             continue
         if practice_ai_id is not None and rec.get("practice_ai_id") != practice_ai_id:
             continue
+        threshold = stale_after if stale_after is not None else _stale_after_for_status(rec.get("status"))
         last = rec.get("last_heartbeat")
         age = (now - last) if isinstance(last, (int, float)) else None
-        rec["stale"] = age is None or age > stale_after
+        rec["stale"] = age is None or age > threshold
         if rec["stale"] and not include_stale:
             continue
         out.append(rec)
     return out
+
+
+def _pid_alive(pid: int) -> bool:
+    """True if the process is still alive (signal-0 probe)."""
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True  # exists but owned by another user — still alive
+    except OSError:
+        return False
+    return True
+
+
+def refresh_live_presence(*, now: float | None = None) -> dict[str, int]:
+    """Daemon liveness re-stamp — keep alive-but-quiet sessions non-stale.
+
+    For each presence record carrying a live ``session_pid`` (the Claude Code
+    parent), bump ``last_heartbeat`` to now. This is the FIX for the
+    blocked-while-idle gap: a session blocked on a user question stops firing
+    UserPromptSubmit, so the per-turn refresh can't keep it warm and it would go
+    stale after the active window — even though it's alive and waiting. The
+    persistent service calls this each tick BEFORE listing/forwarding, so an
+    alive session of ANY status (active, idle, blocked, paused) keeps emitting to
+    cortex as long as its process lives.
+
+    Records with no ``session_pid`` (legacy / pre-PID writers) or a dead PID are
+    left untouched — they fall through to the status-aware TTL. Returns counts:
+    ``{"refreshed", "alive", "dead", "no_pid"}``.
+    """
+    now = time.time() if now is None else now
+    counts = {"refreshed": 0, "alive": 0, "dead": 0, "no_pid": 0}
+    for path in _all_presence_files():
+        try:
+            rec = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        pid = rec.get("session_pid")
+        if not isinstance(pid, int):
+            counts["no_pid"] += 1
+            continue
+        if not _pid_alive(pid):
+            counts["dead"] += 1
+            continue
+        counts["alive"] += 1
+        rec["last_heartbeat"] = now
+        tmp = path.with_name(path.name + ".tmp")
+        try:
+            tmp.write_text(json.dumps(rec), encoding="utf-8")
+            tmp.replace(path)  # atomic
+            counts["refreshed"] += 1
+        except OSError:
+            pass
+    return counts
 
 
 def resolve_practitioners(practice_ai_id: str, *, include_stale: bool = False) -> list[dict[str, Any]]:

--- a/empirica/plugins/claude-code-integration/hooks/context-shift-tracker.py
+++ b/empirica/plugins/claude-code-integration/hooks/context-shift-tracker.py
@@ -297,12 +297,20 @@ def _refresh_presence(claude_session_id):
     cortex.
 
     session-init writes presence once at session start; without a per-turn
-    refresh the record goes stale after DEFAULT_STALE_AFTER_S (180s) and a live
+    refresh the record goes stale after the active window (180s) and a live
     session stops emitting — the mesh's busy/free/blocked active-state signal
     goes dark on any session older than 3 minutes. `practitioner write` resolves
     ai_id / location / empirica-session / active-transaction from the running
     context, so only --session is needed. Fire-and-forget (detached Popen) so it
     never adds latency to — or fails — the user turn.
+
+    We also re-supply --session-pid (this hook is spawned by Claude Code, so
+    getppid() is CC): it makes the per-turn refresh self-healing for the daemon's
+    liveness anchor — any session that emits a prompt gets its session_pid set or
+    corrected, even one created before the anchor existed. (write_presence also
+    preserves an existing anchor across rewrites, so this is belt-and-suspenders.)
+    A prompt submission also means the practitioner is active again, so this
+    naturally clears any status=blocked the AskUserQuestion gate stamped.
     """
     if not claude_session_id:
         return
@@ -310,7 +318,17 @@ def _refresh_presence(claude_session_id):
         import subprocess
 
         subprocess.Popen(
-            ["empirica", "practitioner", "write", "--session", claude_session_id, "--output", "json"],
+            [
+                "empirica",
+                "practitioner",
+                "write",
+                "--session",
+                claude_session_id,
+                "--session-pid",
+                str(os.getppid()),
+                "--output",
+                "json",
+            ],
             stdin=subprocess.DEVNULL,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,

--- a/empirica/plugins/claude-code-integration/hooks/sentinel-gate.py
+++ b/empirica/plugins/claude-code-integration/hooks/sentinel-gate.py
@@ -1109,6 +1109,50 @@ def _atomic_write_counters(counters: dict, counters_path: Path) -> None:
             pass
 
 
+def _stamp_blocked_presence(claude_session_id: str | None, tool_input: dict | None) -> None:
+    """Mark this practitioner BLOCKED-on-question the moment AskUserQuestion fires.
+
+    A session blocked waiting for a user answer is alive but goes quiet — no
+    UserPromptSubmit fires until the user replies, so the per-turn presence
+    refresh can't keep it warm. Stamping status=blocked lets the daemon apply the
+    longer blocked-grace TTL and lets autonomy's watch-sweep distinguish
+    'blocked' from 'idle'/'working'. --session-pid (getppid()=CC, this hook's
+    parent) keeps the daemon's liveness anchor set so refresh_live_presence keeps
+    re-stamping it. The next user prompt re-stamps status=active, clearing this.
+    Detached fire-and-forget — never adds latency to, or fails, the gate.
+    """
+    if not claude_session_id:
+        return
+    pending = None
+    try:
+        questions = (tool_input or {}).get("questions") or []
+        if questions and isinstance(questions[0], dict):
+            pending = (questions[0].get("question") or questions[0].get("header") or "")[:200] or None
+    except Exception:
+        pending = None
+    try:
+        import subprocess
+
+        cmd = [
+            "empirica",
+            "practitioner",
+            "write",
+            "--session",
+            claude_session_id,
+            "--status",
+            "blocked",
+            "--session-pid",
+            str(os.getppid()),
+            "--output",
+            "json",
+        ]
+        if pending:
+            cmd += ["--pending-question", pending]
+        subprocess.Popen(cmd, stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    except Exception:
+        pass
+
+
 def _try_increment_tool_count(
     claude_session_id: str | None = None, tool_name: str | None = None, tool_input: dict | None = None
 ) -> tuple:
@@ -1162,6 +1206,7 @@ def _try_increment_tool_count(
 
         if tool_name == "AskUserQuestion":
             counters["pending_user_response"] = True
+            _stamp_blocked_presence(claude_session_id, tool_input)
 
         if tool_name:
             _record_workflow_trace(counters, tool_name, tool_input, is_noetic)

--- a/empirica/plugins/claude-code-integration/hooks/session-init.py
+++ b/empirica/plugins/claude-code-integration/hooks/session-init.py
@@ -1503,6 +1503,12 @@ def main():
                         ai_id,
                         "--empirica-session",
                         result["session_id"],
+                        # The Claude Code parent PID — this hook is spawned by CC,
+                        # so getppid() is CC. It's the daemon's liveness anchor:
+                        # refresh_live_presence() probes it to keep an alive-but-
+                        # quiet session (blocked on a question) non-stale.
+                        "--session-pid",
+                        str(os.getppid()),
                         "--output",
                         "json",
                     ],

--- a/tests/test_practitioner_heartbeat.py
+++ b/tests/test_practitioner_heartbeat.py
@@ -169,6 +169,7 @@ def test_emit_once_emits_each_local_practitioner():
         _resolve_creds_fn=CREDS,
         _get_fn=GET_PROJECTS,
         _list_fn=lambda: records,
+        _refresh_fn=lambda: {},  # hermetic — don't touch the real ~/.empirica
     )
     results = emitter.emit_once()
     assert results == {"cc-a": 200, "cc-b": 200}
@@ -182,15 +183,63 @@ def test_emit_once_survives_list_failure():
     def _boom():
         raise RuntimeError("disk gone")
 
-    emitter = PractitionerHeartbeatEmitter(_post_fn=_Recorder(), _resolve_creds_fn=CREDS, _list_fn=_boom)
+    emitter = PractitionerHeartbeatEmitter(
+        _post_fn=_Recorder(), _resolve_creds_fn=CREDS, _list_fn=_boom, _refresh_fn=lambda: {}
+    )
     assert emitter.emit_once() == {}  # never raises — returns empty
 
 
 def test_emit_once_empty_when_no_practitioners():
     rec = _Recorder()
-    emitter = PractitionerHeartbeatEmitter(_post_fn=rec, _resolve_creds_fn=CREDS, _list_fn=lambda: [])
+    emitter = PractitionerHeartbeatEmitter(
+        _post_fn=rec, _resolve_creds_fn=CREDS, _list_fn=lambda: [], _refresh_fn=lambda: {}
+    )
     assert emitter.emit_once() == {}
     assert rec.calls == []
+
+
+def test_emit_once_refreshes_liveness_before_listing():
+    """The daemon re-stamps alive-PID presence BEFORE listing — so an alive but
+    quiet (blocked) session is fresh when forwarded, not dropped as stale."""
+    order = []
+    rec = _Recorder(code=200)
+
+    def _refresh():
+        order.append("refresh")
+        return {"refreshed": 1}
+
+    def _list():
+        order.append("list")
+        return [_record(claude_session_id="cc-a")]
+
+    emitter = PractitionerHeartbeatEmitter(
+        machine="host-1",
+        _post_fn=rec,
+        _resolve_creds_fn=CREDS,
+        _get_fn=GET_PROJECTS,
+        _list_fn=_list,
+        _refresh_fn=_refresh,
+    )
+    emitter.emit_once()
+    assert order == ["refresh", "list"]  # liveness re-stamp precedes the read
+
+
+def test_emit_once_survives_refresh_failure():
+    """A refresh blowup never breaks emission — list/forward still proceed."""
+
+    def _boom_refresh():
+        raise RuntimeError("fs gone")
+
+    rec = _Recorder(code=200)
+    emitter = PractitionerHeartbeatEmitter(
+        machine="host-1",
+        _post_fn=rec,
+        _resolve_creds_fn=CREDS,
+        _get_fn=GET_PROJECTS,
+        _list_fn=lambda: [_record(claude_session_id="cc-a")],
+        _refresh_fn=_boom_refresh,
+    )
+    assert emitter.emit_once() == {"cc-a": 200}  # emission unaffected by refresh failure
 
 
 def test_start_stop_idempotent():
@@ -200,6 +249,7 @@ def test_start_stop_idempotent():
         _post_fn=_Recorder(),
         _resolve_creds_fn=NO_CREDS,
         _list_fn=lambda: [],
+        _refresh_fn=lambda: {},
     )
     emitter.start()
     emitter.start()  # idempotent — no second thread

--- a/tests/test_practitioner_presence.py
+++ b/tests/test_practitioner_presence.py
@@ -104,3 +104,127 @@ def test_safe_filename(fake_home):
     pp.write_presence("a/b%c", practice_ai_id="empirica")
     assert pp.presence_path("a/b%c").name == "practitioner_presence_a-bc.json"
     assert pp.read_presence("a/b%c") is not None
+
+
+# ── session_pid: the daemon's liveness anchor (da902b30) ────────────────────
+
+
+def test_write_stores_session_pid(fake_home):
+    rec = pp.write_presence("cc-pid", practice_ai_id="empirica", session_pid=4242)
+    assert rec["session_pid"] == 4242
+    assert pp.read_presence("cc-pid")["session_pid"] == 4242
+
+
+def test_session_pid_preserved_on_none_rewrite(fake_home):
+    # The per-turn refresh / a daemon touch rewrites presence WITHOUT re-supplying
+    # the pid. The anchor must survive — else the daemon loses its liveness probe.
+    pp.write_presence("cc-keep", practice_ai_id="empirica", session_pid=777)
+    pp.write_presence("cc-keep", practice_ai_id="empirica", status="idle")  # no session_pid
+    rec = pp.read_presence("cc-keep")
+    assert rec["session_pid"] == 777  # anchor survived the churn
+    assert rec["status"] == "idle"
+
+
+def test_explicit_session_pid_overrides_preserved(fake_home):
+    pp.write_presence("cc-ov", practice_ai_id="empirica", session_pid=1)
+    pp.write_presence("cc-ov", practice_ai_id="empirica", session_pid=2)
+    assert pp.read_presence("cc-ov")["session_pid"] == 2
+
+
+def test_legacy_record_has_null_session_pid(fake_home):
+    rec = pp.write_presence("cc-legacy", practice_ai_id="empirica")
+    assert rec["session_pid"] is None
+
+
+# ── status-aware staleness: blocked/paused get the longer grace window ───────
+
+
+def test_status_aware_staleness_blocked_grace(fake_home):
+    # Both back-dated to the same age: just past the active window, but within the
+    # blocked grace window. Active goes stale; blocked survives.
+    age = pp.DEFAULT_STALE_AFTER_S + 60
+    assert age < pp._blocked_stale_after()  # precondition for the test to be meaningful
+    for sid, status in (("cc-act", "active"), ("cc-blk", "blocked")):
+        pp.write_presence(sid, practice_ai_id="empirica", status=status)
+        p = pp.presence_path(sid)
+        d = json.loads(p.read_text())
+        d["last_heartbeat"] = time.time() - age
+        p.write_text(json.dumps(d))
+    live = {r["claude_session_id"] for r in pp.list_presence("empirica")}
+    assert live == {"cc-blk"}  # blocked survives the active-window cutoff, active doesn't
+
+
+def test_blocked_grace_env_tunable(fake_home, monkeypatch):
+    monkeypatch.setenv("EMPIRICA_PRESENCE_BLOCKED_STALE_S", "10")
+    pp.write_presence("cc-blk", practice_ai_id="empirica", status="blocked")
+    p = pp.presence_path("cc-blk")
+    d = json.loads(p.read_text())
+    d["last_heartbeat"] = time.time() - 30  # past the now-tightened 10s grace
+    p.write_text(json.dumps(d))
+    assert pp.list_presence("empirica") == []  # blocked but past the tuned window → stale
+
+
+def test_explicit_stale_after_forces_flat_threshold(fake_home):
+    # Passing stale_after overrides status-awareness with a single flat threshold.
+    pp.write_presence("cc-b", practice_ai_id="empirica", status="blocked")
+    p = pp.presence_path("cc-b")
+    d = json.loads(p.read_text())
+    d["last_heartbeat"] = time.time() - 10
+    p.write_text(json.dumps(d))
+    assert pp.list_presence("empirica", stale_after=5) == []  # flat 5s threshold → stale
+    assert len(pp.list_presence("empirica")) == 1  # status-aware default → still fresh
+
+
+# ── refresh_live_presence: the daemon liveness re-stamp (the core fix) ───────
+
+
+def test_refresh_live_presence_alive_dead_nopid(fake_home):
+    import os
+    import subprocess
+
+    pp.write_presence("cc-alive", practice_ai_id="empirica", session_pid=os.getpid())
+    proc = subprocess.Popen(["true"])  # a process that exits immediately
+    proc.wait()  # reaped → its PID is now dead (not reused within the test window)
+    pp.write_presence("cc-dead", practice_ai_id="empirica", session_pid=proc.pid)
+    pp.write_presence("cc-nopid", practice_ai_id="empirica")  # legacy: no anchor
+
+    old = time.time() - 1000
+    for sid in ("cc-alive", "cc-dead", "cc-nopid"):
+        p = pp.presence_path(sid)
+        d = json.loads(p.read_text())
+        d["last_heartbeat"] = old
+        p.write_text(json.dumps(d))
+
+    counts = pp.refresh_live_presence()
+    assert counts == {"refreshed": 1, "alive": 1, "dead": 1, "no_pid": 1}
+    assert pp.read_presence("cc-alive")["last_heartbeat"] > old  # alive → re-stamped
+    assert pp.read_presence("cc-dead")["last_heartbeat"] == old  # dead → untouched
+    assert pp.read_presence("cc-nopid")["last_heartbeat"] == old  # no anchor → untouched
+
+
+def test_refresh_keeps_blocked_alive_session_nonstale(fake_home):
+    import os
+
+    # The whole point: a blocked, ALIVE session back-dated past the active window
+    # would be dropped — refresh re-stamps it so it stays on the mesh.
+    pp.write_presence("cc-blk", practice_ai_id="empirica", status="blocked", session_pid=os.getpid())
+    p = pp.presence_path("cc-blk")
+    d = json.loads(p.read_text())
+    d["last_heartbeat"] = time.time() - (pp.DEFAULT_STALE_AFTER_S + 30)
+    p.write_text(json.dumps(d))
+
+    pp.refresh_live_presence()
+    # fresh again — present even under a strict flat active-window check
+    assert len(pp.list_presence("empirica", stale_after=pp.DEFAULT_STALE_AFTER_S)) == 1
+
+
+def test_pid_alive_probe(fake_home):
+    import os
+    import subprocess
+
+    assert pp._pid_alive(os.getpid()) is True
+    assert pp._pid_alive(0) is False
+    assert pp._pid_alive(-1) is False
+    proc = subprocess.Popen(["true"])
+    proc.wait()
+    assert pp._pid_alive(proc.pid) is False


### PR DESCRIPTION
## Problem

A session blocked on a user question (AskUserQuestion) is **alive but quiet** — no `UserPromptSubmit` fires until the user replies, so the per-turn presence refresh (#179) can't keep it warm. After the 180s active window the record goes stale, the emitter stops forwarding it, and the session **goes dark on the mesh despite being alive and waiting**. #179 closed the always-quiet-after-3min gap for *active* sessions but not the blocked-while-idle case.

## Fix — two complementary mechanisms

**Daemon liveness re-stamp (primary).** `refresh_live_presence()` probes each record's `session_pid` (the Claude Code parent PID, captured at session-init where `getppid() == CC`) and bumps `last_heartbeat` for any alive PID — called each emit tick *before* listing. An alive session of **any** status keeps emitting as long as its process lives.

**Status-aware staleness (fallback).** `blocked`/`paused` get a longer, env-tunable grace window (`EMPIRICA_PRESENCE_BLOCKED_STALE_S`, default 30min) for records the daemon can't PID-verify (legacy no-pid records, or the gap before the next tick).

## Supporting wiring

- `write_presence` gains `session_pid` + **preserve-on-None** so the anchor survives high-churn rewrites (the per-turn refresh, a daemon touch).
- `session-init` + `context-shift-tracker` pass `--session-pid` (`getppid()`).
- `sentinel-gate` stamps `status=blocked` at the AskUserQuestion block-moment (detached); the next user prompt re-stamps `active`, clearing it.
- CLI: `--session-pid` on `practitioner write`.

Subsumes #179's per-turn hook (kept as belt-and-suspenders).

## Tests

- **presence**: `session_pid` round-trip + preserve-on-None, status-aware TTL (blocked grace + env-tunable + explicit-override), `refresh_live_presence` (alive/dead/no-pid counts), blocked-alive-survives-strict-window, `_pid_alive` probe.
- **daemon**: refresh-runs-before-list ordering, emit survives a refresh failure; existing emit tests made hermetic with a no-op `_refresh_fn`.
- Live smoke verifies the full CLI write (`--session-pid`) → pid-less rewrite (preserve) → daemon refresh → strict-window survival round-trip.

Local gate green: `ruff check` + `ruff format --check` + `pytest` (51 presence/heartbeat/cli + 250 integrity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)