### PR TITLE
perf(bootstrap): budget the global-learnings context injection (#187 follow-up)

### DIFF
--- a/docs/reference/ENVIRONMENT_VARIABLES.md
+++ b/docs/reference/ENVIRONMENT_VARIABLES.md
@@ -89,6 +89,12 @@ The full context stays retrievable on demand via `empirica investigate` /
 `empirica project-search` / `empirica commit-context` — the injected block is a
 ranked teaser, not the whole store.
 
+`EMPIRICA_PATTERN_MAX_ITEM_CHARS` and `EMPIRICA_PATTERN_BUDGET_OFF` additionally
+govern the **global-learnings** (cross-project) block that `project-bootstrap`
+injects every session — a distinct block from the pattern block above, but
+truncated per-item by the same knobs (and capped at 5 items). `BUDGET_OFF=1`
+restores its full untrimmed text too.
+
 ---
 
 ## Paths & Directories

--- a/empirica/cli/command_handlers/project_bootstrap.py
+++ b/empirica/cli/command_handlers/project_bootstrap.py
@@ -318,16 +318,32 @@ def _query_global_learnings(task_description):
     """Query global learnings for cross-project context from Qdrant.
 
     Returns global_learnings dict or None.
+
+    This injection runs at EVERY bootstrap, so per-item text is truncated to a
+    context budget (``EMPIRICA_PATTERN_MAX_ITEM_CHARS``, default 280) to keep
+    the session-start context lean — the same budget #187 applied to pattern
+    retrieval. Set ``EMPIRICA_PATTERN_BUDGET_OFF=1`` for the full untrimmed
+    text. (The 5-item count cap is already enforced by ``limit=5``.)
     """
     try:
+        import os
+
         from empirica.core.qdrant.vector_store import search_global
 
         global_results = search_global(task_description, limit=5)
-        if global_results:
-            return {"query": task_description, "results": global_results, "count": len(global_results)}
+        if not global_results:
+            return None
+        if os.getenv("EMPIRICA_PATTERN_BUDGET_OFF") != "1":
+            from empirica.core.context_budget import truncate_text
+
+            max_chars = int(os.getenv("EMPIRICA_PATTERN_MAX_ITEM_CHARS", "280"))
+            for item in global_results:
+                if isinstance(item, dict) and isinstance(item.get("text"), str):
+                    item["text"] = truncate_text(item["text"], max_chars)
+        return {"query": task_description, "results": global_results, "count": len(global_results)}
     except Exception as e:
         logger.debug(f"Global learnings query failed (non-fatal): {e}")
-    return None
+        return None
 
 
 def _reinstall_auto_capture_hooks(session_id):

--- a/empirica/core/context_budget.py
+++ b/empirica/core/context_budget.py
@@ -821,6 +821,22 @@ def estimate_tokens(text: str) -> int:
     return max(1, len(text) // 4)
 
 
+def truncate_text(text: str, max_chars: int) -> str:
+    """Truncate ``text`` to ``max_chars`` at a word boundary, appending an
+    overflow marker.
+
+    Non-strings and already-short strings pass through unchanged. This is the
+    single source of truth for display-string truncation at context-injection
+    sites (pattern retrieval, bootstrap global-learnings) — keeping one
+    algorithm avoids the two-sources-of-truth drift that a per-site copy
+    invites.
+    """
+    if not isinstance(text, str) or len(text) <= max_chars:
+        return text
+    head = text[:max_chars].rsplit(" ", 1)[0].rstrip()
+    return f"{head}… (+{len(text) - len(head)} chars)"
+
+
 # --- Threshold Loading ---
 
 

--- a/empirica/core/qdrant/pattern_retrieval.py
+++ b/empirica/core/qdrant/pattern_retrieval.py
@@ -536,11 +536,14 @@ def _content_sig(text: str) -> str:
 
 
 def _truncate_text(text: str, max_chars: int) -> str:
-    """Truncate to max_chars at a word boundary, appending an overflow marker."""
-    if not isinstance(text, str) or len(text) <= max_chars:
-        return text
-    head = text[:max_chars].rsplit(" ", 1)[0].rstrip()
-    return f"{head}… (+{len(text) - len(head)} chars)"
+    """Truncate to max_chars at a word boundary, appending an overflow marker.
+
+    Delegates to the shared ``context_budget.truncate_text`` — single source
+    of truth for display-string truncation across context-injection sites.
+    """
+    from empirica.core.context_budget import truncate_text
+
+    return truncate_text(text, max_chars)
 
 
 def _item_sections(result: dict):

--- a/tests/test_bootstrap_global_budget.py
+++ b/tests/test_bootstrap_global_budget.py
@@ -1,0 +1,84 @@
+"""Tests for the context budget on the bootstrap global-learnings injection.
+
+`_query_global_learnings` runs at EVERY project-bootstrap and injects up to 5
+cross-project results into the AI's session-start context. #187 budgeted the
+pattern-retrieval injection but missed this sibling site; these tests cover the
+follow-up trim — per-item text truncation via the shared
+``context_budget.truncate_text`` (single source of truth, same EMPIRICA_PATTERN_*
+knobs + escape hatch as #187).
+"""
+
+from __future__ import annotations
+
+from empirica.cli.command_handlers import project_bootstrap as pb
+from empirica.core import context_budget as cb
+from empirica.core.qdrant import vector_store
+
+# --- shared truncate_text (single source of truth) -------------------------
+
+
+def test_truncate_text_passes_short_through():
+    assert cb.truncate_text("short", 280) == "short"
+
+
+def test_truncate_text_truncates_long_at_word_boundary_with_marker():
+    text = "word " * 200  # 1000 chars
+    out = cb.truncate_text(text, 50)
+    assert len(out) < len(text)
+    assert out.endswith("chars)")
+    assert "…" in out
+    assert " …" not in out  # head rstripped — no dangling space before the marker
+
+
+def test_truncate_text_nonstring_passthrough():
+    assert cb.truncate_text(None, 280) is None  # type: ignore[arg-type]
+    assert cb.truncate_text(12345, 280) == 12345  # type: ignore[arg-type]
+
+
+# --- bootstrap injection budgeting -----------------------------------------
+
+
+def _patch_search(monkeypatch, results):
+    def fake_search_global(*_args, **_kwargs):
+        return results
+
+    monkeypatch.setattr(vector_store, "search_global", fake_search_global)
+
+
+def test_query_global_learnings_truncates_item_text(monkeypatch):
+    monkeypatch.delenv("EMPIRICA_PATTERN_BUDGET_OFF", raising=False)
+    monkeypatch.setenv("EMPIRICA_PATTERN_MAX_ITEM_CHARS", "40")
+    long_text = "alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu"
+    _patch_search(monkeypatch, [{"text": long_text, "score": 0.9}])
+
+    out = pb._query_global_learnings("some task")
+
+    assert out is not None
+    item = out["results"][0]
+    assert len(item["text"]) < len(long_text)
+    assert item["text"].endswith("chars)")
+
+
+def test_query_global_learnings_budget_off_keeps_full_text(monkeypatch):
+    monkeypatch.setenv("EMPIRICA_PATTERN_BUDGET_OFF", "1")
+    monkeypatch.setenv("EMPIRICA_PATTERN_MAX_ITEM_CHARS", "40")
+    long_text = "alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu"
+    _patch_search(monkeypatch, [{"text": long_text, "score": 0.9}])
+
+    out = pb._query_global_learnings("some task")
+
+    assert out is not None
+    assert out["results"][0]["text"] == long_text  # untrimmed
+
+
+def test_query_global_learnings_none_when_empty(monkeypatch):
+    _patch_search(monkeypatch, [])
+    assert pb._query_global_learnings("some task") is None
+
+
+def test_query_global_learnings_tolerates_missing_text_field(monkeypatch):
+    monkeypatch.delenv("EMPIRICA_PATTERN_BUDGET_OFF", raising=False)
+    _patch_search(monkeypatch, [{"score": 0.9}, {"text": "ok", "score": 0.8}])
+    out = pb._query_global_learnings("some task")
+    assert out is not None
+    assert out["count"] == 2


### PR DESCRIPTION
## What

`project-bootstrap`'s `_query_global_learnings` injected **up to 5 full-text** cross-project results into session-start context **every bootstrap**, with no budget. That's the same context-bloat class #187 fixed for pattern retrieval — at a sibling injection site #187 missed.

## How

- **Single-source** the truncation algorithm as a public `context_budget.truncate_text` (word-boundary cut + overflow marker), so the two injection sites can't drift apart (the two-sources-of-truth anti-pattern).
- `pattern_retrieval._truncate_text` now **delegates** to it — behavior identical, #187's tests unchanged.
- `_query_global_learnings` truncates each item's `text` via the **same** `EMPIRICA_PATTERN_MAX_ITEM_CHARS` (default 280) knob and honors the `EMPIRICA_PATTERN_BUDGET_OFF=1` escape hatch. The 5-item count cap is already enforced by `limit=5`.
- Env-var doc updated to note these knobs also govern the bootstrap global-learnings block.
- New test: `tests/test_bootstrap_global_budget.py` (7 cases: shared helper + bootstrap budgeting + escape hatch + edge cases).

## Why not just delete the local path?

The local `global_learnings` pipeline is **LIVE**, not dead — auto-written at POSTFLIGHT (`auto_sync_session_to_global`), read at every bootstrap (`search_global`), and it's the deliberate **cortex-less cross-project fallback** per #190. This trims its *context footprint*, not the capability. (The mesh supersedes it only for cross-*practice* retrieval, and only when Cortex is connected — and `cortex investigate` is pull-only, so it doesn't fill the at-bootstrap push slot.)

## Verification

- `tests/test_bootstrap_global_budget.py` + `tests/test_pattern_context_budget.py` + 3 bootstrap suites: **64 passed**
- ruff check + ruff format --check: clean
- pyright (3 source files + test): 0 errors / 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)