### PR TITLE
fix(sentinel): CHECK survives compaction — resolver self-sources claude_session_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to Empirica will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **CHECK no longer desyncs from its transaction across compaction** — the CLI
+  workflow verbs (`check-submit`, `postflight`) resolved the active transaction
+  with no session key, so the suffix-mismatch fallback never engaged. When a
+  compaction rotated the instance suffix, the open transaction became
+  unresolvable → CHECK was stored *unbound* → the praxic firewall blocked
+  `Write`/`Edit` despite an OPEN transaction (reported on a compacted session).
+  `read_active_transaction_full` now self-sources the durable
+  `claude_session_id` (the tty-anchored, compaction-stable key) when the caller
+  doesn't pass one, so the transaction stays resolvable across suffix/session
+  rotation. Additive — the exact-suffix primary path is unchanged, so the
+  firewall never regresses on the common case.
+
 ## [1.12.9] — 2026-06-30
 
 A cockpit-liveness + local-provisioning hardening release: multi-instance liveness is now multiplexer-agnostic and resume/reuse-safe, `instance prune` reaps superseded ghosts, the empirica-mcp wrapper can no longer drift from core, and `doctor` honestly reports the optional noetic toolchain.

--- a/empirica/utils/session_resolver.py
+++ b/empirica/utils/session_resolver.py
@@ -1281,6 +1281,18 @@ def read_active_transaction_full(claude_session_id: str | None = None) -> dict |
 
     suffix = _get_instance_suffix()
 
+    # Self-source the durable practitioner key when the caller didn't pass one.
+    # CLI verbs (check-submit, postflight, status) call R.transaction_id() /
+    # transaction_read() with no args, leaving claude_session_id=None — which
+    # skips the suffix-mismatch fallback below, so the active transaction is lost
+    # across a compaction that rotated the instance suffix (CHECK then stores
+    # UNBOUND → firewall blocks praxic despite an OPEN transaction). The
+    # tty-anchored session file is stable across compaction (same terminal), so
+    # get_claude_session_id() recovers the key. Exact-suffix primary is unchanged
+    # (it runs first in _find_transaction_file), so the common case never regresses.
+    if claude_session_id is None:
+        claude_session_id = get_claude_session_id()
+
     # Resolve session_id for fallback scanning
     session_id = None
     if claude_session_id:

--- a/tests/test_transaction_dual_key.py
+++ b/tests/test_transaction_dual_key.py
@@ -180,3 +180,47 @@ def test_hook_resolver_mirrors_package(tmp_path):
     assert hook._find_transaction_file(ed, "_tmux_1", None, "cc-1") == p
     # No keys → no cross-talk.
     assert hook._find_transaction_file(ed, "_tmux_9", None, None) is None
+
+
+# ---- read_active_transaction_full: self-sources cc when caller passes none ----
+# 1.12.10: CLI verbs (check-submit, postflight) call R.transaction_id() /
+# transaction_read() with no cc. The resolver must self-source the durable key
+# via get_claude_session_id() so the active transaction survives a compaction
+# that rotated the instance suffix — else CHECK stores UNBOUND and the firewall
+# blocks praxic despite an OPEN transaction.
+
+
+def test_read_full_self_sources_cc_after_suffix_rotation(tmp_path, monkeypatch):
+    proj = tmp_path / "proj"
+    ed = proj / ".empirica"
+    _write_tx(ed, "_tmux_1", transaction_id="tx-1", session_id="es-1", claude_session_id="cc-1", status="open")
+    # Compaction rotated the suffix; the tty-anchored cc is still recoverable.
+    monkeypatch.setattr(sr, "_get_instance_suffix", lambda: "_tmux_9")
+    monkeypatch.setattr(sr, "get_claude_session_id", lambda: "cc-1")
+    monkeypatch.setattr(sr, "get_active_project_path", lambda cc=None: str(proj))
+
+    data = sr.read_active_transaction_full()  # no cc passed — the regression path
+    assert data is not None and data["transaction_id"] == "tx-1"
+
+
+def test_read_full_no_cc_recoverable_returns_none(tmp_path, monkeypatch):
+    """No passed cc AND none recoverable + suffix rotated → None, gracefully."""
+    proj = tmp_path / "proj"
+    ed = proj / ".empirica"
+    _write_tx(ed, "_tmux_1", transaction_id="tx-1", claude_session_id="cc-1", status="open")
+    monkeypatch.setattr(sr, "_get_instance_suffix", lambda: "_tmux_9")
+    monkeypatch.setattr(sr, "get_claude_session_id", lambda: None)
+    monkeypatch.setattr(sr, "get_active_project_path", lambda cc=None: str(proj))
+    assert sr.read_active_transaction_full() is None
+
+
+def test_read_full_explicit_cc_not_overridden_by_self_source(tmp_path, monkeypatch):
+    """An explicitly-passed cc is used as-is; self-source only fills None."""
+    proj = tmp_path / "proj"
+    ed = proj / ".empirica"
+    _write_tx(ed, "_tmux_1", transaction_id="tx-mine", claude_session_id="cc-mine", status="open")
+    monkeypatch.setattr(sr, "_get_instance_suffix", lambda: "_tmux_9")
+    monkeypatch.setattr(sr, "get_claude_session_id", lambda: "cc-other")  # must NOT be used
+    monkeypatch.setattr(sr, "get_active_project_path", lambda cc=None: str(proj))
+    data = sr.read_active_transaction_full(claude_session_id="cc-mine")
+    assert data is not None and data["transaction_id"] == "tx-mine"


### PR DESCRIPTION
Fixes the `check-submit` transaction-bind desync on session compaction (autonomy/mesh-support field report; Philipp). **First fix of 1.12.10.**

## Root cause (grounded, ground-first per David)
The CLI workflow verbs (`check-submit`, `postflight`) call `R.transaction_id()` / `transaction_read()` **with no session key**. `read_active_transaction_full` then leaves *both* `claude_session_id` and the empirica `session_id` `None` — so `_find_transaction_file`'s suffix-mismatch fallback never engages; it's stuck on the exact instance suffix. When a compaction **rotates that suffix**, the OPEN transaction becomes unresolvable → CHECK is stored **unbound** (`transaction_id=None`) → phase stays noetic → the praxic firewall blocks `Write`/`Edit` despite an open transaction.

**It is not key-rotation, and not a new `practitioner_id`** (the report's initial theory, corrected during grounding — David's challenge drove the verification). `claude_session_id` is the right durable key; it simply wasn't being passed to the resolver.

## Fix
`read_active_transaction_full` self-sources the durable `claude_session_id` via `get_claude_session_id()` (tty-anchored, stable across compaction — same terminal) when the caller passes none. The existing B3 dual-key fallback then resolves the transaction by the durable key across suffix/session rotation. **One central change covers all 8 no-arg CLI call sites** (check ×3, postflight ×4).

**Safe:** the exact-suffix primary path runs first and is byte-identical → no firewall regression on the common case; the firewall hook copy already passes cc from its hook payload (unaffected).

## Verification
- +3 tests: self-source resolves after suffix rotation; graceful `None` when cc unrecoverable; explicit cc not overridden by self-source
- 55 resolver-suite tests pass (`test_transaction_dual_key`, `test_session_resolver`, `test_open_transaction_guard`, `test_chat_compact`); ruff + pyright clean

## Remaining for 1.12.10 (separate, smaller)
The secondary `/empirica off` per-instance pause keying by tmux/tty (no-op) — tracked, follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)