### PR TITLE
feat(modules): register provisioned module as a <name>@local plugin (Model B)

### DIFF
--- a/empirica/core/modules/executors.py
+++ b/empirica/core/modules/executors.py
@@ -32,6 +32,7 @@ import sys
 import tarfile
 import urllib.error
 import urllib.request
+from datetime import datetime, timezone
 from importlib import metadata
 from pathlib import Path
 
@@ -280,6 +281,76 @@ def _place_plugin_artifact(
         return {"kind": "plugin_files", "target": archive, "status": "error", "detail": str(e)[:300]}
 
 
+def _ensure_plugin_manifest(dest: Path, manifest: ModuleManifest) -> bool:
+    """Ensure ``<dest>/.claude-plugin/plugin.json`` exists so Claude Code
+    recognizes the module as a plugin. Generate a minimal one from the module
+    manifest when the archive didn't ship it. Returns True if a file was written."""
+    pj = dest / ".claude-plugin" / "plugin.json"
+    if pj.exists():
+        return False
+    pj.parent.mkdir(parents=True, exist_ok=True)
+    pj.write_text(
+        json.dumps(
+            {"name": manifest.name, "version": manifest.version, "description": f"{manifest.name} — empirica module"},
+            indent=2,
+        )
+    )
+    return True
+
+
+def _register_plugin(manifest: ModuleManifest, plugin_root: Path | None, dry_run: bool) -> dict:
+    """Register the module as a ``<name>@local`` Claude Code plugin (Model B).
+
+    Writes an entry into ``~/.claude/plugins/installed_plugins.json`` so CC
+    discovers the module's ``skills``/``agents`` from its own plugin dir — clean
+    separation from the empirica plugin, clean uninstall. Idempotent: an existing
+    entry for the same installPath is a no-op. ``.claude-plugin/plugin.json`` is
+    generated from the manifest if the archive didn't include one.
+
+    NOTE: ``hooks`` discovery for local plugins additionally needs a
+    ``~/.claude/settings.json`` entry (Claude Code's local-plugin hook
+    auto-discovery is unreliable) — a separate follow-up. Registration covers
+    skills + agents, the common module shape.
+    """
+    root = plugin_root or CLAUDE_PLUGIN_ROOT
+    dest = root / manifest.name
+    key = f"{manifest.name}@local"
+    registry = root.parent / "installed_plugins.json"
+    if dry_run:
+        # The would-place step (above) hasn't extracted yet, so dest may not
+        # exist — report the plan, not not_placed.
+        return {"kind": "plugin_register", "target": key, "status": "would_register", "detail": str(registry)}
+    if not dest.exists():
+        return {"kind": "plugin_register", "target": key, "status": "not_placed", "detail": "no placed plugin dir"}
+    try:
+        data: dict = json.loads(registry.read_text()) if registry.exists() else {"version": 2, "plugins": {}}
+        plugins = data.setdefault("plugins", {})
+        if any(e.get("installPath") == str(dest) for e in plugins.get(key, [])):
+            return {"kind": "plugin_register", "target": key, "status": "skipped", "detail": "already registered"}
+        generated = _ensure_plugin_manifest(dest, manifest)
+        now = datetime.now(timezone.utc).isoformat()
+        plugins[key] = [
+            {
+                "scope": "user",
+                "installPath": str(dest),
+                "version": manifest.version,
+                "installedAt": now,
+                "lastUpdated": now,
+                "isLocal": True,
+            }
+        ]
+        registry.parent.mkdir(parents=True, exist_ok=True)
+        registry.write_text(json.dumps(data, indent=2))
+        return {
+            "kind": "plugin_register",
+            "target": key,
+            "status": "registered",
+            "detail": "registered" + ("; generated plugin.json" if generated else ""),
+        }
+    except (OSError, json.JSONDecodeError) as e:
+        return {"kind": "plugin_register", "target": key, "status": "error", "detail": str(e)[:300]}
+
+
 def _register_automation(auto, dry_run: bool) -> dict:
     """Register one automation via the canonical ``empirica loop register`` (idempotent)."""
     kind = _AUTOMATION_KIND_MAP.get(auto.kind, auto.kind)
@@ -429,6 +500,10 @@ def provision_module(
             cortex_api_key = cortex_api_key or cfg.get("api_key")
 
     steps: list[dict] = [_place_plugin_artifact(manifest, staging_root, plugin_root, dry_run)]
+    if manifest.artifacts.plugin_archive:
+        # Model B: register the placed dir as a <name>@local plugin so CC
+        # discovers its skills/agents (clean separation, not folded into empirica).
+        steps.append(_register_plugin(manifest, plugin_root, dry_run))
     steps += [_register_automation(a, dry_run) for a in manifest.provides.automations]
     steps += _grant_topics(manifest, cortex_url, cortex_api_key, org, tenant, dry_run)
     steps += _check_env(manifest)

--- a/tests/test_module_provision.py
+++ b/tests/test_module_provision.py
@@ -92,6 +92,74 @@ def test_placement_idempotent_skip(tmp_path):
     assert receipt["steps"][0]["status"] == "skipped"
 
 
+# ── plugin registration — Model B (installed_plugins.json) ──────────────
+
+
+def test_register_plugin_writes_entry(tmp_path):
+    staging = _staged_tar(tmp_path)
+    m = _manifest(tmp_path, plugin_archive="outreach-0.4.0-plugin.tar.gz")
+    plugins = tmp_path / "plugins"
+    receipt = provision_module(m, dry_run=False, plugin_root=plugins, staging_root=staging)
+    reg_step = next(s for s in receipt["steps"] if s["kind"] == "plugin_register")
+    assert reg_step["status"] == "registered"
+    registry = json.loads((tmp_path / "installed_plugins.json").read_text())
+    entry = registry["plugins"]["outreach@local"][0]
+    assert entry["installPath"] == str(plugins / "outreach")
+    assert entry["version"] == "0.4.0" and entry["isLocal"] is True
+
+
+def test_register_plugin_generates_plugin_json(tmp_path):
+    staging = _staged_tar(tmp_path)
+    m = _manifest(tmp_path, plugin_archive="outreach-0.4.0-plugin.tar.gz")
+    plugins = tmp_path / "plugins"
+    provision_module(m, dry_run=False, plugin_root=plugins, staging_root=staging)
+    pj = plugins / "outreach" / ".claude-plugin" / "plugin.json"
+    assert pj.exists()
+    data = json.loads(pj.read_text())
+    assert data["name"] == "outreach" and data["version"] == "0.4.0"
+
+
+def test_register_plugin_idempotent(tmp_path):
+    staging = _staged_tar(tmp_path)
+    m = _manifest(tmp_path, plugin_archive="outreach-0.4.0-plugin.tar.gz")
+    plugins = tmp_path / "plugins"
+    provision_module(m, dry_run=False, plugin_root=plugins, staging_root=staging)
+    receipt = provision_module(m, dry_run=False, plugin_root=plugins, staging_root=staging)
+    reg_step = next(s for s in receipt["steps"] if s["kind"] == "plugin_register")
+    assert reg_step["status"] == "skipped"
+
+
+def test_register_plugin_dry_run_no_write(tmp_path):
+    staging = _staged_tar(tmp_path)
+    m = _manifest(tmp_path, plugin_archive="outreach-0.4.0-plugin.tar.gz")
+    plugins = tmp_path / "plugins"
+    receipt = provision_module(m, dry_run=True, plugin_root=plugins, staging_root=staging)
+    reg_step = next(s for s in receipt["steps"] if s["kind"] == "plugin_register")
+    assert reg_step["status"] == "would_register"
+    assert not (tmp_path / "installed_plugins.json").exists()
+
+
+def test_no_archive_no_register_step(tmp_path):
+    m = _manifest(tmp_path)  # no plugin_archive → competence layer absent
+    receipt = provision_module(m, dry_run=False, plugin_root=tmp_path / "plugins", staging_root=tmp_path / "s")
+    assert not any(s["kind"] == "plugin_register" for s in receipt["steps"])
+
+
+def test_register_plugin_preserves_existing_entries(tmp_path):
+    registry = tmp_path / "installed_plugins.json"
+    registry.write_text(
+        json.dumps(
+            {"version": 2, "plugins": {"empirica@local": [{"installPath": "/x", "version": "1.0", "isLocal": True}]}}
+        )
+    )
+    staging = _staged_tar(tmp_path)
+    m = _manifest(tmp_path, plugin_archive="outreach-0.4.0-plugin.tar.gz")
+    provision_module(m, dry_run=False, plugin_root=tmp_path / "plugins", staging_root=staging)
+    data = json.loads(registry.read_text())
+    assert "empirica@local" in data["plugins"]  # preserved
+    assert "outreach@local" in data["plugins"]  # added
+
+
 # ── automation registration (loop register, mocked) ─────────────────────
 
 


### PR DESCRIPTION
## What

`provision_module` placed a module's files at `~/.claude/plugins/local/<name>/` but **never registered it**, so Claude Code didn't discover the module's `skills`/`agents` — only the empirica plugin's own dirs were scanned. (Gap 1 from outreach's productization brief; goal `5c919950`.)

## Model decision (David, 2026-06-29)

**Model B — register the module as its own plugin** (the way every other plugin loads — `empirica@local`, `pyright-lsp@...`, etc.), chosen over Model A (folding the module's skill/agent files into the empirica plugin's dirs). B gives clean separation + clean uninstall and matches the plugin architecture, vs A's file duplication + muddied empirica namespace.

## How

- **`_register_plugin`** writes a `<name>@local` entry into `~/.claude/plugins/installed_plugins.json` (idempotent on `installPath`; preserves existing entries). This is what makes CC scan the module's own `skills/`/`agents/` dirs — verified by the fact that `empirica@local` loads its skills exactly this way.
- **`_ensure_plugin_manifest`** generates `.claude-plugin/plugin.json` from the module manifest when the archive didn't ship one (CC needs it to recognize a plugin dir).
- Wired into `provision_module`, **gated on `artifacts.plugin_archive`** (no competence layer → no registration). Dry-run reports `would_register` without writing.

## Scope / follow-up

Covers **skills + agents** — the common module shape (outreach ships 1 skill + 3 agents, no hooks). `hooks` discovery for *local* plugins additionally needs a `~/.claude/settings.json` entry (CC's local-plugin hook auto-discovery is unreliable — captured dead-end); noted in the function docstring as a separate follow-up, not in scope here.

## Tests

6 new unit tests: registry-entry write, plugin.json generation, idempotency, dry-run no-write, no-archive→no-registration, existing-entries preserved. Full module suite green (provision + fetch + manifest, 57 randomized), ruff + format + pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)