### PR TITLE
fix(cockpit): multiplexer-agnostic liveness via process scan + count-aware dedup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to Empirica will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **Multiplexer-agnostic cockpit liveness** — `status` / `status --all` and the
+  cockpit TUI no longer under-report instances running Claude under a non-tmux
+  multiplexer (GNU screen, WezTerm, zellij, cmux), or after `claude --resume` /
+  an env-unset manual restart that left a stale captured PID. Liveness now
+  consults a direct process-table scan: the primary signal matches each live
+  `claude` process to its instance by `EMPIRICA_INSTANCE_ID` (exact and
+  resume-proof — it survives PID changes and is independent of any multiplexer),
+  with a coarser working-directory match as a fallback for processes that carry
+  no instance-id env. Both override a stale captured PID and are alive-positive
+  only (never a new dead verdict). A count-aware dedup caps how many same-project
+  instances the cwd fallback can revive at the number of live processes, so
+  duplicate stale sessions don't inflate the count, and `instance prune` honors
+  the same signals so it won't offer to kill a Claude that's alive under a
+  non-tmux multiplexer.
+
 ## [1.12.8] — 2026-06-29
 
 A context-hygiene + module-install patch: the PREFLIGHT/CHECK/bootstrap pattern block is now budgeted lean-by-default, and `module provision` completes the competence layer (skill/agent discovery) for installed modules.

--- a/empirica/core/cockpit/instance_state.py
+++ b/empirica/core/cockpit/instance_state.py
@@ -1,6 +1,11 @@
 """Instance discovery + state aggregation for the cockpit `status` command.
 
-Discovery is via state-file scan only — no tmux, no /proc, no process scanning.
+Discovery (which instances exist) is via state-file scan only — no tmux, no
+/proc. LIVENESS (whether an instance's Claude is still running) is a separate
+concern handled by `liveness.is_alive`, which additionally consults a
+multiplexer-agnostic process scan (`liveness.scan_live_claude`) so non-tmux
+multiplexers and `claude --resume` / env-unset restarts aren't under-reported.
+
 An instance is anything that has left a footprint in ~/.empirica/:
 
   - instance_projects/{instance_id}.json  (canonical: instance → project map)
@@ -23,6 +28,7 @@ Phase model (file-derived, no DB):
 from __future__ import annotations
 
 import json
+import os
 import re
 from datetime import datetime, timezone
 from pathlib import Path
@@ -38,7 +44,7 @@ from empirica.core.cockpit.listener_registry import (
     ListenerRegistry,
     is_listener_paused,
 )
-from empirica.core.cockpit.liveness import _live_tmux_panes, is_alive
+from empirica.core.cockpit.liveness import _live_tmux_panes, is_alive, scan_live_claude
 from empirica.core.cockpit.loop_registry import LoopRegistry, is_loop_paused
 from empirica.core.cockpit.notify_dispatcher_view import (
     annotate_loops_with_last_notify,
@@ -431,6 +437,8 @@ def aggregate_instance_state(
     instance_id: str,
     live_panes: set[str] | None = None,
     current_instance_id: str | None = None,
+    live_claude_instance_ids: set[str] | None = None,
+    live_claude_cwds: set[str] | None = None,
 ) -> dict[str, Any]:
     """Read all state for one instance and return a serializable dict.
 
@@ -439,7 +447,10 @@ def aggregate_instance_state(
 
     `live_panes` is an optional pre-computed set of live tmux pane numbers
     (sweep optimization). `current_instance_id` exempts the running cockpit
-    from liveness checks (it's alive by definition).
+    from liveness checks (it's alive by definition). `live_claude_instance_ids`
+    (EMPIRICA_INSTANCE_ID env per live proc) is the exact, resume-proof
+    liveness signal; `live_claude_cwds` is the coarse cwd fallback. Pass None
+    to skip either.
     """
     project_path = _instance_project_path(instance_id)
     label = _instance_label(instance_id, project_path)
@@ -465,6 +476,9 @@ def aggregate_instance_state(
         last_activity_seconds=tx_state["last_activity_seconds"],
         live_panes=live_panes,
         current_instance_id=current_instance_id,
+        project_path=project_path,
+        live_claude_instance_ids=live_claude_instance_ids,
+        live_claude_cwds=live_claude_cwds,
     )
 
     state = _derive_state_symbol(tx_state, instance_mtime, alive=liveness.alive)
@@ -544,6 +558,7 @@ def aggregate_instance_state(
         "last_activity_seconds": tx_state["last_activity_seconds"],
         "alive": liveness.alive,
         "liveness_reason": liveness.reason,
+        "liveness_signal": liveness.signal,
         "sentinel": {
             "paused": sentinel.paused,
             "scope": sentinel.scope,
@@ -566,6 +581,50 @@ def aggregate_instance_state(
     }
 
 
+def _dedup_process_scan_overcount(instances: list[dict[str, Any]], live_cwd_counts: dict[str, int]) -> None:
+    """Demote surplus process_cwd-revived instances in place.
+
+    The cwd FALLBACK liveness signal keys on project cwd, so every stale
+    instance file for a project whose cwd hosts a live claude process flips
+    alive — over-counting when there are more stale files than live procs
+    (the duplicate-session incident). For each project keep at most
+    (live procs − instances already alive via a stronger, process-bearing
+    signal) instances alive via process_cwd, preferring the most-recently
+    active; demote the rest back to dead. Touches process_cwd instances
+    only — never demotes a current/tmux/process_env/pid/recent_activity verdict.
+
+    The exact env match (process_env) is instance-level and counts as strong:
+    it consumes a live-proc slot but is itself never demoted here.
+    """
+    strong = {"current", "tmux", "process_env", "pid"}  # each = a real process
+
+    by_project: dict[str, list[dict[str, Any]]] = {}
+    for inst in instances:
+        if not inst.get("alive"):
+            continue
+        pp = inst.get("project_path")
+        if not pp:
+            continue
+        by_project.setdefault(os.path.realpath(pp), []).append(inst)
+
+    for rp, insts in by_project.items():
+        scanned = [i for i in insts if i.get("liveness_signal") == "process_cwd"]
+        if not scanned:
+            continue
+        strong_count = sum(1 for i in insts if i.get("liveness_signal") in strong)
+        budget = max(0, live_cwd_counts.get(rp, 0) - strong_count)
+        if len(scanned) <= budget:
+            continue
+        # Most-recently-active first (smallest last_activity_seconds); None last.
+        scanned.sort(
+            key=lambda i: i.get("last_activity_seconds") if i.get("last_activity_seconds") is not None else float("inf")
+        )
+        for surplus in scanned[budget:]:
+            surplus["alive"] = False
+            surplus["liveness_signal"] = ""
+            surplus["liveness_reason"] = "duplicate stale session — no distinct live claude process"
+
+
 def aggregate_all(include_dead: bool = False) -> dict[str, Any]:
     """Scan and aggregate every discoverable instance.
 
@@ -576,6 +635,13 @@ def aggregate_all(include_dead: bool = False) -> dict[str, Any]:
     """
     # Pre-compute the live tmux pane set once, share across instances.
     live_panes = _live_tmux_panes()
+
+    # Walk the process table once for live claude sessions. instance_ids
+    # (EMPIRICA_INSTANCE_ID env) is the exact, resume-proof primary signal;
+    # cwd_counts is the coarse fallback + feeds the count-aware dedup.
+    scan = scan_live_claude()
+    live_iids = scan.instance_ids if scan else None
+    live_cwds = set(scan.cwd_counts) if scan else None
 
     # Resolve the current instance lazily — exempts the running cockpit
     # from liveness checks (it's alive by definition, even if PID/PPID
@@ -592,9 +658,18 @@ def aggregate_all(include_dead: bool = False) -> dict[str, Any]:
             i,
             live_panes=live_panes,
             current_instance_id=current_id,
+            live_claude_instance_ids=live_iids,
+            live_claude_cwds=live_cwds,
         )
         for i in discover_instances()
     ]
+
+    # Count-aware dedup: the cwd FALLBACK signal is project-level, so several
+    # stale instance files for one project would all flip alive. Cap the
+    # process_cwd-revived instances per project at the live-proc count. The
+    # exact env-match (process_env) is instance-level and needs no dedup.
+    if scan:
+        _dedup_process_scan_overcount(instances, scan.cwd_counts)
 
     if not include_dead:
         instances = [i for i in instances if i.get("alive")]
@@ -641,6 +716,12 @@ def discover_dead_instances() -> list[str]:
     instance even if it lacks PID capture (it's running this code).
     """
     live_panes = _live_tmux_panes()
+    # Same multiplexer-agnostic signals the cockpit uses — so `prune` never
+    # offers to kill a Claude that's alive under a non-tmux multiplexer or
+    # whose captured PID went stale across a manual restart.
+    scan = scan_live_claude()
+    live_iids = scan.instance_ids if scan else None
+    live_cwds = set(scan.cwd_counts) if scan else None
     try:
         from empirica.utils.session_resolver import get_instance_id
 
@@ -663,6 +744,9 @@ def discover_dead_instances() -> list[str]:
             last_activity_seconds=last_activity,
             live_panes=live_panes,
             current_instance_id=current_id,
+            project_path=project_path,
+            live_claude_instance_ids=live_iids,
+            live_claude_cwds=live_cwds,
         )
         if not liveness.alive:
             dead.append(iid)

--- a/empirica/core/cockpit/liveness.py
+++ b/empirica/core/cockpit/liveness.py
@@ -31,6 +31,7 @@ import shutil
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
+from typing import NamedTuple
 
 EMPIRICA_DIR = Path.home() / ".empirica"
 TTY_SESSIONS_DIR = EMPIRICA_DIR / "tty_sessions"
@@ -49,6 +50,10 @@ class LivenessResult:
     reason: str
     pid_checked: int | None = None
     tmux_pane: str | None = None
+    # Which signal produced the verdict — for programmatic consumers
+    # (e.g. aggregate_all's count-aware dedup). One of:
+    # "current" | "tmux" | "process_scan" | "pid" | "recent_activity" | "".
+    signal: str = ""
 
 
 # Commands tmux reports as the foreground process when Claude Code is running.
@@ -123,6 +128,84 @@ def _process_alive(pid: int) -> bool:
         return False
 
 
+def _is_claude_proc(name: str | None, cmdline: list[str] | None) -> bool:
+    """Heuristic: is this process a Claude Code session?
+
+    The CC binary reports as ``claude``; older/dev installs run via ``node``
+    with the claude entrypoint in argv. We require the ``claude`` token in
+    the cmdline for the node case to avoid sweeping in unrelated node apps.
+    """
+    nm = (name or "").lower()
+    if nm == "claude":
+        return True
+    if nm in _CLAUDE_COMMANDS:  # node — confirm it's actually claude
+        return any("claude" in (arg or "").lower() for arg in (cmdline or []))
+    return False
+
+
+class LiveClaudeScan(NamedTuple):
+    """Result of one process-table walk for live Claude sessions.
+
+    ``instance_ids`` — the ``EMPIRICA_INSTANCE_ID`` env of every live claude
+    process that declares one. EXACT and resume-proof: it maps a record to its
+    live process regardless of pid changes (``claude --resume`` mints a new pid
+    the record never learned) or which multiplexer draws the pane. This is the
+    PRIMARY liveness signal.
+
+    ``cwd_counts`` — realpath cwd → live-proc count. A coarser, project-level
+    FALLBACK for the rare live proc that carries no ``EMPIRICA_INSTANCE_ID``
+    (legacy launch). It can't tell which same-project record maps to which proc,
+    so aggregate_all count-caps how many records it may revive.
+    """
+
+    instance_ids: set[str]
+    cwd_counts: dict[str, int]
+
+
+def scan_live_claude() -> LiveClaudeScan | None:
+    """Walk the process table once for live ``claude`` sessions.
+
+    MULTIPLEXER-AGNOSTIC and STATE-INDEPENDENT: sees Claude regardless of
+    tmux/screen/WezTerm/zellij/cmux or whether ``session-init`` captured a PID.
+    Returns ``None`` if psutil is unavailable or the whole walk fails — an
+    inconclusive signal, never a dead verdict. Per-process access failures are
+    skipped, not fatal to the sweep.
+    """
+    try:
+        import psutil
+    except ImportError:
+        return None
+
+    instance_ids: set[str] = set()
+    cwd_counts: dict[str, int] = {}
+    try:
+        for proc in psutil.process_iter(["name", "cmdline"]):
+            try:
+                info = proc.info
+                if not _is_claude_proc(info.get("name"), info.get("cmdline")):
+                    continue
+            except (psutil.Error, OSError):
+                continue
+            # Primary: EMPIRICA_INSTANCE_ID env — exact, resume-proof.
+            try:
+                iid = proc.environ().get("EMPIRICA_INSTANCE_ID")
+            except (psutil.Error, OSError):
+                iid = None
+            if iid:
+                instance_ids.add(iid)
+            # Fallback: cwd — coarse project-level attribution.
+            try:
+                cwd = proc.cwd()
+            except (psutil.Error, OSError):
+                cwd = None
+            if cwd:
+                rp = os.path.realpath(cwd)
+                cwd_counts[rp] = cwd_counts.get(rp, 0) + 1
+    except Exception:
+        return None
+    return LiveClaudeScan(instance_ids=instance_ids, cwd_counts=cwd_counts)
+
+
 def _read_captured_pids(instance_id: str) -> tuple[int | None, int | None]:
     """Return (pid, ppid) captured at session-init time, or (None, None)."""
     inst_file = EMPIRICA_DIR / "instance_projects" / f"{instance_id}.json"
@@ -160,6 +243,10 @@ def is_alive(
     last_activity_seconds: float | None = None,
     live_panes: set[str] | None = None,
     current_instance_id: str | None = None,
+    *,
+    project_path: str | None = None,
+    live_claude_instance_ids: set[str] | None = None,
+    live_claude_cwds: set[str] | None = None,
 ) -> LivenessResult:
     """Determine whether an instance is alive.
 
@@ -167,10 +254,27 @@ def is_alive(
     only when ALL signals report dead do we report dead):
 
       1. Current instance — running this code → ALIVE.
-      2. Tmux pane shows claude foreground → ALIVE (definitive).
-      3. Captured PID alive (``os.kill(pid, 0)``) → ALIVE (definitive).
-      4. Recent activity (< RECENT_ACTIVITY_S) → ALIVE (fallback).
-      5. Otherwise → DEAD.
+      2. A live claude process declares this ``instance_id`` in its
+         ``EMPIRICA_INSTANCE_ID`` env → ALIVE. EXACT and resume-proof;
+         overrides a stale captured PID. Primary signal — consulted when the
+         caller passes ``live_claude_instance_ids`` (a sweep precomputes it
+         once via ``scan_live_claude``).
+      3. Tmux pane shows claude foreground → ALIVE (definitive).
+      4. Live claude process whose cwd == this instance's project_path →
+         ALIVE. Coarser project-level FALLBACK for a live proc with no
+         ``EMPIRICA_INSTANCE_ID`` env. Only consulted when the caller passes
+         ``live_claude_cwds``.
+      5. Captured PID alive (``os.kill(pid, 0)``) → ALIVE (definitive).
+      6. Recent activity (< RECENT_ACTIVITY_S) → ALIVE (fallback).
+      7. Otherwise → DEAD.
+
+    The process-scan signals (2, 4) are the fix for non-tmux multiplexers
+    (screen/wezterm/zellij/cmux) and ``claude --resume`` / env-unset manual
+    restarts: a Claude that is genuinely running but is neither the tmux pane
+    foreground nor has a *live* captured PID is still detectable in the process
+    table. Signal 2 (env) is exact; signal 4 (cwd) is a coarse fallback. Both
+    are ALIVE-positive only — absence is never a dead verdict, so they never
+    override a definitive negative.
 
     The earlier shape short-circuited on tmux: if a pane existed but
     Claude was not the foreground command (e.g. user temporarily at
@@ -189,11 +293,29 @@ def is_alive(
             optimization — pass None to query lazily)
         current_instance_id: if equal to instance_id, treat as alive
             (the running cockpit is alive by definition)
+        project_path: this instance's project directory — matched against
+            ``live_claude_cwds`` for the cwd-fallback process signal
+        live_claude_instance_ids: pre-computed set of EMPIRICA_INSTANCE_IDs
+            declared by live claude processes (the exact, resume-proof primary
+            process signal; pass None to skip it)
+        live_claude_cwds: pre-computed set of realpath cwds hosting a live
+            claude process (the coarse fallback signal; pass None to skip it)
     """
     if current_instance_id and instance_id == current_instance_id:
-        return LivenessResult(alive=True, reason="current instance")
+        return LivenessResult(alive=True, reason="current instance", signal="current")
 
-    # Signal 1 — tmux pane shows claude foreground.
+    # Signal 2 — a live claude process declares this instance_id in its env.
+    # Exact + resume-proof: survives pid changes and is independent of any
+    # multiplexer. Checked first among the process signals because it maps the
+    # record to its live process unambiguously.
+    if live_claude_instance_ids and instance_id in live_claude_instance_ids:
+        return LivenessResult(
+            alive=True,
+            reason="live claude process (EMPIRICA_INSTANCE_ID match)",
+            signal="process_env",
+        )
+
+    # Signal 3 — tmux pane shows claude foreground.
     tmux_pane: str | None = None
     pane_state: str | None = None  # 'claude' | 'bash' | 'absent' | None (untestable)
     m = TMUX_INSTANCE_PATTERN.match(instance_id)
@@ -207,12 +329,26 @@ def is_alive(
                     alive=True,
                     reason=f"tmux pane %{tmux_pane} running claude",
                     tmux_pane=tmux_pane,
+                    signal="tmux",
                 )
             all_panes = _all_tmux_panes() or set()
             pane_state = "bash" if tmux_pane in all_panes else "absent"
         # tmux not queryable → pane_state stays None; fall through to PID
 
-    # Signal 2 — captured PID liveness. Authoritative when present.
+    # Signal 4 — live claude process attributable to this project by cwd.
+    # Coarse FALLBACK for a live proc with no EMPIRICA_INSTANCE_ID env (the
+    # exact env match is Signal 2). Catches Claude under screen/wezterm/zellij/
+    # cmux and stale-PID restarts. ALIVE-positive only. Placed before the
+    # captured-PID check so a genuinely-live process overrides a stale PID.
+    if project_path and live_claude_cwds and os.path.realpath(project_path) in live_claude_cwds:
+        return LivenessResult(
+            alive=True,
+            reason=f"live claude process in {project_path}",
+            tmux_pane=tmux_pane,
+            signal="process_cwd",
+        )
+
+    # Signal 5 — captured PID liveness. Authoritative when present.
     pid, ppid = _read_captured_pids(instance_id)
     target_pid = ppid if ppid else pid
     if target_pid:
@@ -225,6 +361,7 @@ def is_alive(
                 reason=f"pid {target_pid} alive",
                 pid_checked=target_pid,
                 tmux_pane=tmux_pane,
+                signal="pid",
             )
         # PID dead → definitive dead, independent of tmux.
         return LivenessResult(
@@ -234,7 +371,7 @@ def is_alive(
             tmux_pane=tmux_pane,
         )
 
-    # Signal 3 — recent activity. Last-resort fallback when neither
+    # Signal 6 — recent activity. Last-resort fallback when neither
     # tmux nor a captured PID can be consulted (e.g., fresh non-tmux
     # session, or tmux server unreachable). SKIP when tmux gave a
     # definitive negative — a stale instance file getting touched by a
@@ -246,6 +383,7 @@ def is_alive(
             alive=True,
             reason=f"recent activity ({int(last_activity_seconds)}s ago)",
             tmux_pane=tmux_pane,
+            signal="recent_activity",
         )
 
     # All signals exhausted. If tmux gave us a definitive negative,
@@ -260,4 +398,4 @@ def is_alive(
     return LivenessResult(alive=False, reason=reason, tmux_pane=tmux_pane)
 
 
-__all__ = ["LivenessResult", "is_alive"]
+__all__ = ["LiveClaudeScan", "LivenessResult", "is_alive", "scan_live_claude"]

--- a/tests/test_cockpit_instance_state.py
+++ b/tests/test_cockpit_instance_state.py
@@ -297,3 +297,76 @@ def test_discover_when_tmux_unavailable(env, monkeypatch):
     _bind_instance(home, project, "tmux_5")
     monkeypatch.setattr(ist, "_live_tmux_panes", lambda: None)
     assert ist.discover_instances() == ["tmux_5"]
+
+
+# --- _dedup_process_scan_overcount -----------------------------------------
+
+
+def _scan_inst(project_path, last_activity, signal="process_cwd", alive=True):
+    """Minimal instance dict for dedup tests."""
+    return {
+        "project_path": project_path,
+        "last_activity_seconds": last_activity,
+        "alive": alive,
+        "liveness_signal": signal,
+        "liveness_reason": signal,
+    }
+
+
+def test_dedup_caps_process_scan_at_live_proc_count(tmp_path):
+    """3 stale instance files for a project but only 1 live claude proc →
+    keep the most-recently-active, demote the other 2."""
+    proj = str((tmp_path / "p").resolve())
+    instances = [
+        _scan_inst(proj, 30.0),
+        _scan_inst(proj, 10.0),  # most recent
+        _scan_inst(proj, 20.0),
+    ]
+    ist._dedup_process_scan_overcount(instances, {proj: 1})
+    alive = [i for i in instances if i["alive"]]
+    assert len(alive) == 1
+    assert alive[0]["last_activity_seconds"] == 10.0
+    demoted = [i for i in instances if not i["alive"]]
+    assert all("duplicate stale session" in str(d["liveness_reason"]) for d in demoted)
+
+
+def test_dedup_strong_signal_consumes_budget(tmp_path):
+    """A pid-alive instance consumes the only live-proc slot → the
+    process_cwd sibling for the same project is demoted."""
+    proj = str((tmp_path / "p").resolve())
+    instances = [
+        _scan_inst(proj, 5.0, signal="pid"),
+        _scan_inst(proj, 10.0, signal="process_cwd"),
+    ]
+    ist._dedup_process_scan_overcount(instances, {proj: 1})
+    assert instances[0]["alive"] is True  # pid untouched
+    assert instances[1]["alive"] is False  # process_cwd demoted
+
+
+def test_dedup_keeps_within_budget(tmp_path):
+    """2 live procs, 2 process_scan instances → both kept."""
+    proj = str((tmp_path / "p").resolve())
+    instances = [_scan_inst(proj, 5.0), _scan_inst(proj, 10.0)]
+    ist._dedup_process_scan_overcount(instances, {proj: 2})
+    assert all(i["alive"] for i in instances)
+
+
+def test_dedup_never_demotes_strong_signals(tmp_path):
+    """Even with zero scanned procs reported, tmux/pid verdicts stand."""
+    proj = str((tmp_path / "p").resolve())
+    instances = [_scan_inst(proj, 5.0, signal="tmux"), _scan_inst(proj, 10.0, signal="pid")]
+    ist._dedup_process_scan_overcount(instances, {proj: 0})
+    assert all(i["alive"] for i in instances)
+
+
+def test_dedup_env_match_consumes_slot_and_survives(tmp_path):
+    """An exact env match (process_env) is strong: it consumes the only live
+    slot (never demoted), so the cwd-fallback sibling is demoted."""
+    proj = str((tmp_path / "p").resolve())
+    instances = [
+        _scan_inst(proj, 5.0, signal="process_env"),
+        _scan_inst(proj, 10.0, signal="process_cwd"),
+    ]
+    ist._dedup_process_scan_overcount(instances, {proj: 1})
+    assert instances[0]["alive"] is True  # env match untouched
+    assert instances[1]["alive"] is False  # cwd fallback demoted

--- a/tests/test_cockpit_liveness.py
+++ b/tests/test_cockpit_liveness.py
@@ -184,3 +184,174 @@ def test_pid_capture_falls_back_to_tty_sessions(fake_home, monkeypatch):
     result = lv.is_alive("term-pts-7")
     assert result.alive is True
     assert result.pid_checked == 67890
+
+
+# --- Signal 2: exact env-match process scan (primary) ----------------------
+
+
+def test_process_env_match_is_alive(fake_home):
+    """A live claude proc declaring this instance_id in EMPIRICA_INSTANCE_ID →
+    alive. Exact + resume-proof; no tmux pane, no captured PID needed."""
+    result = lv.is_alive("empirica-vr", live_claude_instance_ids={"empirica-vr"})
+    assert result.alive is True
+    assert result.signal == "process_env"
+
+
+def test_process_env_overrides_stale_captured_pid(fake_home, monkeypatch):
+    """The reported incident: `claude --resume` left the captured PID stale,
+    but the live proc declares the instance_id. Env match wins over dead PID."""
+    (fake_home / "instance_projects" / "empirica-vr.json").write_text(json.dumps({"pid": 111, "ppid": 222}))
+    monkeypatch.setattr(lv, "_process_alive", lambda _: False)  # captured PID dead
+    result = lv.is_alive("empirica-vr", live_claude_instance_ids={"empirica-vr"})
+    assert result.alive is True
+    assert result.signal == "process_env"
+
+
+def test_process_env_takes_precedence_over_cwd(fake_home, tmp_path):
+    """When both signals would fire, the exact env match wins (it's checked
+    first and is instance-level, not project-level)."""
+    proj = tmp_path / "projX"
+    proj.mkdir()
+    result = lv.is_alive(
+        "empirica-vr",
+        project_path=str(proj),
+        live_claude_instance_ids={"empirica-vr"},
+        live_claude_cwds={str(proj.resolve())},
+    )
+    assert result.signal == "process_env"
+
+
+def test_process_env_skipped_when_instance_ids_none(fake_home):
+    """Default None param → env signal never consulted (opt-in)."""
+    result = lv.is_alive("empirica-vr")
+    assert result.alive is False
+
+
+# --- Signal 4: cwd-fallback process scan -----------------------------------
+
+
+def test_process_cwd_makes_non_tmux_instance_alive(fake_home, tmp_path):
+    """A live claude process whose cwd matches the instance's project_path →
+    alive (fallback for a live proc with no EMPIRICA_INSTANCE_ID env)."""
+    proj = tmp_path / "projA"
+    proj.mkdir()
+    result = lv.is_alive(
+        "term-pts-7",
+        project_path=str(proj),
+        live_claude_cwds={str(proj.resolve())},
+    )
+    assert result.alive is True
+    assert result.signal == "process_cwd"
+    assert "live claude process" in result.reason
+
+
+def test_process_cwd_overrides_stale_captured_pid(fake_home, monkeypatch, tmp_path):
+    """Captured PID stale (dead), pane is bash, but a live proc exists for the
+    project (no env). The cwd fallback wins — checked BEFORE the PID verdict."""
+    proj = tmp_path / "projB"
+    proj.mkdir()
+    (fake_home / "instance_projects" / "tmux_5.json").write_text(json.dumps({"pid": 111, "ppid": 222}))
+    monkeypatch.setattr(lv, "_process_alive", lambda _: False)  # captured PID dead
+    monkeypatch.setattr(lv, "_all_tmux_panes", lambda: {"5"})  # pane is bash
+    result = lv.is_alive(
+        "tmux_5",
+        live_panes=set(),
+        project_path=str(proj),
+        live_claude_cwds={str(proj.resolve())},
+    )
+    assert result.alive is True
+    assert result.signal == "process_cwd"
+
+
+def test_process_cwd_absent_falls_through_to_pid(fake_home, monkeypatch, tmp_path):
+    """Project not in the live-cwd set → signal skipped, normal precedence."""
+    proj = tmp_path / "projC"
+    proj.mkdir()
+    (fake_home / "instance_projects" / "term-pts-7.json").write_text(json.dumps({"pid": 111, "ppid": 222}))
+    monkeypatch.setattr(lv, "_process_alive", lambda pid: pid == 222)
+    result = lv.is_alive(
+        "term-pts-7",
+        project_path=str(proj),
+        live_claude_cwds={"/some/other/project"},
+    )
+    assert result.alive is True
+    assert result.signal == "pid"
+
+
+def test_process_scan_skipped_when_both_none(fake_home, tmp_path):
+    """Default None params → neither process signal consulted (preserves prior
+    behavior for every existing caller / test)."""
+    proj = tmp_path / "projD"
+    proj.mkdir()
+    result = lv.is_alive("term-pts-7", project_path=str(proj))
+    assert result.alive is False
+
+
+# --- claude-process heuristic + scan ---------------------------------------
+
+
+def test_is_claude_proc_matches_claude_binary():
+    assert lv._is_claude_proc("claude", []) is True
+    assert lv._is_claude_proc("Claude", None) is True
+
+
+def test_is_claude_proc_node_requires_claude_in_cmdline():
+    assert lv._is_claude_proc("node", ["node", "/usr/lib/claude/cli.js"]) is True
+    assert lv._is_claude_proc("node", ["node", "server.js"]) is False
+
+
+def test_is_claude_proc_rejects_other_processes():
+    assert lv._is_claude_proc("bash", ["bash"]) is False
+    assert lv._is_claude_proc("python", ["python", "claude_helper.py"]) is False
+
+
+class _FakeProc:
+    """psutil-like process stub for scan_live_claude tests."""
+
+    def __init__(self, name, cmdline, cwd=None, env=None, cwd_exc=None):
+        self.info = {"name": name, "cmdline": cmdline}
+        self._cwd = cwd
+        self._env = env or {}
+        self._cwd_exc = cwd_exc
+
+    def environ(self):
+        return self._env
+
+    def cwd(self):
+        if self._cwd_exc is not None:
+            raise self._cwd_exc
+        return self._cwd
+
+
+def test_scan_live_claude_collects_env_ids_and_cwd_counts(monkeypatch, tmp_path):
+    """instance_ids come from EMPIRICA_INSTANCE_ID env; cwd_counts group by dir."""
+    import psutil
+
+    a = str((tmp_path / "a").resolve())
+    b = str((tmp_path / "b").resolve())
+    procs = [
+        _FakeProc("claude", ["claude"], cwd=a, env={"EMPIRICA_INSTANCE_ID": "empirica-vr"}),
+        _FakeProc("claude", ["claude"], cwd=a, env={"EMPIRICA_INSTANCE_ID": "empirica-storyboard"}),
+        _FakeProc("node", ["node", "/x/claude/cli.js"], cwd=b, env={}),  # no env id
+        _FakeProc("bash", ["bash"], cwd=a),  # not claude — ignored
+    ]
+    monkeypatch.setattr(psutil, "process_iter", lambda attrs=None: procs)
+    scan = lv.scan_live_claude()
+    assert scan.instance_ids == {"empirica-vr", "empirica-storyboard"}
+    assert scan.cwd_counts == {a: 2, b: 1}
+
+
+def test_scan_live_claude_skips_inaccessible_procs(monkeypatch, tmp_path):
+    """A proc whose cwd() raises is skipped for cwd but not fatal to the sweep;
+    its env id is still collected."""
+    import psutil
+
+    a = str((tmp_path / "a").resolve())
+    procs = [
+        _FakeProc("claude", ["claude"], cwd=a, env={"EMPIRICA_INSTANCE_ID": "good"}),
+        _FakeProc("claude", ["claude"], env={"EMPIRICA_INSTANCE_ID": "bad"}, cwd_exc=psutil.AccessDenied()),
+    ]
+    monkeypatch.setattr(psutil, "process_iter", lambda attrs=None: procs)
+    scan = lv.scan_live_claude()
+    assert scan.instance_ids == {"good", "bad"}
+    assert scan.cwd_counts == {a: 1}


### PR DESCRIPTION
## Problem

Cockpit liveness (`status` / `status --all` / TUI, and wake routing keyed off it) was effectively **tmux-only whenever the captured PID was absent or stale**. `claude --resume` and env-unset manual restarts leave the instance's stored PID pointing at a *dead* pre-restart process, so `os.kill` reports dead and liveness falls back to the tmux-pane probe — structurally blind to non-tmux multiplexers (GNU screen, WezTerm, zellij, cmux).

Ground truth from a real support incident: a box with **15 live claude procs (all carrying correct `EMPIRICA_INSTANCE_ID`), 14 listeners green** — yet `status --all` showed only 3–5. Only the recently-active instances (whose PID had been refreshed by a transaction) showed alive.

## Fix — a direct process-table scan as a liveness signal (`scan_live_claude`)

- **PRIMARY — exact env match.** Match each live `claude` process to its instance by `EMPIRICA_INSTANCE_ID`. **Exact and resume-proof** (survives PID changes), multiplexer-agnostic, and *instance-level* — so no over-count and no dedup needed for it.
- **FALLBACK — cwd match.** Working-directory → project match for the rare live proc that carries no instance-id env. Coarser (project-level), so it's count-capped.
- **`is_alive()`** gains `live_claude_instance_ids` + `live_claude_cwds` signals, placed **before** the captured-PID check so a genuinely-live process overrides a *stale* captured PID. Both alive-positive only; **opt-in via default-`None` params** so all 18 prior tests + every existing caller are unchanged. `LivenessResult.signal` records which signal fired.
- **`aggregate_all()`** walks the process table once and runs **count-aware dedup** on the cwd fallback: several stale instance files for one project would all flip alive via cwd, so cap at the live-proc count (strong `current`/`tmux`/`process_env`/`pid` signals consume slots first; exact env matches are never demoted).
- **`discover_dead_instances()`** (→ `instance prune`) honors the same signals, so prune won't offer to kill a Claude alive under a non-tmux multiplexer.

## Follow-ups (separate PRs, this is T1 of 6)

The same incident surfaced 5 more items, each tracked + queued: the `os.kill` **flapping** bug; **refresh captured PID on resume/SessionStart**; **reap fallback ghost records** + stop minting tty/pane fallbacks when env is present; an **`instance rebind`** verb; and **raising generated hook timeouts**. Per-multiplexer pane *detectors* (attribution display) are also deferred — the process scan makes *liveness* multiplexer-agnostic without them.

## Verification

- New tests: env-match + cwd-fallback signals, precedence (env > cwd), `scan_live_claude` env/cwd collection + inaccessible-proc skip, count-aware dedup (incl. env-consumes-slot)
- 131 cockpit-area tests pass (`test_cockpit_liveness`, `test_cockpit_instance_state`, `test_cockpit_tui`, `test_mesh_status_health`, `test_practitioner_presence`)
- ruff check + ruff format --check + pyright: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)