### PR TITLE
feat(sentinel): expand noetic allowlist + close find/awk/fd/sort/yq write-flag holes

### DIFF
--- a/empirica/plugins/claude-code-integration/hooks/sentinel-gate.py
+++ b/empirica/plugins/claude-code-integration/hooks/sentinel-gate.py
@@ -247,6 +247,45 @@ SAFE_BASH_PREFIXES = (
     "mypy ",
     "flake8 ",
     "pylint ",
+    "vulture ",
+    "pip-audit",
+    # Text pipeline (read-only, pure stdout — no native write mode)
+    "cut ",
+    "tr ",
+    "nl ",
+    "fold ",
+    "tac ",
+    "rev ",
+    "paste ",
+    "column ",
+    "sort ",  # sort -o/--output is guarded in _has_dangerous_tool_flags
+    "uniq ",
+    # Structured data (read-only; yq -i is guarded)
+    "yq ",
+    "yq.",
+    "gron ",
+    # Binary / encoding inspection (read-only)
+    "xxd ",
+    "od ",
+    "strings ",
+    # Fast search / navigation (read-only; fd -x and ast-grep --rewrite guarded).
+    # No-ops until installed — harmless to allowlist ahead of the dep landing.
+    "fd ",
+    "fdfind ",
+    "ast-grep ",
+    "bat ",
+    "tokei ",
+    "scc ",
+    # Git read operations (additions)
+    "git rev-parse",
+    "git rev-list",
+    "git for-each-ref",
+    "git describe",
+    "git shortlog",
+    "git grep",
+    "git config --get",
+    "git config --list",
+    "git config -l",
 )
 
 # Dangerous shell operators (command injection prevention)
@@ -1410,8 +1449,64 @@ def is_plan_file(tool_input: dict) -> bool:
     return "/.claude/plans/" in normalized
 
 
+# Per-tool flags that turn a normally-inert, safe-prefixed tool PRAXIC — it
+# runs / deletes / writes / rewrites. The tool NAME is inert (find/fd/sort/yq/
+# ast-grep all read by default), so a bare prefix match would wave these through;
+# this is the membrane-hole class. A prefix match PLUS one of these flags is gated.
+_TOOL_DANGEROUS_FLAGS: dict[str, frozenset[str]] = {
+    # deletes files / runs arbitrary commands / writes files
+    "find": frozenset({"-delete", "-exec", "-execdir", "-ok", "-okdir", "-fprint", "-fprint0", "-fprintf", "-fls"}),
+    # fd -x/-X run a command per result (find -exec equivalent)
+    "fd": frozenset({"-x", "-X", "--exec", "--exec-batch"}),
+    "fdfind": frozenset({"-x", "-X", "--exec", "--exec-batch"}),
+    # sort -o / --output writes to a file
+    "sort": frozenset({"-o", "--output"}),
+    # yq -i edits YAML in place
+    "yq": frozenset({"-i", "--inplace", "--in-place"}),
+    # ast-grep rewrites source in place
+    "ast-grep": frozenset({"-U", "--update-all", "--rewrite"}),
+}
+
+# awk family writes via print/printf > "file" INSIDE its program (the
+# redirect-outside-quotes guard can't see it) and execs via system(...).
+_AWK_WRITE_RE = re.compile(r"(print|printf)[^;\n]*>>?\s*\"")
+_AWK_NAMES = frozenset({"awk", "gawk", "mawk", "nawk"})
+
+
+def _has_dangerous_tool_flags(cmd: str) -> bool:
+    """True if ``cmd`` is a safe-prefixed tool invoked with a mutating/exec flag
+    its prefix would otherwise wave through (the membrane-hole class).
+
+    Closes the holes where the tool NAME is inert but a flag makes it praxic:
+    find -delete/-exec, fd -x, sort -o, yq -i, ast-grep --rewrite, and awk
+    system()/print-to-file. Known residuals (rare, low-severity): ``uniq IN OUT``
+    positional output, and combined short flags like ``-iX`` — both degrade to
+    "needs CHECK" at worst if ever extended, never a silent allow elsewhere.
+    """
+    stripped = cmd.lstrip()
+    head = stripped.split(" ", 1)[0]
+    if head in _AWK_NAMES:
+        return "system(" in stripped or bool(_AWK_WRITE_RE.search(stripped))
+    flags = _TOOL_DANGEROUS_FLAGS.get(head)
+    if flags:
+        for tok in stripped.split()[1:]:
+            if tok in flags:
+                return True
+            if tok.startswith("--") and "=" in tok and tok.split("=", 1)[0] in flags:
+                return True
+    return False
+
+
 def _matches_safe_prefix(cmd: str) -> bool:
-    """Check if a command matches any SAFE_BASH_PREFIXES entry."""
+    """Check if a command matches any SAFE_BASH_PREFIXES entry.
+
+    A prefix match is necessary but NOT sufficient: a normally-inert tool made
+    mutating/exec by a flag (find -delete, awk system(), fd -x, sort -o, yq -i,
+    ast-grep --rewrite) is rejected even when its prefix matches. See
+    _has_dangerous_tool_flags — the centralized chokepoint guard.
+    """
+    if _has_dangerous_tool_flags(cmd):
+        return False
     for prefix in SAFE_BASH_PREFIXES:
         if cmd.startswith(prefix):
             return True

--- a/tests/test_sentinel_shell_constructs.py
+++ b/tests/test_sentinel_shell_constructs.py
@@ -385,3 +385,93 @@ class TestNewlineChainAndPipeOverAllow:
         # body isn't shredded into bogus segments.
         cmd = "empirica preflight-submit - << 'EOF'\n{\"vectors\": {}}\nEOF"
         assert gate.is_safe_bash_command({"command": cmd}) is True
+
+
+class TestNoeticAllowlistExpansion:
+    """T1: expanded inert-tool allowlist + the per-tool write/exec-flag guards
+    (find/fd/sort/yq/ast-grep/awk membrane-hole closures)."""
+
+    # ── new inert prefixes flow free ────────────────────────────────────
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "yq '.foo' config.yaml",
+            "sort -rn data.txt",
+            "sort",  # bare (stdin) — covered via prefix.rstrip() match
+            "uniq -c",
+            "cut -d, -f2 x.csv",
+            "tr -d ' '",
+            "nl file.py",
+            "column -t",
+            "rev",
+            "tac log.txt",
+            "xxd binary.bin",
+            "od -c x",
+            "strings ./a.out",
+            "fd -e py",
+            "fd pattern src/",
+            "ast-grep -p 'def $F()' --lang py",
+            "bat README.md",
+            "tokei",
+            "scc .",
+            "gron data.json",
+            "git rev-parse HEAD",
+            "git for-each-ref refs/notes/",
+            "git describe --tags",
+            "git shortlog -sn",
+            "git grep TODO",
+            "git config --get user.name",
+            "git config --list",
+            "vulture empirica/",
+            "pip-audit",
+        ],
+    )
+    def test_new_inert_prefixes_allowed(self, gate, cmd):
+        assert gate._matches_safe_prefix(cmd) is True
+        assert gate.is_safe_bash_command({"command": cmd}) is True
+
+    # ── write/exec flags GATED even though the tool name is safe-listed ──
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "find . -delete",
+            "find . -name '*.py' -delete",
+            "find . -exec rm {} +",
+            "find . -fls out.txt",
+            "fd -e tmp -x rm",
+            "fd pattern --exec rm",
+            "sort -o out.txt in.txt",
+            "sort --output=out.txt in.txt",
+            "yq -i '.x=1' f.yaml",
+            "yq --inplace '.x=1' f.yaml",
+            "ast-grep --rewrite 'X' -p 'Y'",
+            "ast-grep -U -p 'Y'",
+            "awk 'BEGIN{system(\"rm -rf x\")}'",
+            "awk '{print $1 > \"out.txt\"}' in",
+            "awk '{print >> \"a\"}'",
+            "gawk 'BEGIN{system(\"id\")}'",
+        ],
+    )
+    def test_write_exec_flags_gated(self, gate, cmd):
+        assert gate._has_dangerous_tool_flags(cmd) is True
+        assert gate._matches_safe_prefix(cmd) is False
+        assert gate.is_safe_bash_command({"command": cmd}) is False
+
+    # ── no false-positives: inert variants of the guarded tools stay safe ─
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "find . -type f -name '*.py'",
+            "find . -maxdepth 2",
+            "fd -e py --hidden",
+            "sort -rn",
+            "awk '$3 > 100'",  # numeric comparison, not a write
+            "awk '{print $1, $2}'",  # print with no file redirect
+            "awk '$1 > \"foo\"'",  # string comparison, no print-to-file
+            "ast-grep -p 'def $F()'",
+            "yq '.version' pyproject.toml",
+        ],
+    )
+    def test_guard_no_false_positive(self, gate, cmd):
+        assert gate._has_dangerous_tool_flags(cmd) is False
+        assert gate._matches_safe_prefix(cmd) is True


### PR DESCRIPTION
## What (T1 of the noetic-tooling plan, goal `861e9ffe`)

Expand the Sentinel's `SAFE_BASH_PREFIXES` so typical noetic recon flows without a CHECK — **and** close the write-flag holes that adding write-capable tools would otherwise open.

## Allowlist additions (genuinely inert)
- **structured data**: `yq`, `gron`
- **text pipeline**: `cut`/`tr`/`nl`/`fold`/`tac`/`rev`/`paste`/`column`/`sort`/`uniq`
- **binary read**: `xxd`/`od`/`strings`
- **fast nav/search**: `fd`/`ast-grep`/`bat`/`tokei`/`scc`
- **git read**: `rev-parse`/`rev-list`/`for-each-ref`/`describe`/`shortlog`/`grep`/`config --get`/`--list`
- **analysis**: `vulture`/`pip-audit`

(`pyright`/`ruff check`/`radon`/`mypy`/`flake8`/`pylint`/`grep`/`rg`/`jq`/`echo` were already present — the delta is targeted.)

## Membrane-hole guard (the important part)
Several added tools have write/exec modes, so a bare prefix match would be a hole. New per-tool dangerous-flag table + `_has_dangerous_tool_flags`, called at the **`_matches_safe_prefix` chokepoint** (every classifier path inherits it):

| Tool | Gated flags |
|---|---|
| `find` | `-delete`, `-exec`/`-execdir`/`-ok`/`-okdir`/`-fprint*`/`-fls` |
| `fd` | `-x`/`-X`/`--exec` |
| `sort` | `-o`/`--output` |
| `yq` | `-i`/`--inplace` |
| `ast-grep` | `-U`/`--update-all`/`--rewrite` |
| `awk` (gawk/mawk) | `system(...)`, `print`/`printf > "file"` (regex won't false-positive on numeric/string comparisons) |

This also **closes 2 pre-existing holes**: `find . -delete` and `awk 'system("rm")'` were already allowed by the bare `find `/`awk ` prefixes.

**Deliberately not allowlisted**: `sg` (collides with the `setgroups` command), `semgrep` (`--autofix` writes), `tee`, `git reflog` (`expire` mutates). **Known residual** (rare, low-severity): `uniq IN OUT` positional output.

## Tests
50+ parametrized cases: new prefixes pass; every write/exec form gated (`find -delete`, `fd -x`, `sort -o`, `yq -i`, `ast-grep --rewrite`, `awk system()`/`print>file`); no false-positives (`awk '$3 > 100'`, `find -type f`, `fd -e py`, `sort -rn`). 109 shell-construct + 26 recovery/pause regression tests green. Live smoke confirms the gate.

Follow-ups (separate PRs, goals logged): T2 the "what is noetic" principle across prompt/skills; T3 wire Tier-1 tools (`rg`/`fd`/`jq`/`yq`/`ast-grep`) as ecosystem deps + `doctor` check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)