### PR TITLE
docs+feat(noetic): noetic principle in lean prompt + doctor check for Tier-1 tools

### DIFF
--- a/empirica/cli/command_handlers/doctor.py
+++ b/empirica/cli/command_handlers/doctor.py
@@ -141,6 +141,42 @@ def check_git_present() -> Check:
     return Check("git on PATH", PASS, path, data={"path": path})
 
 
+def check_noetic_tools() -> Check:
+    """Tier-1 noetic CLI tools that sharpen agentic recon (recommended, not required).
+
+    These are read-only/inert and are on the Sentinel's noetic allowlist, so when
+    present they flow free for a practitioner doing investigation — yq for YAML,
+    fd for fast gitignore-aware find, ast-grep for structural (by-syntax) code
+    search, rg/jq as the search + JSON workhorses. Absence is a WARN, never a
+    failure: empirica works without them.
+    """
+    # (binaries, human description). fd is `fdfind` on Debian/Ubuntu; ast-grep's
+    # short alias `sg` is deliberately NOT probed (it collides with the setgroups
+    # command), so only the full `ast-grep` name counts as present.
+    tools: dict[str, tuple[list[str], str]] = {
+        "rg": (["rg"], "ripgrep — fast, gitignore-aware search"),
+        "fd": (["fd", "fdfind"], "fast, gitignore-aware file find"),
+        "jq": (["jq"], "JSON query"),
+        "yq": (["yq"], "YAML query"),
+        "ast-grep": (["ast-grep"], "structural / AST-aware code search"),
+    }
+    present: dict[str, str | None] = {}
+    for label, spec in tools.items():
+        present[label] = next((p for n in spec[0] if (p := _which(n))), None)
+    missing = [t for t, p in present.items() if not p]
+    found = {t: p for t, p in present.items() if p}
+    if not missing:
+        return Check("Noetic tools (Tier 1)", PASS, "all present: " + ", ".join(tools), data={"present": found})
+    return Check(
+        "Noetic tools (Tier 1)",
+        WARN,
+        f"{len(found)}/{len(tools)} present; missing: {', '.join(missing)}",
+        "Install for sharper agentic recon (rg/fd/jq/yq/ast-grep) — all read-only, "
+        "Sentinel-noetic. e.g. `cargo install ripgrep fd-find ast-grep` or your package manager.",
+        data={"present": found, "missing": missing},
+    )
+
+
 # ─── Project state ─────────────────────────────────────────────────────
 
 
@@ -908,6 +944,7 @@ def run_all_checks(cwd: Path | None = None) -> list[Check]:
         check_empirica_mcp(),
         check_claude_code_cli(),
         check_git_present(),
+        check_noetic_tools(),
         # Project state
         check_empirica_folder(cwd),
         check_project_yaml(cwd),

--- a/empirica/plugins/claude-code-integration/templates/empirica-system-prompt-lean.md
+++ b/empirica/plugins/claude-code-integration/templates/empirica-system-prompt-lean.md
@@ -249,10 +249,32 @@ observations, which signals a discipline gap to address in future transactions.
 
 ## NOETIC FIREWALL
 
-- **Noetic tools** (Read, Grep, Glob, search): Always allowed
-- **Praxic tools** (Edit, Write, Bash execution): Require PREFLIGHT + CHECK
+**The principle.** *Noetic* work gathers information and mutates nothing — it is
+provably inert, so it flows free (no PREFLIGHT/CHECK). *Praxic* work can change
+state (write a file, run code, mutate a remote), so it requires PREFLIGHT → CHECK.
+The discriminator is not a tool's NAME but its EFFECT: **can this invocation, as
+written, change state?** No → noetic. Yes (or "maybe") → praxic. The Sentinel
+enforces this via PreToolUse hooks and, when unsure, errs toward gating. Use this
+test to reason about a tool you haven't seen before, rather than memorizing a list.
 
-The Sentinel enforces this automatically via PreToolUse hooks.
+- **Always noetic (flow free):**
+  - The dedicated tools — `Read`, `Grep`, `Glob`, `investigate`,
+    `project-search`, `noetic-batch` — are the PRIMARY noetic surface. Prefer them.
+  - Read-only shell is the fallback for specialized recon: file inspection
+    (`cat`/`head`/`tail`/`less`/`wc`/`stat`/`tree`/`file`), search
+    (`grep`/`rg`/`ag`/`find`/`fd`/`ast-grep`), structured data (`jq`/`yq`/`gron`),
+    text pipeline (`cut`/`sort`/`uniq`/`tr`/`nl`/`column`/`comm`/`diff`), binary
+    read (`xxd`/`od`/`strings`), git-read (`git status`/`log`/`diff`/`show`/`blame`/
+    `grep`/`for-each-ref`/`rev-parse`…), `gh` read verbs, read-only analysis
+    (`ruff check`/`pyright`/`radon`/`vulture`/`mypy`), package inspection
+    (`pip show`/`list`), and `sqlite3 db "SELECT…"`/`.schema`/`PRAGMA` (read queries).
+- **Praxic (need CHECK):** `Edit`, `Write`, and any Bash that *can* mutate —
+  `python3 -c` / `node -e` (arbitrary execution), a redirect to a file (`> f`),
+  package installs, `git commit`/`push`, `rm`/`mv`/`cp`, **and the write/exec MODES
+  of otherwise-inert tools**: `find -delete`/`-exec`, `fd -x`, `sort -o`, `yq -i`,
+  `ast-grep --rewrite`, `sed -i`, `awk 'system()'`/`print>"file"`,
+  `sqlite3 "INSERT/UPDATE/DROP…"`. A tool being on the noetic list does NOT make a
+  mutating invocation noetic — the Sentinel inspects the flags, not just the name.
 
 ### Batch Noetic Work
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -30,6 +30,7 @@ from empirica.cli.command_handlers.doctor import (
     check_git_present,
     check_loops_registered,
     check_mcp_config,
+    check_noetic_tools,
     check_ntfy_auth,
     check_ntfy_creds,
     check_ollama_backend,
@@ -73,6 +74,37 @@ def test_check_claude_code_cli_warns_when_missing():
     with patch("empirica.cli.command_handlers.doctor._which", return_value=None):
         result = check_claude_code_cli()
     assert result.status == WARN
+
+
+def test_check_noetic_tools_passes_when_all_present():
+    # Tier-1 tools all on PATH → PASS.
+    with patch("empirica.cli.command_handlers.doctor._which", return_value="/usr/bin/tool"):
+        result = check_noetic_tools()
+    assert result.status == PASS
+    assert len(result.data["present"]) == 5
+
+
+def test_check_noetic_tools_warns_when_some_missing():
+    # Only jq present → WARN (recommended, not required), with an install hint.
+    def _fake_which(cmd):
+        return "/usr/bin/jq" if cmd == "jq" else None
+
+    with patch("empirica.cli.command_handlers.doctor._which", side_effect=_fake_which):
+        result = check_noetic_tools()
+    assert result.status == WARN
+    assert "rg" in result.data["missing"] and "ast-grep" in result.data["missing"]
+    assert "jq" in result.data["present"]
+
+
+def test_check_noetic_tools_fd_fdfind_fallback():
+    # On Debian/Ubuntu fd's binary is `fdfind`; the fallback must count it present.
+    def _fake_which(cmd):
+        return "/usr/bin/fdfind" if cmd == "fdfind" else None
+
+    with patch("empirica.cli.command_handlers.doctor._which", side_effect=_fake_which):
+        result = check_noetic_tools()
+    assert "fd" in result.data["present"]  # resolved via fdfind
+    assert result.data["present"]["fd"] == "/usr/bin/fdfind"
 
 
 # ─── Project state ─────────────────────────────────────────────────────
@@ -392,9 +424,9 @@ def test_run_all_checks_returns_complete_list():
     assert "Outreach project" in names
 
 
-def test_run_all_checks_count_is_23():
-    """Post-prop_ilf6uy4q expansion: 18 base + 5 mesh = 23 total."""
-    assert len(run_all_checks()) == 23
+def test_run_all_checks_count_is_24():
+    """Post-prop_ilf6uy4q expansion: 18 base + 5 mesh = 23, + noetic-tools = 24."""
+    assert len(run_all_checks()) == 24
 
 
 # ─── Tailscale (prop_ilf6uy4q) ─────────────────────────────────────────


### PR DESCRIPTION
## What (T2 + T3 of the noetic-tooling plan, goals `e62a0006` + `a5a6904e`)

Pairs with #185 (the allowlist expansion). Two parts:

### T2 — "what is noetic" made explicit (lean prompt NOETIC FIREWALL)
Replaces the thin two-liner with the **principle**:
> Noetic = provably inert (gathers info, mutates nothing) → flows free. Praxic = *can* change state → needs CHECK. The discriminator is **effect, not name** — "can this invocation, as written, change state?"

Plus enumerated inert categories (dedicated tools primary; read-only shell fallback: search/structured-data/text-pipeline/binary/git-read/analysis/`sqlite3 SELECT`), and an explicit callout that the **write/exec MODES** of otherwise-inert tools (`find -delete`, `yq -i`, `awk system()`, `sqlite3 INSERT`) are praxic — a name on the noetic list doesn't make a mutating invocation noetic.

*(The constitution covers noetic **phases**, not tool classification — the lean prompt is the canonical home, so no forced duplication into the skills.)*

### T3 — `empirica doctor` reports Tier-1 noetic tools
New `check_noetic_tools()`: probes `rg`/`fd`/`jq`/`yq`/`ast-grep`. **PASS** when all present; **WARN** (recommended, not required — with an install hint) when some are missing. `fd`→`fdfind` fallback for Debian/Ubuntu; `ast-grep`'s `sg` alias deliberately not probed (collides with the `setgroups` command). 3 tests + the run-all count test updated (23→24).

## Also in this set
- **G4 (sqlite3 read-only)** closed as **already-shipped** — `is_safe_sqlite_command` already allows `SELECT`/`.schema`/`PRAGMA` and blocks `INSERT`/`DROP`/etc.

Local gate: `ruff check` + `ruff format --check` clean; 59 doctor tests pass; live `check_noetic_tools()` + lean-prompt render verified.

Note: making Tier-1 tools **hard install deps** (vs system-assumed) is left as a follow-up — they're system binaries (cargo/brew/apt), not pip packages, so it's an ecosystem packaging decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)