### PR TITLE
fix(cockpit): instance prune reaps superseded fallback ghosts (T5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   duplicate stale sessions don't inflate the count, and `instance prune` honors
   the same signals so it won't offer to kill a Claude that's alive under a
   non-tmux multiplexer.
+- **`instance prune` now reaps superseded fallback ghosts** — an old
+  tty/pane-name record (`tmux_N` / `term_*`) left behind by a session that
+  started without `EMPIRICA_INSTANCE_ID` was kept "alive" by the project-level
+  cwd signal (its project still hosts a live canonical instance), so it
+  survived `prune` forever — `status --include-dead` filled with zombies.
+  `discover_dead_instances` now applies the same count-aware dedup the cockpit
+  uses, so a fallback record superseded by a canonical (env-declared) instance
+  for the same project is identified as dead and pruned. Canonical
+  env-matched instances are never reaped. (Prevention was already in place:
+  `get_instance_id` prefers `EMPIRICA_INSTANCE_ID`, so no fallback record is
+  minted while the env var is set.)
 - **Liveness no longer flaps on a recycled PID** — `is_alive`'s captured-PID
   check could read a *reused* pid number (after `claude --resume` or a crash,
   the OS recycles the old pid for an unrelated process) as "alive", then "dead"

--- a/empirica/core/cockpit/instance_state.py
+++ b/empirica/core/cockpit/instance_state.py
@@ -714,6 +714,14 @@ def discover_dead_instances() -> list[str]:
 
     Used by `empirica instance prune` for bulk cleanup. Skips the current
     instance even if it lacks PID capture (it's running this code).
+
+    Applies the same count-aware dedup as the cockpit, so a superseded
+    *fallback ghost* — an old tty/pane-name record (``tmux_N`` / ``term_*``)
+    whose project still hosts a live claude declared under a canonical
+    ``EMPIRICA_INSTANCE_ID`` — is reaped instead of being kept alive by the
+    project-level cwd signal. Without the dedup such ghosts read alive via
+    ``process_cwd`` and survive prune forever (the cockpit dedups them away,
+    but prune never cleaned them up).
     """
     live_panes = _live_tmux_panes()
     # Same multiplexer-agnostic signals the cockpit uses — so `prune` never
@@ -729,7 +737,7 @@ def discover_dead_instances() -> list[str]:
     except Exception:
         current_id = None
 
-    dead: list[str] = []
+    records: list[dict[str, Any]] = []
     for iid in discover_instances():
         # We need last_activity to evaluate the recent-activity fallback,
         # so a cheap aggregate is unavoidable. _read_transaction_state is
@@ -748,9 +756,23 @@ def discover_dead_instances() -> list[str]:
             live_claude_instance_ids=live_iids,
             live_claude_cwds=live_cwds,
         )
-        if not liveness.alive:
-            dead.append(iid)
-    return dead
+        records.append(
+            {
+                "instance_id": iid,
+                "project_path": project_path,
+                "last_activity_seconds": last_activity,
+                "alive": liveness.alive,
+                "liveness_signal": liveness.signal,
+            }
+        )
+
+    # Reap superseded fallback ghosts: demote cwd-only revivals that exceed the
+    # live-proc count for their project (env-matched canonicals are strong and
+    # never demoted), then anything not-alive is dead.
+    if scan and scan.cwd_counts:
+        _dedup_process_scan_overcount(records, scan.cwd_counts)
+
+    return [r["instance_id"] for r in records if not r["alive"]]
 
 
 __all__ = [

--- a/tests/test_cockpit_instance_state.py
+++ b/tests/test_cockpit_instance_state.py
@@ -8,6 +8,7 @@ shape.
 from __future__ import annotations
 
 import json
+import os
 import time
 from pathlib import Path
 
@@ -370,3 +371,46 @@ def test_dedup_env_match_consumes_slot_and_survives(tmp_path):
     ist._dedup_process_scan_overcount(instances, {proj: 1})
     assert instances[0]["alive"] is True  # env match untouched
     assert instances[1]["alive"] is False  # cwd fallback demoted
+
+
+# ─── discover_dead_instances reaps superseded fallback ghosts ───────────────
+
+
+def test_discover_dead_reaps_superseded_fallback_ghost(env, monkeypatch):
+    """A canonical env-matched instance + an old fallback ghost (tmux_N) for the
+    same project, with one live proc: the ghost is kept 'alive' by the cwd
+    signal but dedup demotes it → it lands in the dead list (prune reaps it).
+    The canonical instance stays alive and is NOT reaped."""
+    home, project = env
+    _bind_instance(home, project, "empirica")  # canonical (env id)
+    _bind_instance(home, project, "tmux_16")  # superseded fallback ghost
+    rp = os.path.realpath(str(project))
+
+    monkeypatch.setattr(
+        ist,
+        "scan_live_claude",
+        lambda: lv.LiveClaudeScan(instance_ids={"empirica"}, cwd_counts={rp: 1}),
+    )
+    monkeypatch.setattr("empirica.utils.session_resolver.get_instance_id", lambda: None)
+
+    dead = ist.discover_dead_instances()
+    assert "tmux_16" in dead  # ghost reaped
+    assert "empirica" not in dead  # canonical (process_env) survives
+
+
+def test_discover_dead_keeps_ghost_when_no_canonical(env, monkeypatch):
+    """If a fallback record is the ONLY instance for a project with a live proc,
+    it legitimately represents that process (within budget) → not reaped."""
+    home, project = env
+    _bind_instance(home, project, "tmux_16")
+    rp = os.path.realpath(str(project))
+
+    monkeypatch.setattr(
+        ist,
+        "scan_live_claude",
+        lambda: lv.LiveClaudeScan(instance_ids=set(), cwd_counts={rp: 1}),
+    )
+    monkeypatch.setattr("empirica.utils.session_resolver.get_instance_id", lambda: None)
+
+    dead = ist.discover_dead_instances()
+    assert "tmux_16" not in dead  # within budget — kept


### PR DESCRIPTION
**T5** of the liveness sequence (after #194, #195, #196). From the mesh-support field report: 21 records for 15 instances — `status --include-dead` full of zombies under old fallback ids (`tmux_N`, `term_*`).

## Problem

A fallback record left behind by a session that started without `EMPIRICA_INSTANCE_ID` is kept "alive" by #194's **project-level** cwd signal — its project still hosts a live *canonical* instance — so it survived `instance prune` forever. The cockpit dedups these away (`aggregate_all` runs `_dedup_process_scan_overcount`), but prune (`discover_dead_instances`) called `is_alive` per-instance with **no dedup**, so the ghost read alive via `process_cwd` and never got cleaned.

## Fix

`discover_dead_instances` now collects per-instance liveness records and applies the **same count-aware dedup** the cockpit uses. A fallback record superseded by a canonical (env-declared, `process_env`) instance for the same project is demoted to dead and pruned. Canonical env-matched instances are strong and never reaped; a lone fallback within the live-proc budget is kept.

## Prevention already in place

`get_instance_id` prefers `EMPIRICA_INSTANCE_ID` over the tmux/tty fallback (session_resolver.py), so **no fallback record is minted while the env var is set**. This PR handles the historical ghosts that prevention can't retroactively retract. (The bare-ai_id ghosts — `outreach` vs `empirica-outreach` — are a separate ai_id-naming concern handled by the ai_id heal at session-init, not instance_projects records.)

## Verification

- Tests: ghost reaped when superseded by a canonical; lone fallback within budget kept
- 30 instance-state tests pass; ruff check + format + pyright clean

## Remaining

T6 — raise generated hook timeouts (last of the sequence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)