### PR TITLE
fix(daemon): scope engagement goals/sources via entity_artifacts (data-leak fix, part 1)

### DIFF
--- a/empirica/api/routes/artifacts.py
+++ b/empirica/api/routes/artifacts.py
@@ -671,14 +671,21 @@ async def list_sources(
     limit: int = Query(50, ge=1, le=500),
     project_id: str | None = Query(None),
     path: str | None = Query(None),
+    entity: str | None = Query(None, description="Scope to an entity's linked artifacts (e.g. 'engagement')"),
+    entity_id: str | None = Query(None, description="The entity id, required when 'entity' is set"),
 ):
+    """List sources. With ``entity=engagement&entity_id=``, scopes to that
+    engagement's linked sources via entity_artifacts (ratified boundary §4)."""
+    allowed = _engagement_artifact_ids(entity, entity_id, "source")
     project = _resolve_project_dict(project_id, path)
     proj_pid = project.get("project_id")
     if not proj_pid:
         return {"sources": [], "project_id": None}
     db = _open_db_for(project)
     try:
-        rows = _list_sources(db, proj_pid, limit)
+        rows = _list_sources(db, proj_pid, 500 if allowed is not None else limit)
+        if allowed is not None:
+            rows = [r for r in rows if r.get("id") in allowed][:limit]
         rows = _attach_related_to(db, rows)
         return {"sources": rows, "project_id": proj_pid}
     finally:
@@ -877,20 +884,63 @@ def _resolve_file_source(
     }
 
 
+def _engagement_artifact_ids(entity: str | None, entity_id: str | None, artifact_type: str) -> set[str] | None:
+    """Resolve the artifact ids linked to an entity, from workspace.db entity_artifacts.
+
+    Returns:
+      - ``None``  → no entity scoping requested; caller keeps project-wide behavior.
+      - ``set()`` → scoping requested but the entity has no linked artifacts of this
+        type; caller returns honest-empty, NOT the full project set.
+      - ``{ids}`` → the allowed artifact ids.
+
+    The ratified CRM/ERM boundary (§4, decision #2) mandates that an engagement's
+    goals/sources resolve via ``entity_artifacts(entity_type='engagement')`` — the
+    work FOR the contact — NOT the practitioner's own project artifacts. Without
+    this scoping the daemon returned every project goal/source for any engagement
+    (the Contact-area data leak: an engagement with 0 linked goals showed all 50).
+
+    Only ``engagement`` scoping is defined today; any other entity with an id is a
+    no-match (honest-empty), never a silent full-set return. workspace.db being
+    absent/unreadable is likewise honest-empty — we never leak the full set.
+    """
+    if not entity or not entity_id:
+        return None
+    if entity != "engagement":
+        return set()
+    try:
+        from empirica.data.repositories.workspace_db import WorkspaceDBRepository
+
+        with WorkspaceDBRepository.open() as repo:
+            links = repo.get_entity_artifacts_by_entity("engagement", entity_id, limit=500)
+        return {ln["artifact_id"] for ln in links if ln.get("artifact_type") == artifact_type and ln.get("artifact_id")}
+    except Exception:
+        return set()
+
+
 @router.get("/goals")
 async def list_goals(
     status: str = Query("active", pattern="^(active|completed|planned|all)$"),
     limit: int = Query(50, ge=1, le=500),
     project_id: str | None = Query(None),
     path: str | None = Query(None),
+    entity: str | None = Query(None, description="Scope to an entity's linked artifacts (e.g. 'engagement')"),
+    entity_id: str | None = Query(None, description="The entity id, required when 'entity' is set"),
 ):
+    """List goals. With ``entity=engagement&entity_id=``, scopes to that
+    engagement's linked goals via entity_artifacts (ratified boundary §4) instead
+    of returning the daemon project's own goals."""
+    allowed = _engagement_artifact_ids(entity, entity_id, "goal")
     project = _resolve_project_dict(project_id, path)
     proj_pid = project.get("project_id")
     if not proj_pid:
         return {"goals": [], "project_id": None}
     db = _open_db_for(project)
     try:
-        rows = _list_goals(db, proj_pid, status, limit)
+        # When entity-scoping, fetch generously then intersect — the engagement's
+        # linked goals may sit beyond the first `limit` of the project list.
+        rows = _list_goals(db, proj_pid, status, 500 if allowed is not None else limit)
+        if allowed is not None:
+            rows = [r for r in rows if r.get("id") in allowed][:limit]
         rows = _attach_related_to(db, rows)
         return {"goals": rows, "project_id": proj_pid}
     finally:

--- a/tests/test_serve_artifacts_entity_scoping.py
+++ b/tests/test_serve_artifacts_entity_scoping.py
@@ -1,0 +1,89 @@
+"""Engagement-scoped artifact resolution for the daemon /goals + /sources routes.
+
+Ratified CRM/ERM boundary §4 (decision #2): an engagement's goals/sources must
+resolve via ``entity_artifacts(entity_type='engagement')``, NOT the daemon
+project's own artifacts. Without it the daemon leaked every project goal/source
+for any engagement (the Contact-area data leak: an engagement with 0 linked
+goals showed all 50 project goals). These pin ``_engagement_artifact_ids`` — the
+cross-db resolver where that fix lives.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from empirica.api.routes import artifacts as art
+
+
+class _FakeRepo:
+    def __init__(self, links):
+        self._links = links
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def get_entity_artifacts_by_entity(self, entity_type, entity_id, limit=500):
+        return self._links
+
+
+def _patch_repo(links):
+    return patch(
+        "empirica.data.repositories.workspace_db.WorkspaceDBRepository.open",
+        return_value=_FakeRepo(links),
+    )
+
+
+def test_no_entity_scoping_returns_none():
+    # None == "no scoping requested" → caller keeps project-wide behavior.
+    assert art._engagement_artifact_ids(None, None, "goal") is None
+    assert art._engagement_artifact_ids("engagement", None, "goal") is None
+    assert art._engagement_artifact_ids(None, "e-1", "goal") is None
+
+
+def test_unknown_entity_is_honest_empty_not_none():
+    # An unknown entity type WITH an id must be a no-match (empty), never a silent
+    # fall-through to the full project set.
+    assert art._engagement_artifact_ids("organization", "o-1", "goal") == set()
+    assert art._engagement_artifact_ids("project", "p-1", "source") == set()
+
+
+def test_engagement_filters_by_artifact_type():
+    links = [
+        {"artifact_type": "goal", "artifact_id": "g1"},
+        {"artifact_type": "goal", "artifact_id": "g2"},
+        {"artifact_type": "source", "artifact_id": "s1"},
+        {"artifact_type": "finding", "artifact_id": "f1"},
+    ]
+    with _patch_repo(links):
+        assert art._engagement_artifact_ids("engagement", "e-1", "goal") == {"g1", "g2"}
+    with _patch_repo(links):
+        assert art._engagement_artifact_ids("engagement", "e-1", "source") == {"s1"}
+
+
+def test_engagement_with_no_links_is_empty_not_leak():
+    # THE leak fix: an engagement with 0 linked goals → empty set, so the route
+    # returns honest-empty instead of every project goal.
+    with _patch_repo([]):
+        assert art._engagement_artifact_ids("engagement", "e-empty", "goal") == set()
+
+
+def test_workspace_unreadable_is_honest_empty():
+    # workspace.db absent/unreadable → never leak the full set.
+    with patch(
+        "empirica.data.repositories.workspace_db.WorkspaceDBRepository.open",
+        side_effect=RuntimeError("workspace.db gone"),
+    ):
+        assert art._engagement_artifact_ids("engagement", "e-1", "goal") == set()
+
+
+def test_links_missing_artifact_id_are_skipped():
+    links = [
+        {"artifact_type": "goal", "artifact_id": "g1"},
+        {"artifact_type": "goal"},  # malformed — no artifact_id
+        {"artifact_type": "goal", "artifact_id": None},
+    ]
+    with _patch_repo(links):
+        assert art._engagement_artifact_ids("engagement", "e-1", "goal") == {"g1"}


### PR DESCRIPTION
## What

The empirica daemon's `/api/v1/goals` + `/api/v1/sources` GET routes **silently dropped scoping params** (FastAPI ignores undeclared query args) and returned *every project goal/source for any engagement* — the **Contact-area data leak** extension probed (prop_2yrh5wha: an engagement with `goal_count=0` rendered all 50 project goals).

This is empirica's leg of the **ratified CRM/ERM boundary** (David, 2026-06-28), §4 decision #2: an engagement's goals/sources must resolve via `entity_artifacts(entity_type='engagement')` — the work *for* the contact — not the practitioner's own project artifacts.

## Fix (part 1 — engagement artifact JOINs)

- Add `entity` + `entity_id` Query params to `/goals` + `/sources`.
- New `_engagement_artifact_ids(entity, entity_id, artifact_type)` cross-resolves the engagement's linked artifact ids from **workspace.db** `entity_artifacts`, then the route intersects the **sessions.db** rows.
- **Honest-empty discipline**: no links → empty (not the full set); workspace.db absent/unreadable → empty; unknown entity type with an id → empty. Never a silent full-set leak.
- `None` (no entity params) preserves the existing project-wide behavior exactly.

## Tests
6 unit tests on the resolver (where the leak-fix logic lives) — type filtering, no-links honest-empty, unknown-entity honest-empty, workspace-unreadable honest-empty, malformed-link skip. Existing `test_serve_artifacts_list` + `test_serve_artifacts_crud` suites still green (routes unchanged for the no-scoping path). Live app builds + routes register.

## Held for a follow-up (part 2)
Org/entity scoping on `/entities` + `/engagements`: the boundary doc names `contact_organizations`/`engagement_contacts` junctions, but core's workspace.db uses the generic `entity_memberships` — escalated to workspace for the canonical join before building. Also queued: core-side crm.db removal (workspace's migration-check confirmed SAFE-to-delete).

🤖 Generated with [Claude Code](https://claude.com/claude-code)