### PR TITLE
fix(cockpit): resume-proof + reuse-safe captured-PID liveness (T2+T3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   duplicate stale sessions don't inflate the count, and `instance prune` honors
   the same signals so it won't offer to kill a Claude that's alive under a
   non-tmux multiplexer.
+- **Liveness no longer flaps on a recycled PID** — `is_alive`'s captured-PID
+  check could read a *reused* pid number (after `claude --resume` or a crash,
+  the OS recycles the old pid for an unrelated process) as "alive", then "dead"
+  moments later as that impostor came and went. session-init now records the
+  Claude parent's start time (`ppid_create_time`) alongside the pid, and the
+  liveness check requires the start time to match — a recycled pid no longer
+  passes. Re-stamped every SessionStart (incl. `--resume`) so the captured pid
+  stays current. Falls back to the bare `os.kill` probe when psutil is
+  unavailable or the start time wasn't captured (older instances).
 
 ## [1.12.8] — 2026-06-29
 

--- a/empirica/core/cockpit/liveness.py
+++ b/empirica/core/cockpit/liveness.py
@@ -118,9 +118,34 @@ def _all_tmux_panes() -> set[str] | None:
     return {line.strip().lstrip("%") for line in result.stdout.splitlines() if line.strip()}
 
 
-def _process_alive(pid: int) -> bool:
+def _try_create_time(pid: int) -> float | None:
+    """psutil start time (epoch secs) for ``pid``, or None if psutil is
+    unavailable or the process is gone."""
+    try:
+        import psutil
+
+        return psutil.Process(pid).create_time()
+    except Exception:
+        return None
+
+
+def _process_alive(pid: int, expected_create_time: float | None = None) -> bool:
+    """True if ``pid`` is a live process.
+
+    When ``expected_create_time`` is given, additionally require the process's
+    start time to match it (within 1s) — this rejects a *recycled* pid number
+    whose original owner has exited (the cause of cockpit liveness flapping:
+    a bare ``os.kill`` reads whatever impostor now holds the reused number).
+    Falls back to the bare ``os.kill`` probe when psutil is unavailable or no
+    start time was captured, preserving prior behavior.
+    """
     if pid <= 1:
         return False
+    if expected_create_time is not None:
+        actual = _try_create_time(pid)
+        if actual is not None:
+            return abs(actual - expected_create_time) < 1.0
+        # couldn't read start time → fall through to the os.kill probe below
     try:
         os.kill(pid, 0)
         return True
@@ -206,17 +231,30 @@ def scan_live_claude() -> LiveClaudeScan | None:
     return LiveClaudeScan(instance_ids=instance_ids, cwd_counts=cwd_counts)
 
 
-def _read_captured_pids(instance_id: str) -> tuple[int | None, int | None]:
-    """Return (pid, ppid) captured at session-init time, or (None, None)."""
+def _pids_from_data(data: dict) -> tuple[int | None, int | None, float | None]:
+    """Extract (pid, ppid, ppid_create_time) from a state-file dict."""
+    pid = data.get("pid") if isinstance(data.get("pid"), int) else None
+    ppid = data.get("ppid") if isinstance(data.get("ppid"), int) else None
+    ct = data.get("ppid_create_time")
+    ct = float(ct) if isinstance(ct, (int, float)) else None
+    return pid, ppid, ct
+
+
+def _read_captured_pids(instance_id: str) -> tuple[int | None, int | None, float | None]:
+    """Return (pid, ppid, ppid_create_time) captured at session-init, or Nones.
+
+    ``ppid_create_time`` is the Claude parent's start time — used to reject a
+    recycled ppid number (the flapping guard). Absent for instances captured
+    before that field existed → falls back to the bare ``os.kill`` probe.
+    """
     inst_file = EMPIRICA_DIR / "instance_projects" / f"{instance_id}.json"
     if inst_file.exists():
         try:
             with open(inst_file, encoding="utf-8") as f:
                 data = json.load(f)
-            pid = data.get("pid") if isinstance(data.get("pid"), int) else None
-            ppid = data.get("ppid") if isinstance(data.get("ppid"), int) else None
+            pid, ppid, ct = _pids_from_data(data)
             if pid or ppid:
-                return pid, ppid
+                return pid, ppid, ct
             tty_key = data.get("tty_key")
         except (OSError, json.JSONDecodeError):
             tty_key = None
@@ -229,13 +267,11 @@ def _read_captured_pids(instance_id: str) -> tuple[int | None, int | None]:
             try:
                 with open(tty_file, encoding="utf-8") as f:
                     data = json.load(f)
-                pid = data.get("pid") if isinstance(data.get("pid"), int) else None
-                ppid = data.get("ppid") if isinstance(data.get("ppid"), int) else None
-                return pid, ppid
+                return _pids_from_data(data)
             except (OSError, json.JSONDecodeError):
                 pass
 
-    return None, None
+    return None, None, None
 
 
 def is_alive(
@@ -349,10 +385,13 @@ def is_alive(
         )
 
     # Signal 5 — captured PID liveness. Authoritative when present.
-    pid, ppid = _read_captured_pids(instance_id)
+    pid, ppid, ppid_ct = _read_captured_pids(instance_id)
     target_pid = ppid if ppid else pid
     if target_pid:
-        if _process_alive(target_pid):
+        # The create_time guard was captured for the ppid; only apply it when
+        # the ppid is what we're probing (reject a recycled ppid number).
+        expected_ct = ppid_ct if (ppid and target_pid == ppid) else None
+        if _process_alive(target_pid, expected_ct):
             # PID overrides tmux disagreement: claude is running even
             # though it's not the pane foreground (sub-process, wrapper,
             # split window, etc.).

--- a/empirica/plugins/claude-code-integration/hooks/session-init.py
+++ b/empirica/plugins/claude-code-integration/hooks/session-init.py
@@ -24,6 +24,25 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "lib"))
 from project_resolver import _find_git_root, find_project_root, get_instance_id, has_valid_db
 
 
+def _proc_create_time(pid: int) -> float | None:
+    """Process start time (epoch seconds) for ``pid``, or None if unavailable.
+
+    Captured alongside pid/ppid so cockpit liveness can guard against PID
+    reuse: after ``claude --resume`` or a crash the OS may recycle the old
+    pid number for an unrelated process, and a bare ``os.kill(pid, 0)`` would
+    read that impostor as "alive" (the source of the liveness flapping). A
+    stored start time lets the liveness check reject a recycled pid that
+    doesn't match. Best-effort — psutil may be absent in a minimal hook env,
+    or the process may already have exited.
+    """
+    try:
+        import psutil
+
+        return psutil.Process(pid).create_time()
+    except Exception:
+        return None
+
+
 def archive_stale_plans() -> list:
     """
     Archive plan files whose goals are complete.
@@ -727,6 +746,10 @@ def _write_instance_projects(project_path: str, claude_session_id: str, empirica
             # pid is this hook process (short-lived, usually dead by query time).
             "pid": os.getpid(),
             "ppid": os.getppid(),
+            # Start time of the Claude parent, so liveness can reject a recycled
+            # ppid number (the flapping guard). Re-stamped every SessionStart
+            # (incl. `--resume`), keeping the captured pid current.
+            "ppid_create_time": _proc_create_time(os.getppid()),
         }
         with open(instance_file, "w") as f:
             json.dump(instance_data, f, indent=2)
@@ -785,6 +808,7 @@ def _write_instance_projects(project_path: str, claude_session_id: str, empirica
             tty_data["timestamp"] = datetime.now().isoformat()
             tty_data["pid"] = os.getpid()
             tty_data["ppid"] = os.getppid()
+            tty_data["ppid_create_time"] = _proc_create_time(os.getppid())
 
             with open(tty_session_file, "w") as f:
                 json.dump(tty_data, f, indent=2)

--- a/tests/test_cockpit_liveness.py
+++ b/tests/test_cockpit_liveness.py
@@ -58,7 +58,7 @@ def test_tmux_pane_gone_is_dead(fake_home, monkeypatch):
 
 def test_non_tmux_with_alive_ppid_is_alive(fake_home, monkeypatch):
     (fake_home / "instance_projects" / "term-pts-7.json").write_text(json.dumps({"pid": 12345, "ppid": 67890}))
-    monkeypatch.setattr(lv, "_process_alive", lambda pid: pid == 67890)
+    monkeypatch.setattr(lv, "_process_alive", lambda pid, ct=None: pid == 67890)
     result = lv.is_alive("term-pts-7")
     assert result.alive is True
     assert result.pid_checked == 67890
@@ -66,7 +66,7 @@ def test_non_tmux_with_alive_ppid_is_alive(fake_home, monkeypatch):
 
 def test_non_tmux_with_dead_ppid_is_dead(fake_home, monkeypatch):
     (fake_home / "instance_projects" / "term-pts-7.json").write_text(json.dumps({"pid": 12345, "ppid": 67890}))
-    monkeypatch.setattr(lv, "_process_alive", lambda _: False)
+    monkeypatch.setattr(lv, "_process_alive", lambda _pid, _ct=None: False)
     result = lv.is_alive("term-pts-7")
     assert result.alive is False
     assert "pid 67890 dead" in result.reason
@@ -109,7 +109,7 @@ def test_tmux_bash_but_captured_pid_alive_is_alive(fake_home, monkeypatch):
     """
     (fake_home / "instance_projects" / "tmux_5.json").write_text(json.dumps({"pid": 12345, "ppid": 67890}))
     monkeypatch.setattr(lv, "_all_tmux_panes", lambda: {"5"})
-    monkeypatch.setattr(lv, "_process_alive", lambda pid: pid == 67890)
+    monkeypatch.setattr(lv, "_process_alive", lambda pid, ct=None: pid == 67890)
 
     # Pane exists, claude is NOT the foreground command, but PID is alive.
     result = lv.is_alive("tmux_5", live_panes=set())
@@ -125,7 +125,7 @@ def test_tmux_bash_and_captured_pid_dead_is_dead(fake_home, monkeypatch):
     """
     (fake_home / "instance_projects" / "tmux_5.json").write_text(json.dumps({"pid": 12345, "ppid": 67890}))
     monkeypatch.setattr(lv, "_all_tmux_panes", lambda: {"5"})
-    monkeypatch.setattr(lv, "_process_alive", lambda _: False)
+    monkeypatch.setattr(lv, "_process_alive", lambda _pid, _ct=None: False)
 
     result = lv.is_alive("tmux_5", live_panes=set())
 
@@ -180,7 +180,7 @@ def test_pid_capture_falls_back_to_tty_sessions(fake_home, monkeypatch):
     """instance_projects has tty_key but no pid; tty_sessions has the pid."""
     (fake_home / "instance_projects" / "term-pts-7.json").write_text(json.dumps({"tty_key": "pts-7"}))
     (fake_home / "tty_sessions" / "pts-7.json").write_text(json.dumps({"pid": 12345, "ppid": 67890}))
-    monkeypatch.setattr(lv, "_process_alive", lambda pid: pid == 67890)
+    monkeypatch.setattr(lv, "_process_alive", lambda pid, ct=None: pid == 67890)
     result = lv.is_alive("term-pts-7")
     assert result.alive is True
     assert result.pid_checked == 67890
@@ -201,7 +201,7 @@ def test_process_env_overrides_stale_captured_pid(fake_home, monkeypatch):
     """The reported incident: `claude --resume` left the captured PID stale,
     but the live proc declares the instance_id. Env match wins over dead PID."""
     (fake_home / "instance_projects" / "empirica-vr.json").write_text(json.dumps({"pid": 111, "ppid": 222}))
-    monkeypatch.setattr(lv, "_process_alive", lambda _: False)  # captured PID dead
+    monkeypatch.setattr(lv, "_process_alive", lambda _pid, _ct=None: False)  # captured PID dead
     result = lv.is_alive("empirica-vr", live_claude_instance_ids={"empirica-vr"})
     assert result.alive is True
     assert result.signal == "process_env"
@@ -251,7 +251,7 @@ def test_process_cwd_overrides_stale_captured_pid(fake_home, monkeypatch, tmp_pa
     proj = tmp_path / "projB"
     proj.mkdir()
     (fake_home / "instance_projects" / "tmux_5.json").write_text(json.dumps({"pid": 111, "ppid": 222}))
-    monkeypatch.setattr(lv, "_process_alive", lambda _: False)  # captured PID dead
+    monkeypatch.setattr(lv, "_process_alive", lambda _pid, _ct=None: False)  # captured PID dead
     monkeypatch.setattr(lv, "_all_tmux_panes", lambda: {"5"})  # pane is bash
     result = lv.is_alive(
         "tmux_5",
@@ -268,7 +268,7 @@ def test_process_cwd_absent_falls_through_to_pid(fake_home, monkeypatch, tmp_pat
     proj = tmp_path / "projC"
     proj.mkdir()
     (fake_home / "instance_projects" / "term-pts-7.json").write_text(json.dumps({"pid": 111, "ppid": 222}))
-    monkeypatch.setattr(lv, "_process_alive", lambda pid: pid == 222)
+    monkeypatch.setattr(lv, "_process_alive", lambda pid, ct=None: pid == 222)
     result = lv.is_alive(
         "term-pts-7",
         project_path=str(proj),
@@ -355,3 +355,94 @@ def test_scan_live_claude_skips_inaccessible_procs(monkeypatch, tmp_path):
     scan = lv.scan_live_claude()
     assert scan.instance_ids == {"good", "bad"}
     assert scan.cwd_counts == {a: 1}
+
+
+# --- create_time reuse guard (flapping fix) --------------------------------
+
+
+class _FakePsutilProc:
+    """Stub for psutil.Process(pid) with a fixed create_time."""
+
+    def __init__(self, _pid, create_time):
+        self._ct = create_time
+
+    def create_time(self):
+        return self._ct
+
+
+def test_process_alive_create_time_match(monkeypatch):
+    import psutil
+
+    monkeypatch.setattr(psutil, "Process", lambda pid: _FakePsutilProc(pid, 1000.0))
+    assert lv._process_alive(4242, expected_create_time=1000.0) is True
+
+
+def test_process_alive_create_time_mismatch_is_dead(monkeypatch):
+    """Recycled pid: process exists but its start time differs → dead (no flap)."""
+    import psutil
+
+    monkeypatch.setattr(psutil, "Process", lambda pid: _FakePsutilProc(pid, 9999.0))
+    assert lv._process_alive(4242, expected_create_time=1000.0) is False
+
+
+def test_process_alive_no_expected_uses_oskill(monkeypatch):
+    """No captured create_time → bare os.kill probe (prior behavior)."""
+    monkeypatch.setattr(lv.os, "kill", lambda pid, sig: None)
+    assert lv._process_alive(4242) is True
+
+    def _boom(pid, sig):
+        raise ProcessLookupError
+
+    monkeypatch.setattr(lv.os, "kill", _boom)
+    assert lv._process_alive(4242) is False
+
+
+def test_process_alive_psutil_error_falls_back_to_oskill(monkeypatch):
+    """If psutil errors despite an expected create_time, fall back to os.kill."""
+    import psutil
+
+    def _raise(pid):
+        raise psutil.AccessDenied()
+
+    monkeypatch.setattr(psutil, "Process", _raise)
+    monkeypatch.setattr(lv.os, "kill", lambda pid, sig: None)
+    assert lv._process_alive(4242, expected_create_time=1000.0) is True
+
+
+def test_read_captured_pids_includes_create_time(fake_home):
+    (fake_home / "instance_projects" / "x.json").write_text(
+        json.dumps({"pid": 1, "ppid": 2, "ppid_create_time": 1234.5})
+    )
+    assert lv._read_captured_pids("x") == (1, 2, 1234.5)
+
+
+def test_read_captured_pids_absent_create_time_is_none(fake_home):
+    (fake_home / "instance_projects" / "x.json").write_text(json.dumps({"pid": 1, "ppid": 2}))
+    _pid, _ppid, ct = lv._read_captured_pids("x")
+    assert ct is None
+
+
+def test_is_alive_reused_ppid_does_not_flap_alive(fake_home, monkeypatch):
+    """End-to-end: a recycled ppid number (live impostor, wrong start time) →
+    dead, not alive. Without the guard os.kill would read it alive (the flap)."""
+    import psutil
+
+    (fake_home / "instance_projects" / "x.json").write_text(
+        json.dumps({"pid": 1, "ppid": 5000, "ppid_create_time": 1000.0})
+    )
+    monkeypatch.setattr(psutil, "Process", lambda pid: _FakePsutilProc(pid, 8888.0))  # impostor
+    result = lv.is_alive("x")
+    assert result.alive is False
+    assert "dead" in result.reason
+
+
+def test_is_alive_matching_ppid_create_time_is_alive(fake_home, monkeypatch):
+    import psutil
+
+    (fake_home / "instance_projects" / "x.json").write_text(
+        json.dumps({"pid": 1, "ppid": 5000, "ppid_create_time": 1000.0})
+    )
+    monkeypatch.setattr(psutil, "Process", lambda pid: _FakePsutilProc(pid, 1000.0))
+    result = lv.is_alive("x")
+    assert result.alive is True
+    assert result.signal == "pid"


### PR DESCRIPTION
Two coupled fixes to the captured-PID liveness path (mesh-support field report, Philipp's box). This is **T2+T3** of the 6-part liveness sequence — merged into one PR because the deterministic flapping fix needs the start time captured at session-init (splitting would ship a no-op guard).

## FLAPPING (T2)

`is_alive`'s captured-PID check did a bare `os.kill(ppid, 0)`. After `claude --resume` or a crash, the OS recycles the old ppid *number* for an unrelated process, so `os.kill` reads that **impostor** as "alive" — then "dead" moments later as it comes and goes. Ground truth: the same live PID flapped alive↔dead ~2 min apart on a genuinely-running session.

## RESUME STALENESS (T3)

`claude --resume` runs under a new pid the instance record never learned; the captured ppid pointed at the dead pre-resume process.

## Fix — capture the parent's start time, guard against pid reuse

- **session-init** records `ppid_create_time` (psutil start time of the Claude parent) alongside pid/ppid, at both write sites (`instance_projects` + `tty_sessions`). Re-stamped every SessionStart incl. `--resume`, keeping the captured pid current.
- **liveness** `_process_alive(pid, expected_create_time)` requires the live process's start time to match (within 1s) — a recycled pid no longer passes, killing the flap. `_read_captured_pids` returns the create_time; `is_alive` applies the guard to the ppid it was captured from.
- **Graceful fallback** to the bare `os.kill` probe when psutil is unavailable or the start time wasn't captured (older instances) — prior behavior preserved.

## Relationship to #194

Complementary. #194's env-scan resolves env'd instances *before* this captured-PID path is reached, so it already masks the flap for the common case. This PR hardens the **fallback** path — which still matters for non-env instances and the macOS case where `psutil.environ()` may be restricted (degrading the env-scan).

## Verification

- New tests: create_time match/mismatch guard, os.kill fallback, psutil-error fallback, `_read_captured_pids` create_time, end-to-end reused-ppid-no-flap + matching-create_time-alive
- 120 cockpit-area tests pass; ruff check + format + pyright clean

## Remaining sequence

T4 `instance rebind` verb · T5 reap fallback ghosts · T6 raise generated hook timeouts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)