### PR TITLE
fix(provisioning): pin empirica-mcp to core + doctor surfaces full noetic toolchain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   be made visible to the cockpit again on demand.
 
 ### Fixed
+- **empirica-mcp pinned to its core version (drift footgun)** — `empirica-mcp`
+  declared a loose `empirica>=` dep, so `pipx upgrade empirica-mcp` could bump the
+  thin wrapper while leaving the `empirica` core several versions stale — silently
+  serving an old tool set (the real cause of "enhanced noetic tools missing" on a
+  recently-upgraded box). The dep is now pinned `empirica==<matching version>`,
+  and `release.py` bumps the pin in lockstep with the package version, so wrapper
+  and core can never diverge. An integrity test guards the `==` pin.
+- **`empirica doctor` surfaces the full optional noetic toolchain** — the Sentinel
+  allowlists rg/fd/yq/gron/ast-grep/bat/tokei/scc ahead of install, but `doctor`
+  only reported a subset, so practitioners could be told a tool was available when
+  it wasn't. `doctor`'s noetic-tools check now mirrors the allowlist (adds
+  gron/bat/tokei/scc) and reports each as present/missing with an install hint —
+  optional, never a hard failure (no auto-install).
 - **Multiplexer-agnostic cockpit liveness** — `status` / `status --all` and the
   cockpit TUI no longer under-report instances running Claude under a non-tmux
   multiplexer (GNU screen, WezTerm, zellij, cmux), or after `claude --resume` /

--- a/empirica-mcp/pyproject.toml
+++ b/empirica-mcp/pyproject.toml
@@ -23,8 +23,12 @@ classifiers = [
 ]
 
 dependencies = [
-    "empirica>=1.7.0",  # Main package (1.8.14 co-released)
-    "mcp>=1.25.0",      # MCP SDK (python-multipart CVE-2026-24486 fix in 1.25+)
+    # PINNED to the exact core version (not >=): empirica-mcp is a thin wrapper
+    # over the empirica CLI, so a loose constraint let `pipx upgrade empirica-mcp`
+    # bump the wrapper while leaving core stale — silently serving a 3-version-old
+    # tool set. release.py bumps this pin in lockstep with the version field below.
+    "empirica==1.12.8",  # keep == in lockstep with [project].version
+    "mcp>=1.25.0",       # MCP SDK (python-multipart CVE-2026-24486 fix in 1.25+)
 ]
 
 [project.urls]

--- a/empirica/cli/command_handlers/doctor.py
+++ b/empirica/cli/command_handlers/doctor.py
@@ -153,12 +153,20 @@ def check_noetic_tools() -> Check:
     # (binaries, human description). fd is `fdfind` on Debian/Ubuntu; ast-grep's
     # short alias `sg` is deliberately NOT probed (it collides with the setgroups
     # command), so only the full `ast-grep` name counts as present.
+    # Mirrors the Sentinel's optional noetic allowlist (SAFE_BASH_PREFIXES) so
+    # every tool that's allowlisted-ahead-of-install is surfaced here — closing
+    # the "told it's available when it isn't" gap. rg/fd/yq/ast-grep are the
+    # priority recon set; gron/bat/tokei/scc are the lower-tier extras.
     tools: dict[str, tuple[list[str], str]] = {
         "rg": (["rg"], "ripgrep — fast, gitignore-aware search"),
         "fd": (["fd", "fdfind"], "fast, gitignore-aware file find"),
         "jq": (["jq"], "JSON query"),
         "yq": (["yq"], "YAML query"),
         "ast-grep": (["ast-grep"], "structural / AST-aware code search"),
+        "gron": (["gron"], "flatten JSON to greppable paths"),
+        "bat": (["bat", "batcat"], "syntax-highlighted file view"),
+        "tokei": (["tokei"], "fast LOC / code stats"),
+        "scc": (["scc"], "code counter + complexity"),
     }
     present: dict[str, str | None] = {}
     for label, spec in tools.items():

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -368,6 +368,13 @@ class ReleaseManager:
                 r'^version\s*=\s*"[^"]+"',
                 f'version = "{self.version}"',
             ),
+            # empirica-mcp pins its core dep with == (anti-drift); bump it in
+            # lockstep so the wrapper always requires the matching core version.
+            (
+                self.repo_root / "empirica-mcp" / "pyproject.toml",
+                r'"empirica==[0-9]+\.[0-9]+\.[0-9]+"',
+                f'"empirica=={self.version}"',
+            ),
             (
                 self.repo_root / "scripts" / "install.py",
                 r'EMPIRICA_VERSION\s*=\s*"[^"]+"',

--- a/tests/integrity/test_version_consistency.py
+++ b/tests/integrity/test_version_consistency.py
@@ -61,6 +61,22 @@ class TestVersionConsistency:
             f"expected {canonical_version!r} (from pyproject.toml)"
         )
 
+    def test_mcp_core_dep_pinned_to_version(self, canonical_version: str) -> None:
+        """empirica-mcp must pin its core dep with == to the current version, not
+        a loose >=. A loose constraint let `pipx upgrade empirica-mcp` bump the
+        wrapper while leaving empirica core stale (the version-drift footgun)."""
+        mcp_pyproject = PROJECT_ROOT / "empirica-mcp" / "pyproject.toml"
+        content = mcp_pyproject.read_text()
+        # Must be an exact pin on the matching version — reject >=, ~=, etc.
+        assert re.search(rf'"empirica=={re.escape(canonical_version)}"', content), (
+            "empirica-mcp/pyproject.toml must pin 'empirica==" + canonical_version + "' "
+            "(exact, matching core) to prevent wrapper/core version drift"
+        )
+        assert not re.search(r'"empirica>=', content), (
+            "empirica-mcp/pyproject.toml has a loose 'empirica>=' constraint — "
+            "use '==' so the wrapper can't drift from core"
+        )
+
     def test_plugin_json_version_matches(self, canonical_version: str) -> None:
         """pyproject.toml version matches plugin.json version."""
         plugin_json = (

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -77,11 +77,15 @@ def test_check_claude_code_cli_warns_when_missing():
 
 
 def test_check_noetic_tools_passes_when_all_present():
-    # Tier-1 tools all on PATH → PASS.
+    # All allowlisted noetic tools on PATH → PASS.
     with patch("empirica.cli.command_handlers.doctor._which", return_value="/usr/bin/tool"):
         result = check_noetic_tools()
     assert result.status == PASS
-    assert len(result.data["present"]) == 5
+    # Mirrors the Sentinel optional-noetic allowlist: priority recon set
+    # (rg/fd/jq/yq/ast-grep) + extras (gron/bat/tokei/scc).
+    present = result.data["present"]
+    for tool in ("rg", "fd", "jq", "yq", "ast-grep", "gron", "bat", "tokei", "scc"):
+        assert tool in present, f"{tool} should be surfaced by doctor (it's allowlisted)"
 
 
 def test_check_noetic_tools_warns_when_some_missing():


### PR DESCRIPTION
Two local-provisioning correctness items from a mesh-support field report (David-directed calls).

## 1. empirica-mcp version-drift footgun → pin

`empirica-mcp` declared a loose `empirica>=1.7.0`, so `pipx upgrade empirica-mcp` bumped the thin wrapper while leaving `empirica` core several versions stale — silently serving an old tool set (the real cause of "enhanced noetic tools missing" on a recently-upgraded box).

**Fix:** pin `empirica==1.12.8` (matches the package's own version) + add a `release.py` sweep entry so the pin bumps in lockstep with the package version on every release — wrapper and core can't diverge. An integrity test asserts the `==` pin matches the canonical version (and rejects a loose `>=`).

empirica-mcp **stays** (David's call) — it's needed for IDE/GUI MCP surfaces; cortex owns the cross-intelligence/mesh layer, the CLI just wraps essentials.

## 2. doctor surfaces the full optional noetic toolchain

`sentinel-gate` allowlists rg/fd/yq/gron/ast-grep/bat/tokei/scc ahead of install, but `empirica doctor`'s noetic-tools check reported only a subset — so a practitioner could be told a tool was available when it wasn't.

**Fix:** the check now mirrors the allowlist (adds gron/bat/tokei/scc) and reports each present/missing with an install hint. Optional + hint, **no auto-install** (David's call — cross-platform install is too invasive).

## Verification

- Tests: doctor surfaces all 9 allowlisted tools; integrity test guards the `empirica==` pin == canonical version
- 65 doctor + version-consistency tests pass; ruff + pyright clean on all in-scope files (`scripts/release.py` is outside ruff's configured `include`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)