### PR TITLE
fix(setup): raise generated lightweight hook timeouts 3/5s → 10s (T6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   duplicate stale sessions don't inflate the count, and `instance prune` honors
   the same signals so it won't offer to kill a Claude that's alive under a
   non-tmux multiplexer.
+- **Generated hook timeouts raised so context injection survives load** —
+  `setup-claude-code` generated the lightweight per-prompt / per-SessionStart
+  hooks (tool-router, context-shift tracker, monitor-arm, the loop/listener
+  pickups) at 3s/5s. On a many-instance restart-herd box (high load, slow cold
+  Python starts) those hooks timed out and Claude Code silently discarded their
+  stdout — so their context injection never landed. They now generate at a
+  single `LIGHT_HOOK_TIMEOUT` (10s); the heavy hooks (compaction, session-init,
+  postflight) keep their own larger budgets. All remain `allowFailure=True`.
 - **`instance prune` now reaps superseded fallback ghosts** — an old
   tty/pane-name record (`tmux_N` / `term_*`) left behind by a session that
   started without `EMPIRICA_INSTANCE_ID` was kept "alive" by the project-level

--- a/empirica/cli/command_handlers/setup_claude_code.py
+++ b/empirica/cli/command_handlers/setup_claude_code.py
@@ -34,6 +34,15 @@ PLUGIN_VERSION = "1.12.8"
 # from. Drives drift-sync (empirica plugin-sync / session-init auto-heal).
 PLUGIN_VERSION_STAMP = ".plugin-version"
 
+# Timeout (seconds) for the lightweight per-prompt / per-SessionStart hooks
+# (tool-router, context-shift tracker, monitor-arm, the loop/listener pickups).
+# Raised from the old 3s/5s: on a many-instance restart-herd box (high load,
+# slow cold Python starts) those hooks were timing out and Claude Code
+# silently discarded their stdout — i.e. their context injection never landed.
+# All are allowFailure=True, so a generous ceiling only helps; the heavy hooks
+# (compaction, session-init, postflight) keep their own larger explicit timeouts.
+LIGHT_HOOK_TIMEOUT = 10
+
 
 def _resolve_empirica_version() -> str:
     """Return the installed empirica version, or 'unknown' on miss.
@@ -366,7 +375,12 @@ def _register_all_hooks(settings, plugin_dir, python_cmd, output_format):
                 "hooks": [
                     {"type": "command", "command": postcompact_script, "timeout": 30},
                     {"type": "command", "command": ewm_script, "timeout": 10, "allowFailure": True},
-                    {"type": "command", "command": monitor_arm_script, "timeout": 5, "allowFailure": True},
+                    {
+                        "type": "command",
+                        "command": monitor_arm_script,
+                        "timeout": LIGHT_HOOK_TIMEOUT,
+                        "allowFailure": True,
+                    },
                 ],
             },
             {
@@ -374,7 +388,12 @@ def _register_all_hooks(settings, plugin_dir, python_cmd, output_format):
                 "hooks": [
                     {"type": "command", "command": sessioninit_script, "timeout": 30},
                     {"type": "command", "command": ewm_script, "timeout": 10, "allowFailure": True},
-                    {"type": "command", "command": monitor_arm_script, "timeout": 5, "allowFailure": True},
+                    {
+                        "type": "command",
+                        "command": monitor_arm_script,
+                        "timeout": LIGHT_HOOK_TIMEOUT,
+                        "allowFailure": True,
+                    },
                 ],
             },
         ],
@@ -440,7 +459,9 @@ def _register_all_hooks(settings, plugin_dir, python_cmd, output_format):
         [
             {
                 "matcher": ".*",
-                "hooks": [{"type": "command", "command": router_script, "timeout": 3, "allowFailure": True}],
+                "hooks": [
+                    {"type": "command", "command": router_script, "timeout": LIGHT_HOOK_TIMEOUT, "allowFailure": True}
+                ],
             },
         ],
         "UserPromptSubmit hook",
@@ -451,7 +472,12 @@ def _register_all_hooks(settings, plugin_dir, python_cmd, output_format):
     cs_script = f"{python_cmd} {plugin_dir}/hooks/context-shift-tracker.py"
     if not _hook_exists(settings["hooks"].get("UserPromptSubmit", []), "context-shift-tracker.py"):
         settings["hooks"].setdefault("UserPromptSubmit", []).append(
-            {"matcher": ".*", "hooks": [{"type": "command", "command": cs_script, "timeout": 5, "allowFailure": True}]}
+            {
+                "matcher": ".*",
+                "hooks": [
+                    {"type": "command", "command": cs_script, "timeout": LIGHT_HOOK_TIMEOUT, "allowFailure": True}
+                ],
+            }
         )
         if output_format != "json":
             print("   ✓ Context-shift tracker configured")
@@ -464,7 +490,9 @@ def _register_all_hooks(settings, plugin_dir, python_cmd, output_format):
         settings["hooks"].setdefault("UserPromptSubmit", []).append(
             {
                 "matcher": ".*",
-                "hooks": [{"type": "command", "command": install_script, "timeout": 5, "allowFailure": True}],
+                "hooks": [
+                    {"type": "command", "command": install_script, "timeout": LIGHT_HOOK_TIMEOUT, "allowFailure": True}
+                ],
             }
         )
         if output_format != "json":
@@ -480,7 +508,14 @@ def _register_all_hooks(settings, plugin_dir, python_cmd, output_format):
         settings["hooks"].setdefault("UserPromptSubmit", []).append(
             {
                 "matcher": ".*",
-                "hooks": [{"type": "command", "command": uninstall_script, "timeout": 5, "allowFailure": True}],
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": uninstall_script,
+                        "timeout": LIGHT_HOOK_TIMEOUT,
+                        "allowFailure": True,
+                    }
+                ],
             }
         )
         if output_format != "json":
@@ -494,7 +529,14 @@ def _register_all_hooks(settings, plugin_dir, python_cmd, output_format):
         settings["hooks"].setdefault("UserPromptSubmit", []).append(
             {
                 "matcher": ".*",
-                "hooks": [{"type": "command", "command": listener_install_script, "timeout": 5, "allowFailure": True}],
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": listener_install_script,
+                        "timeout": LIGHT_HOOK_TIMEOUT,
+                        "allowFailure": True,
+                    }
+                ],
             }
         )
         if output_format != "json":
@@ -510,7 +552,12 @@ def _register_all_hooks(settings, plugin_dir, python_cmd, output_format):
             {
                 "matcher": ".*",
                 "hooks": [
-                    {"type": "command", "command": listener_uninstall_script, "timeout": 5, "allowFailure": True}
+                    {
+                        "type": "command",
+                        "command": listener_uninstall_script,
+                        "timeout": LIGHT_HOOK_TIMEOUT,
+                        "allowFailure": True,
+                    }
                 ],
             }
         )
@@ -525,7 +572,9 @@ def _register_all_hooks(settings, plugin_dir, python_cmd, output_format):
         [
             {
                 "matcher": "Edit|Write",
-                "hooks": [{"type": "command", "command": entity_script, "timeout": 5, "allowFailure": True}],
+                "hooks": [
+                    {"type": "command", "command": entity_script, "timeout": LIGHT_HOOK_TIMEOUT, "allowFailure": True}
+                ],
             },
         ],
         "PostToolUse (entity extraction) hook",
@@ -555,7 +604,9 @@ def _register_all_hooks(settings, plugin_dir, python_cmd, output_format):
         [
             {
                 "matcher": ".*",
-                "hooks": [{"type": "command", "command": failure_script, "timeout": 5, "allowFailure": True}],
+                "hooks": [
+                    {"type": "command", "command": failure_script, "timeout": LIGHT_HOOK_TIMEOUT, "allowFailure": True}
+                ],
             },
         ],
         "PostToolUseFailure hook",
@@ -570,7 +621,9 @@ def _register_all_hooks(settings, plugin_dir, python_cmd, output_format):
         [
             {
                 "matcher": ".*",
-                "hooks": [{"type": "command", "command": stop_script, "timeout": 5, "allowFailure": True}],
+                "hooks": [
+                    {"type": "command", "command": stop_script, "timeout": LIGHT_HOOK_TIMEOUT, "allowFailure": True}
+                ],
             },
         ],
         "Stop (transaction enforcer) hook",

--- a/tests/test_setup_claude_code_hook_timeouts.py
+++ b/tests/test_setup_claude_code_hook_timeouts.py
@@ -1,0 +1,73 @@
+"""Tests for the generated Claude Code hook timeouts.
+
+The lightweight per-prompt / per-SessionStart hooks (tool-router, context-shift
+tracker, monitor-arm, loop/listener pickups) were generated at 3s/5s. On a
+many-instance restart-herd box those timed out and Claude Code silently
+discarded their stdout (context injection lost). They're now generated at
+``LIGHT_HOOK_TIMEOUT`` (>= 10s). This guards against regressing back to the
+tight values.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from empirica.cli.command_handlers import setup_claude_code as scc
+
+# The lightweight hooks that must run on the generous timeout.
+_TIGHT_HOOKS = {
+    "tool-router.py",
+    "context-shift-tracker.py",
+    "session-monitor-arm.py",
+    "loop-install-pickup.py",
+    "loop-uninstall-pickup.py",
+    "listener-install-pickup.py",
+    "listener-uninstall-pickup.py",
+}
+
+
+def _collect_hook_timeouts(settings: dict) -> dict[str, int]:
+    """Map hook-script basename → timeout across all generated events."""
+    found: dict[str, int] = {}
+    for entries in settings["hooks"].values():
+        for entry in entries:
+            for h in entry.get("hooks", []):
+                cmd = h.get("command", "")
+                for name in _TIGHT_HOOKS:
+                    if name in cmd:
+                        found[name] = h.get("timeout")
+    return found
+
+
+def test_light_hook_timeout_is_generous():
+    assert scc.LIGHT_HOOK_TIMEOUT >= 10
+
+
+def test_tight_hooks_generated_with_light_timeout():
+    settings: dict = {"hooks": {}}
+    scc._register_all_hooks(settings, Path("/plugin"), "python3", "json")
+
+    timeouts = _collect_hook_timeouts(settings)
+    assert timeouts, "expected to find the lightweight hooks in generated settings"
+    for name, t in timeouts.items():
+        assert t == scc.LIGHT_HOOK_TIMEOUT, f"{name} timeout={t}, expected {scc.LIGHT_HOOK_TIMEOUT}"
+        assert t >= 10, f"{name} timeout={t} is too tight (restart-herd drops context injection)"
+
+
+def test_heavy_hooks_keep_their_own_timeouts():
+    """The compaction / session-init / postflight hooks must NOT be lowered to
+    the light timeout — they legitimately need their larger budgets."""
+    settings: dict = {"hooks": {}}
+    scc._register_all_hooks(settings, Path("/plugin"), "python3", "json")
+
+    heavy_seen = {}
+    for entries in settings["hooks"].values():
+        for entry in entries:
+            for h in entry.get("hooks", []):
+                cmd = h.get("command", "")
+                for name in ("pre-compact.py", "post-compact.py", "session-init.py"):
+                    if name in cmd:
+                        heavy_seen[name] = h.get("timeout")
+    assert heavy_seen, "expected heavy hooks present"
+    for name, t in heavy_seen.items():
+        assert t >= 20, f"{name} timeout={t} unexpectedly low"


### PR DESCRIPTION
**T6** — the final PR of the liveness sequence (after #194–#197). From the mesh-support field report's "separate but related" item.

## Problem

`setup-claude-code` generated the lightweight per-prompt / per-SessionStart hooks — tool-router (3s), context-shift tracker, session-monitor-arm, and the loop/listener install+uninstall pickups (5s) — at very tight timeouts. On a many-instance restart-herd box (high load, slow cold Python starts) those hooks timed out and **Claude Code silently discarded their stdout** — so their context injection never landed. The heavy hooks (compaction, session-init, postflight) were already at 10–30s.

## Fix

A single `LIGHT_HOOK_TIMEOUT = 10` constant for all the lightweight hooks — documents intent and gives one tuning knob — replacing the scattered `3`/`5` literals. All remain `allowFailure=True`, so a generous ceiling only helps; the heavy hooks keep their own larger explicit budgets.

(The peer also suggested per-hook internal cortex-call timeouts as an "and/or" — that's a deeper per-hook change, deferred; the timeout bump is the targeted fix for the silent-drop.)

## Verification

- Tests: `_register_all_hooks` generates every tight hook at `LIGHT_HOOK_TIMEOUT` (≥10); heavy hooks keep ≥20
- 35 setup-area tests pass; ruff check + format + pyright clean

## Sequence complete

T1 #194 · T2+T3 #195 · T4 #196 · T5 #197 · **T6 (this)**. All six liveness items shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)