### PR TITLE
fix(sentinel): user-facing `empirica off`/`on` — per-instance default + --global

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`empirica off` / `empirica on`** — user-facing Sentinel toggle. `empirica off`
+  pauses the noetic firewall for the current instance (off-the-record);
+  `empirica on` resumes it. Both default to **per-instance** scope (resolved via
+  the same `get_instance_id()` the gate reads) and accept `--global` to widen to
+  all instances (`empirica off --global`). Friendly aliases for
+  `empirica sentinel pause` / `resume`, which also gained `--global`. Recognized
+  as meta-control toggles by the Sentinel gate, so they run even mid-loop — a
+  gate must never block the verb that clears it.
+
 ### Fixed
+- **`/empirica off` no longer silently misses** — the slash command re-implemented
+  instance resolution inline (`TMUX_PANE`/TTY only) and diverged from the
+  canonical resolver the gate reads (which also honors
+  `EMPIRICA_INSTANCE_ID`/`CLAUDE_INSTANCE_ID`, `TERM_SESSION_ID`, `WINDOWID`, and
+  a different TTY key shape). Under the cockpit (which sets `EMPIRICA_INSTANCE_ID`)
+  it wrote a pause file under a name the gate never read, so the pause appeared to
+  succeed but nothing paused. The command now delegates to the canonical
+  `empirica off` / `on` / `sentinel status` CLI — one resolver, writer and reader
+  always agree.
 - **CHECK no longer desyncs from its transaction across compaction** — the CLI
   workflow verbs (`check-submit`, `postflight`) resolved the active transaction
   with no session key, so the suffix-mismatch fallback never engaged. When a

--- a/docs/human/developers/CLI_COMMANDS_UNIFIED.md
+++ b/docs/human/developers/CLI_COMMANDS_UNIFIED.md
@@ -23,8 +23,8 @@
 > dictionary, then running this script.
 
 **Framework version:** 1.12.9
-**Generated:** 2026-06-30 14:11:26 UTC
-**Total commands:** 254 (across 26 categories)
+**Generated:** 2026-06-30 15:38:57 UTC
+**Total commands:** 256 (across 26 categories)
 
 For the most up-to-date detail on any single command, prefer
 `empirica <command> --help` — the generator extracts the same `help`
@@ -76,7 +76,7 @@ require `--session-id` (`project-bootstrap`, `sessions-show`,
 | [issue](#issue) | 6 | `issue-list`, `issue-show`, `issue-handoff`, … |
 | [investigation](#investigation) | 5 | `investigate`, `investigate-create-branch`, `investigate-checkpoint-branch`, … |
 | [monitoring](#monitoring) | 10 | `monitor`, `assess-state`, `trajectory-project`, … |
-| [cockpit](#cockpit) | 14 | `status`, `tui`, `sentinel`, … |
+| [cockpit](#cockpit) | 16 | `status`, `tui`, `off`, … |
 | [skills](#skills) | 3 | `skill-suggest`, `skill-fetch`, `skill-extract` |
 | [architecture](#architecture) | 3 | `assess-component`, `assess-compare`, `assess-directory` |
 | [agents](#agents) | 7 | `agent-spawn`, `agent-report`, `agent-aggregate`, … |
@@ -2823,6 +2823,42 @@ Launch the interactive cockpit (Textual app — clickable controls)
 - `--include-dead` — optional · flag
   Show instances whose Claude process is dead (diagnostic — toggle in-app with D)
 
+#### `empirica off`
+
+Pause the Sentinel for this instance (off-the-record). Add --global to pause all instances.
+
+**Arguments:**
+
+- `--reason` — optional
+  Optional human-readable reason for the pause
+- `--instance` — optional
+  Target instance_id OR a practice ai_id (resolved to its live runtime instance; no-match or ambiguous resolution fails loud)
+- `--session` — optional
+  Target the live instance running this claude_session_id
+- `--all` — optional · flag
+  Fan out across ALL live instances of the resolved practice (required when an ai_id maps to >1 live instance)
+- `--global` — optional · flag
+  Target the single global pause file (pauses the Sentinel for ALL instances, present and future). Broadest scope — overrides --instance/--all.
+- `--output` — optional · type=`choice` · choices={human, json} · default=`human`
+  Output format (default: human)
+
+#### `empirica on`
+
+Resume the Sentinel for this instance (back on-the-record). Add --global for the global pause file.
+
+**Arguments:**
+
+- `--instance` — optional
+  Target instance_id OR a practice ai_id (resolved to its live runtime instance; no-match or ambiguous resolution fails loud)
+- `--session` — optional
+  Target the live instance running this claude_session_id
+- `--all` — optional · flag
+  Fan out across ALL live instances of the resolved practice (required when an ai_id maps to >1 live instance)
+- `--global` — optional · flag
+  Target the single global pause file (pauses the Sentinel for ALL instances, present and future). Broadest scope — overrides --instance/--all.
+- `--output` — optional · type=`choice` · choices={human, json} · default=`human`
+  Output format (default: human)
+
 #### `empirica sentinel`
 
 Sentinel pause/resume/status (per-instance noetic firewall control)
@@ -2843,6 +2879,8 @@ Pause Sentinel for an instance
   Target the live instance running this claude_session_id
 - `--all` — optional · flag
   Fan out across ALL live instances of the resolved practice (required when an ai_id maps to >1 live instance)
+- `--global` — optional · flag
+  Target the single global pause file (pauses the Sentinel for ALL instances, present and future). Broadest scope — overrides --instance/--all.
 - `--output` — optional · type=`choice` · choices={human, json} · default=`human`
   Output format (default: human)
 
@@ -2859,6 +2897,8 @@ Resume Sentinel for an instance
   Target the live instance running this claude_session_id
 - `--all` — optional · flag
   Fan out across ALL live instances of the resolved practice (required when an ai_id maps to >1 live instance)
+- `--global` — optional · flag
+  Target the single global pause file (pauses the Sentinel for ALL instances, present and future). Broadest scope — overrides --instance/--all.
 - `--output` — optional · type=`choice` · choices={human, json} · default=`human`
   Output format (default: human)
 
@@ -2875,6 +2915,8 @@ Show Sentinel pause state
   Target the live instance running this claude_session_id
 - `--all` — optional · flag
   Fan out across ALL live instances of the resolved practice (required when an ai_id maps to >1 live instance)
+- `--global` — optional · flag
+  Target the single global pause file (pauses the Sentinel for ALL instances, present and future). Broadest scope — overrides --instance/--all.
 - `--output` — optional · type=`choice` · choices={human, json} · default=`human`
   Output format (default: human)
 

--- a/docs/human/end-users/EMPIRICA_NATURAL_LANGUAGE_GUIDE.md
+++ b/docs/human/end-users/EMPIRICA_NATURAL_LANGUAGE_GUIDE.md
@@ -70,8 +70,13 @@ to guide the conversation:
 ### The `/empirica` Command
 
 Type `/empirica status` at any time to see the full epistemic state, or:
-- `/empirica on` — Enable tracking
-- `/empirica off` — Pause tracking (for exploratory chat)
+- `/empirica on` — Resume tracking (this instance)
+- `/empirica off` — Pause tracking for exploratory chat (this instance)
+
+These default to the current instance, so pausing one terminal/pane doesn't
+silence the others. Add `--global` (`/empirica off --global`) to pause every
+instance at once. The same toggle is available straight from the shell as
+`empirica off` / `empirica on`.
 
 ---
 

--- a/empirica/cli/cli_core.py
+++ b/empirica/cli/cli_core.py
@@ -136,6 +136,8 @@ from .command_handlers.cockpit_commands import (
     handle_listener_group_command,
     handle_loop_group_command,
     handle_sentinel_group_command,
+    handle_sentinel_pause_command,
+    handle_sentinel_resume_command,
     handle_tui_command,
 )
 from .command_handlers.cockpit_commands import (
@@ -476,6 +478,8 @@ _HELP_CATEGORIES = {
     "cockpit": [
         "status",
         "tui",
+        "off",
+        "on",
         "sentinel",
         "loop",
         "listener",
@@ -755,6 +759,10 @@ def main(args=None):
             "practitioner": handle_practitioner_group_command,
             "status": handle_cockpit_status_command,
             "tui": handle_tui_command,
+            # User-facing Sentinel toggle (friendly aliases for sentinel pause/resume).
+            # Per-instance by default; --global widens to all instances.
+            "off": handle_sentinel_pause_command,
+            "on": handle_sentinel_resume_command,
             # Chat (single-instance collaborative epistemic workspace)
             # See empirica/docs/architecture/CHAT.md
             "chat": handle_chat_command,

--- a/empirica/cli/command_handlers/cockpit_commands.py
+++ b/empirica/cli/command_handlers/cockpit_commands.py
@@ -104,6 +104,8 @@ def _resolve_sentinel_targets(args) -> list[str | None]:
       - [id1, id2, ...] → --all fan-out across a practice's live instances
 
     Resolution order:
+      0. --global → [None] (the single global pause file the gate reads for ALL
+         instances). Broadest scope — wins over any narrower selector.
       1. No --instance / --session / --all → [get_instance_id()] (may be None →
          global), preserving the pre-① default.
       2. --session <claude_session_id>     → the live instance running it.
@@ -120,6 +122,14 @@ def _resolve_sentinel_targets(args) -> list[str | None]:
     requested = getattr(args, "instance", None)
     session = getattr(args, "session", None)
     want_all = bool(getattr(args, "all", False))
+    want_global = bool(getattr(args, "global_scope", False))
+
+    # --global forces the single global pause file (~/.empirica/sentinel_paused),
+    # which the gate reads for EVERY instance. It is the broadest scope, so it
+    # wins over any narrower selector — `empirica off --global` means "pause
+    # everything" regardless of the current instance / --instance / --all.
+    if want_global:
+        return [None]
 
     if not requested and not session and not want_all:
         return [get_instance_id()]  # may be None → global pause (unchanged)

--- a/empirica/cli/parsers/cockpit_parsers.py
+++ b/empirica/cli/parsers/cockpit_parsers.py
@@ -52,11 +52,19 @@ def _add_sentinel_target(parser):
         help="Fan out across ALL live instances of the resolved practice "
         "(required when an ai_id maps to >1 live instance)",
     )
+    parser.add_argument(
+        "--global",
+        dest="global_scope",
+        action="store_true",
+        help="Target the single global pause file (pauses the Sentinel for ALL "
+        "instances, present and future). Broadest scope — overrides --instance/--all.",
+    )
 
 
 def add_cockpit_parsers(subparsers):
     """Register sentinel/loop/listener/instance/practitioner groups + top-level status + tui."""
     _add_sentinel_group(subparsers)
+    _add_offon_aliases(subparsers)
     _add_loop_group(subparsers)
     _add_listener_group(subparsers)
     _add_instance_group(subparsers)
@@ -200,6 +208,35 @@ def _add_sentinel_group(subparsers):
     status = sentinel_subs.add_parser("status", help="Show Sentinel pause state")
     _add_sentinel_target(status)
     _add_output(status)
+
+
+def _add_offon_aliases(subparsers):
+    """Top-level `empirica off` / `empirica on` — the user-facing Sentinel toggle.
+
+    Friendly aliases for `sentinel pause` / `sentinel resume`. Default scope is
+    the current instance (per-instance, resolved via the same get_instance_id()
+    the gate reads — so the pause file the writer creates is exactly the one the
+    gate looks for). `--global` widens to all instances.
+
+    These are dispatched to handle_sentinel_pause_command / _resume_command in
+    cli_core, and recognized as meta-control toggles by sentinel-gate's
+    is_toggle_command so they run even mid-loop / when the gate is otherwise
+    holding (a gate must never block the verb that clears it).
+    """
+    off = subparsers.add_parser(
+        "off",
+        help="Pause the Sentinel for this instance (off-the-record). Add --global to pause all instances.",
+    )
+    off.add_argument("--reason", help="Optional human-readable reason for the pause")
+    _add_sentinel_target(off)
+    _add_output(off)
+
+    on = subparsers.add_parser(
+        "on",
+        help="Resume the Sentinel for this instance (back on-the-record). Add --global for the global pause file.",
+    )
+    _add_sentinel_target(on)
+    _add_output(on)
 
 
 def _add_loop_group(subparsers):

--- a/empirica/plugins/claude-code-integration/commands/empirica.md
+++ b/empirica/plugins/claude-code-integration/commands/empirica.md
@@ -1,190 +1,71 @@
 ---
 description: "Toggle Empirica tracking on/off, check sentinel status, fix OFF-RECORD statusline. Use when: 'sentinel paused', 'sentinel off', 'turn off empirica', 'pause tracking', 'go off record', 'why is statusline showing off-record', 'empirica status', '/empirica on', '/empirica off'. Controls sentinel_paused file (NOT sentinel_enabled)."
-allowed-tools: ["Bash(empirica *)", "Bash(python3 *)", "Bash(cat *)", "Bash(rm *)", "Read"]
+allowed-tools: ["Bash(empirica *)"]
 ---
 
 # /empirica - Epistemic Tracking Toggle (Per-Instance)
 
-**Arguments:** `on` | `off` | `status`
+**Arguments:** `on` | `off` | `status` (add `--global` to `on`/`off` to affect ALL instances)
 
-**Instance Isolation:** Each tmux pane / terminal gets its own pause state.
-- Instance file: `~/.empirica/sentinel_paused_{instance_id}`
-- Global file: `~/.empirica/sentinel_paused` (pauses ALL instances)
+**This command delegates to the canonical `empirica` CLI** (`empirica off` /
+`empirica on` / `empirica sentinel status`). The CLI resolves the instance
+exactly the way the Sentinel gate does — via `session_resolver.get_instance_id()`
+(`EMPIRICA_INSTANCE_ID` → `TMUX_PANE` → `TERM_SESSION_ID` → `WINDOWID` → TTY).
+Do **NOT** re-implement instance resolution inline: a divergent resolver writes a
+pause file under a name the gate never reads, so the pause silently misses (the
+exact bug this command used to have).
+
+**Scope:**
+- Default = **this instance only** (`~/.empirica/sentinel_paused_{instance_id}`).
+- `--global` = **all instances** (`~/.empirica/sentinel_paused`).
+
+These verbs are recognized as meta-control toggles by `sentinel-gate.py`, so they
+run even mid-loop / when the gate is otherwise holding (a gate must never block
+the verb that clears it).
 
 ## For `/empirica off`:
 
-1. Write the instance-specific signal file (allowed at any time, including during open loops):
+Pause this instance (or all instances with `--global`). Pass through `--global`
+only if the user explicitly asked to turn Empirica off everywhere.
+
 ```bash
-python3 -c "
-import json, time, os
-from pathlib import Path
+# this instance only (default)
+empirica off --reason "User requested /empirica off"
 
-# Get instance ID for per-instance isolation
-def get_instance_id():
-    tmux_pane = os.environ.get('TMUX_PANE')
-    if tmux_pane:
-        return f'tmux_{tmux_pane.lstrip(\"%\")}'
-    try:
-        import subprocess
-        result = subprocess.run(['tty'], capture_output=True, text=True, timeout=2)
-        if result.returncode == 0:
-            tty = result.stdout.strip()
-            if tty and tty != 'not a tty':
-                return tty.replace('/dev/', '').replace('/', '-')
-    except:
-        pass
-    return None
-
-base = Path.home() / '.empirica'
-instance_id = get_instance_id()
-if instance_id:
-    safe_id = instance_id.replace('/', '-').replace('%', '')
-    pause_file = base / f'sentinel_paused_{safe_id}'
-else:
-    pause_file = base / 'sentinel_paused'
-
-signal = {
-    'paused_at': time.time(),
-    'paused_at_iso': time.strftime('%Y-%m-%dT%H:%M:%S%z'),
-    'reason': 'User requested /empirica off',
-    'session_id': '$(echo $EMPIRICA_SESSION_ID)',
-    'instance_id': instance_id
-}
-base.mkdir(parents=True, exist_ok=True)
-pause_file.write_text(json.dumps(signal, indent=2))
-print(f'Signal file written: {pause_file.name}')
-"
+# OR, if the user said "turn off empirica everywhere / globally":
+# empirica off --global --reason "User requested /empirica off --global"
 ```
 
-4. Log the transition:
-```bash
-empirica finding-log --session-id $EMPIRICA_SESSION_ID --finding "Empirica tracking paused (off-the-record). Reason: user requested." --impact 0.3 --subject "empirica-toggle"
-```
-
-5. Confirm: **Empirica is now OFF-THE-RECORD (this instance only).** Sentinel enforcement paused. Use `/empirica on` to resume.
+Then confirm to the user: **Empirica is now OFF-THE-RECORD (this instance — or
+"all instances" if `--global`).** Sentinel enforcement paused. Use `/empirica on`
+to resume.
 
 ## For `/empirica on`:
 
-1. Check if paused (instance-specific or global):
+Resume this instance (or clear the global pause with `--global`).
+
 ```bash
-python3 -c "
-import json, time, os
-from pathlib import Path
+# this instance only (default)
+empirica on
 
-def get_instance_id():
-    tmux_pane = os.environ.get('TMUX_PANE')
-    if tmux_pane:
-        return f'tmux_{tmux_pane.lstrip(\"%\")}'
-    try:
-        import subprocess
-        result = subprocess.run(['tty'], capture_output=True, text=True, timeout=2)
-        if result.returncode == 0:
-            tty = result.stdout.strip()
-            if tty and tty != 'not a tty':
-                return tty.replace('/dev/', '').replace('/', '-')
-    except:
-        pass
-    return None
-
-base = Path.home() / '.empirica'
-global_file = base / 'sentinel_paused'
-instance_id = get_instance_id()
-instance_file = None
-if instance_id:
-    safe_id = instance_id.replace('/', '-').replace('%', '')
-    instance_file = base / f'sentinel_paused_{safe_id}'
-
-# Check instance-specific first
-if instance_file and instance_file.exists():
-    data = json.loads(instance_file.read_text())
-    gap = int(time.time() - data.get('paused_at', time.time()))
-    print(f'Was off-record for {gap // 60}m (instance: {instance_id})')
-    instance_file.unlink()
-    print('Instance signal file removed')
-elif global_file.exists():
-    # Note: We don't remove global file from /empirica on - that would unpause ALL instances
-    print('Global pause is active. To unpause all instances, remove ~/.empirica/sentinel_paused')
-    print('This instance cannot override global pause.')
-else:
-    print('Not paused')
-"
+# OR, to clear a global pause:
+# empirica on --global
 ```
 
-2. If **not paused**: Empirica is already on-the-record. No change needed.
+The CLI reports whether anything was actually paused (and, when resuming an
+instance while a global pause still applies, that the global pause is still in
+effect). Relay that to the user.
 
-3. Log the transition (only if was paused):
-```bash
-empirica finding-log --session-id $EMPIRICA_SESSION_ID --finding "Empirica tracking resumed (on-the-record). Gap: <DURATION>." --impact 0.3 --subject "empirica-toggle"
-```
-
-4. Confirm: **Empirica is now ON-THE-RECORD.** Sentinel enforcement resumed. Run PREFLIGHT to start a new epistemic loop.
+Confirm: **Empirica is now ON-THE-RECORD.** Sentinel enforcement resumed. Run
+PREFLIGHT to start a new epistemic loop.
 
 ## For `/empirica status`:
 
-1. Check pause state (both instance-specific and global):
+Show the current pause state (instance + global) for this instance.
+
 ```bash
-python3 -c "
-import json, time, os
-from pathlib import Path
-
-def get_instance_id():
-    tmux_pane = os.environ.get('TMUX_PANE')
-    if tmux_pane:
-        return f'tmux_{tmux_pane.lstrip(\"%\")}'
-    try:
-        import subprocess
-        result = subprocess.run(['tty'], capture_output=True, text=True, timeout=2)
-        if result.returncode == 0:
-            tty = result.stdout.strip()
-            if tty and tty != 'not a tty':
-                return tty.replace('/dev/', '').replace('/', '-')
-    except:
-        pass
-    return None
-
-base = Path.home() / '.empirica'
-global_file = base / 'sentinel_paused'
-instance_id = get_instance_id()
-
-print(f'Instance: {instance_id or \"(no instance ID)\"}')
-print()
-
-# Check global first
-if global_file.exists():
-    try:
-        data = json.loads(global_file.read_text())
-        gap = int(time.time() - data.get('paused_at', time.time()))
-        print(f'GLOBAL: OFF-RECORD (all instances paused {gap // 60}m ago)')
-    except:
-        print('GLOBAL: OFF-RECORD (pause file exists)')
-else:
-    print('GLOBAL: ON-RECORD')
-
-# Check instance-specific
-if instance_id:
-    safe_id = instance_id.replace('/', '-').replace('%', '')
-    instance_file = base / f'sentinel_paused_{safe_id}'
-    if instance_file.exists():
-        try:
-            data = json.loads(instance_file.read_text())
-            gap = int(time.time() - data.get('paused_at', time.time()))
-            print(f'INSTANCE: OFF-RECORD (paused {gap // 60}m ago)')
-        except:
-            print('INSTANCE: OFF-RECORD (pause file exists)')
-    else:
-        print('INSTANCE: ON-RECORD')
-
-# Summary
-print()
-if global_file.exists():
-    print('=> Sentinel enforcement: PAUSED (global)')
-elif instance_id:
-    safe_id = instance_id.replace('/', '-').replace('%', '')
-    if (base / f'sentinel_paused_{safe_id}').exists():
-        print('=> Sentinel enforcement: PAUSED (this instance)')
-    else:
-        print('=> Sentinel enforcement: ACTIVE')
-else:
-    print('=> Sentinel enforcement: ACTIVE')
-"
+empirica sentinel status
 ```
+
+Relay the reported scope (`instance` / `global` / `none`) and, if paused, how
+long it has been off-the-record.

--- a/empirica/plugins/claude-code-integration/hooks/sentinel-gate.py
+++ b/empirica/plugins/claude-code-integration/hooks/sentinel-gate.py
@@ -777,7 +777,31 @@ def is_toggle_command(command: str) -> str | None:
     """
     cmd = command.lstrip()
 
-    # Detect pause file write (python3 -c "..." writing sentinel_paused)
+    # Canonical CLI toggle verbs — the user-facing Sentinel pause/resume surface:
+    #   empirica off [...]             → pause   (per-instance, or --global)
+    #   empirica on  [...]             → unpause
+    #   empirica sentinel pause [...]  → pause
+    #   empirica sentinel resume [...] → unpause
+    # Token-exact (whitespace split) so `empirica onboarding`/`empirica offline-*`
+    # do NOT match `on`/`off`. Meta-control: a gate must never block the verb that
+    # clears it, and the toggle can ONLY pause/unpause the Sentinel (no arbitrary
+    # praxic effect), so this self-exemption is prompt-injection-safe.
+    tokens = cmd.split()
+    if len(tokens) >= 2 and tokens[0] == "empirica":
+        verb = tokens[1]
+        if verb == "off":
+            return "pause"
+        if verb == "on":
+            return "unpause"
+        if verb == "sentinel" and len(tokens) >= 3:
+            sub = tokens[2]
+            if sub == "pause":
+                return "pause"
+            if sub in ("resume", "unpause"):
+                return "unpause"
+
+    # Legacy: the pre-delegation slash command wrote the pause file via inline
+    # python3 -c "...". Kept for back-compat with un-upgraded command files.
     if "sentinel_paused" in cmd and ("write_text" in cmd or "open(" in cmd):
         return "pause"
 

--- a/tests/test_sentinel_release_path.py
+++ b/tests/test_sentinel_release_path.py
@@ -117,6 +117,71 @@ def test_not_exempt_non_recovery_empirica(sg):
     assert _bash(sg, "empirica session-create --ai-id x") is False
 
 
+# ---- user-facing toggle: empirica off / on (and sentinel pause/resume) ------
+# The Sentinel must never block the verb that pauses/clears it. These run as
+# meta-control even mid-loop, via is_toggle_command self-exemption.
+
+
+@pytest.mark.parametrize(
+    "command,expected",
+    [
+        ("empirica off", "pause"),
+        ("empirica off --global", "pause"),
+        ("empirica off --reason 'exploratory chat'", "pause"),
+        ("empirica on", "unpause"),
+        ("empirica on --global", "unpause"),
+        ("empirica sentinel pause", "pause"),
+        ("empirica sentinel pause --instance tmux_3", "pause"),
+        ("empirica sentinel resume", "unpause"),
+        ("empirica sentinel resume --global", "unpause"),
+        # legacy inline-python form (un-upgraded command files) still recognized
+        ("python3 -c \"open('x/sentinel_paused','w')\"", "pause"),
+        ("rm /home/u/.empirica/sentinel_paused_tmux_3", "unpause"),
+    ],
+)
+def test_toggle_command_recognized(sg, command, expected):
+    assert sg.is_toggle_command(command) == expected
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # token-exact: must NOT collide with onboarding / status / other verbs
+        "empirica onboarding",
+        "empirica onboarding start",
+        "empirica sentinel status",
+        "empirica offline-export",  # hypothetical: 'off' is a prefix, not the token
+        "empirica status",
+    ],
+)
+def test_toggle_command_no_false_positive(sg, command):
+    assert sg.is_toggle_command(command) is None
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "empirica off",
+        "empirica off --global",
+        "empirica on",
+        "empirica on --global",
+        "empirica sentinel pause",
+        "empirica sentinel resume",
+    ],
+)
+def test_toggle_verbs_are_exempt_pre_gate(sg, command):
+    # The toggle short-circuits _is_recovery_or_measurement_action (always-open
+    # before every gate), so the pause/resume verb runs even when the gate holds.
+    assert _bash(sg, command) is True
+
+
+def test_onboarding_not_exempt_via_toggle(sg):
+    # onboarding is NOT a toggle — it must not ride the toggle exemption. (It may
+    # or may not be exempt by other rules; here we only assert the toggle path
+    # does not grant it.)
+    assert sg.is_toggle_command("empirica onboarding") is None
+
+
 def test_not_exempt_plain_praxic_bash(sg):
     assert _bash(sg, "rm -rf /tmp/foo") is False
     assert _bash(sg, "git commit -m x") is False

--- a/tests/test_sentinel_target_resolve.py
+++ b/tests/test_sentinel_target_resolve.py
@@ -25,7 +25,14 @@ def _inst(instance_id, ai_id=None, session_id=None):
 
 
 def _args(**kw):
-    base = {"instance": None, "session": None, "all": False, "output": "json", "reason": None}
+    base = {
+        "instance": None,
+        "session": None,
+        "all": False,
+        "global_scope": False,
+        "output": "json",
+        "reason": None,
+    }
     base.update(kw)
     return types.SimpleNamespace(**base)
 
@@ -58,6 +65,23 @@ def test_no_selector_global_when_no_current(monkeypatch, patch_live):
 def test_direct_instance_id_passthrough(patch_live):
     patch_live(_inst("tmux_3", ai_id="empirica"), _inst("tmux_8", ai_id="cortex"))
     assert cc._resolve_sentinel_targets(_args(instance="tmux_3")) == ["tmux_3"]
+
+
+# ── --global scope (empirica off --global) ───────────────────────────────────
+
+
+def test_global_resolves_to_none(monkeypatch):
+    # --global → [None] → the single global pause file the gate reads for ALL
+    # instances. No live-instance lookup needed; current instance is irrelevant.
+    monkeypatch.setattr(cc, "get_instance_id", lambda: "tmux_5")
+    assert cc._resolve_sentinel_targets(_args(global_scope=True)) == [None]
+
+
+def test_global_overrides_narrower_selectors(patch_live):
+    # --global is the broadest scope: it wins even when --instance / --all are set.
+    patch_live(_inst("tmux_3", ai_id="empirica"), _inst("tmux_8", ai_id="empirica"))
+    assert cc._resolve_sentinel_targets(_args(global_scope=True, instance="tmux_3")) == [None]
+    assert cc._resolve_sentinel_targets(_args(global_scope=True, all=True)) == [None]
 
 
 # ── ai_id resolution (the fix) ───────────────────────────────────────────────


### PR DESCRIPTION
## Problem

`/empirica off` was broken for the user. The slash command re-implemented instance resolution **inline** (`TMUX_PANE` → `tmux_{pane}`, TTY → `pts-6`) and diverged from the canonical `session_resolver.get_instance_id()` that the Sentinel gate actually reads. The canonical resolver also honors `EMPIRICA_INSTANCE_ID`/`CLAUDE_INSTANCE_ID` (the cockpit-blessed override the cockpit **sets**), `TERM_SESSION_ID`, `WINDOWID`, and uses `term_{tty_key}` for TTY.

Under the cockpit, the slash command wrote `sentinel_paused_tmux_X` while the gate looked for `sentinel_paused_<slot>` → the pause **appeared** to succeed but nothing actually paused. Classic two-sources-of-truth drift.

## Fix

- **`empirica off` / `empirica on`** — new top-level CLI, friendly aliases for `sentinel pause` / `resume`. **Per-instance by default** (canonical resolver, so writer and gate-reader always agree); **`--global`** widens to all instances.
- **`--global`** added to the sentinel target resolver + `pause`/`resume`/`status` parsers (forces the single global pause file the gate reads for every instance; broadest scope, overrides narrower selectors).
- **Slash command delegates** to the canonical CLI (`empirica off` / `on` / `sentinel status`) — no more inline resolver. One source of truth.
- **`is_toggle_command`** in `sentinel-gate.py` now token-recognizes `empirica off|on` and `sentinel pause|resume`, so they run even mid-loop / when the gate holds (a gate must never block the verb that clears it). Token-exact → `empirica onboarding` ≠ `empirica on`. Self-exemption is injection-safe: the toggle can only pause/unpause.

## Verification

- Round-tripped live: `empirica off` → `sentinel_paused_tmux_0` (the exact name the gate reads), `empirica on` clears it; `--global` writes/clears the global file.
- **72** sentinel tests (`test_sentinel_target_resolve` + `test_sentinel_release_path` + `test_sentinel_recovery_escape`) and **295** cockpit/integrity tests green. ruff clean.
- Regenerated `CLI_COMMANDS_UNIFIED.md`; CHANGELOG + NL guide updated.

## Notes

- The gate change lands in repo source; it deploys to installed hooks on `setup-claude-code`/release (expected).
- Supersedes the long-standing in-progress goal "1.7.3: Fix /empirica off to work WITHIN open loops".

🤖 Generated with [Claude Code](https://claude.com/claude-code)