### PR TITLE
docs(project-search): honest-scope --global (local fallback, not cross-practice)

### DIFF
--- a/docs/reference/api/CROSS_PROJECT.md
+++ b/docs/reference/api/CROSS_PROJECT.md
@@ -39,7 +39,7 @@ Empirica is multi-project by design. Three mechanisms compose:
 | Mechanism | Direction | Use |
 |---|---|---|
 | `--visibility {public,shared,local}` on `*-log` commands | Push (opt-in) | Mark an artifact as shareable when logged |
-| `project-search --global` | Pull | Query the global-learnings pool across projects |
+| `project-search --global` | Pull | Local cross-project recall (global-learnings pool + other local projects, semantic). Cross-practice/mesh retrieval is `cortex investigate`. |
 | `--project-id <name>` on `*-log` commands | Cross-write | Log artifacts to OTHER projects without `project-switch` |
 
 The default workflow: **AIs log liberally with `--visibility shared` when an artifact
@@ -107,18 +107,33 @@ empirica project-search --project-id empirica --task "sentinel bypass" --global
 
 ### How It Works
 
-`--global` queries the `global_learnings` Qdrant collection — high-impact
-artifacts that have been promoted via the visibility flag (or fed in via
-older sync paths).
+`--global` runs two retrieval paths and merges the results:
 
-**Caveat (v1.9.6 state):** the original 1.7.0 design described a "cross-
-project scan" that iterates ALL `project_{id}_{collection}` collections.
-That broader walk is implemented in `search_cross_project` (`empirica.core.qdrant.global_sync`)
-but the `--global` CLI flag currently only hits `global_learnings`. True
-cross-project semantic search across every registered project's full memory/
-eidetic/episodic surface is a logged goal — until it lands, the practical
-guidance is: log liberally with `--visibility shared` so your artifacts
-reach `global_learnings`, and call `--global` proactively to read it back.
+1. **`search_global`** → the `global_learnings` Qdrant collection: high-impact
+   artifacts promoted via `--visibility shared/public` (or older sync paths).
+   The curated cross-project pool.
+2. **`search_cross_project`** (`empirica.core.qdrant.global_sync`) → every
+   **local** project's `memory` / `eidetic` / `episodic` collections, discovered
+   from this machine's Qdrant collection names; semantic top-k per collection,
+   de-duplicated and ranked.
+
+**Scope and limits — be honest about reach:**
+
+- **Local Qdrant only.** Both paths read the Qdrant instance on *this machine*.
+  Projects on other practitioners' machines — the actual mesh — are not visible.
+  `--global` is cross-*project-on-this-box*, **not** cross-*practice-across-the-mesh*.
+- **Semantic only.** Pure cosine top-k; it does not traverse `artifact_edges`
+  (`related_to`). "Related" here means *similar*, not *graph-connected*.
+- **The true cross-practice surface is the mesh.** With Cortex connected,
+  `cortex investigate` / `search_knowledge` retrieve across the tenant's
+  practices server-side — that is the cross-practice retrieval path. Per the
+  ecosystem lane split (Cortex / mesh-support own the Qdrant + glue layer),
+  cross-practice traversal lives there. `project-search --global` is the
+  local-only fallback — and the only cross-project option for Cortex-less installs.
+
+Practical guidance: log liberally with `--visibility shared` so high-value
+artifacts reach `global_learnings`; use `--global` for local cross-project
+recall; reach for `cortex investigate` when you need the whole mesh.
 
 ### API
 

--- a/empirica/cli/command_handlers/project_search.py
+++ b/empirica/cli/command_handlers/project_search.py
@@ -1,6 +1,12 @@
 """
-Project Search Commands - semantic search over docs & memory (Qdrant-backed)
-Path A: command scaffolding; embedding/provider assumed available via env.
+Project Search Commands — semantic search over a project's docs & memory (Qdrant-backed).
+
+Local single-project search by default. With ``--global`` it ALSO pulls the
+``global_learnings`` pool + every other LOCAL project's memory/eidetic/episodic
+collections (semantic top-k, this-machine Qdrant only) — a local cross-project
+fallback, NOT a cross-practice/mesh search. True cross-practice retrieval across
+the tenant's practices is Cortex's ``investigate`` / ``search_knowledge`` (the
+Qdrant + glue layer is Cortex/mesh-support's lane).
 """
 
 from __future__ import annotations

--- a/empirica/cli/parsers/checkpoint_parsers.py
+++ b/empirica/cli/parsers/checkpoint_parsers.py
@@ -861,7 +861,11 @@ def add_checkpoint_parsers(subparsers):
     project_search_parser.add_argument("--output", choices=["human", "json"], default="human", help="Output format")
     project_search_parser.add_argument("--verbose", action="store_true", help="Show detailed operation info")
     project_search_parser.add_argument(
-        "--global", dest="global_search", action="store_true", help="Include global cross-project learnings in search"
+        "--global",
+        dest="global_search",
+        action="store_true",
+        help="Also search the global-learnings pool + other LOCAL projects (semantic, this machine). "
+        "Cross-practice/mesh search is `cortex investigate`.",
     )
 
     # Project embed (build vectors) command


### PR DESCRIPTION
## What

David flagged that cross-project search needed checking — does `--global` actually find related artifacts, should it be "cross-practice", is it superseded by the mesh. The investigation found the **docs are stale**, not the code.

`CROSS_PROJECT.md` claimed `--global` *"currently only hits `global_learnings`"* and called the broader per-project walk a pending goal. But `project_search.py` **already calls both** `search_global` **and** `search_cross_project` (the broader walk shipped). So the doc undersells what it does — while *over*-implying cross-practice reach it doesn't have.

## The accurate behavior (now documented)

`--global` runs two paths, merged:
- `search_global` → the `global_learnings` promoted pool
- `search_cross_project` → every **local** project's `memory`/`eidetic`/`episodic` collections (semantic top-k, dedup, rank)

…with honest limits:
- **Local Qdrant only** — this machine's projects, not the mesh. It's cross-*project-on-this-box*, not cross-*practice*.
- **Semantic only** — no `artifact_edges`/`related_to` traversal; "related" = similar, not graph-connected.
- **True cross-practice retrieval is the mesh** (`cortex investigate`/`search_knowledge`). Per the ratified ecosystem lane split (Cortex/mesh-support own the Qdrant + glue layer), cross-practice traversal lives there; `--global` is the local fallback (and the only option for Cortex-less installs).

## Decision captured (no rename)

Keeping the name `--global` / "cross-project" — renaming to "cross-practice" would **overclaim** (it doesn't span the mesh). The genuine cross-practice surface is the mesh.

## Changes

- `CROSS_PROJECT.md` — corrected "How It Works" + the mechanism table row.
- `project_search.py` — module docstring (was the stale "Path A: command scaffolding").
- `--global` CLI help text — accurate scope.

No logic change — accuracy/scoping only. ruff + format + pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)