### PR TITLE
test(autosync): de-flake — spy records only plugin-sync, not all subprocess.run

### DIFF
--- a/tests/test_plugin_autosync.py
+++ b/tests/test_plugin_autosync.py
@@ -30,8 +30,16 @@ def harness(tmp_path, monkeypatch):
     calls: list = []
 
     def _run(*a, **k):
-        calls.append((a, k))
-        return subprocess.CompletedProcess(a[0] if a else [], 0, b"", b"")
+        # Record ONLY the plugin-sync invocation we're actually testing. The
+        # monkeypatch replaces the module-global subprocess.run, so a background
+        # thread (e.g. an inbox poller shelling out to git) that fires mid-test
+        # would otherwise land in `calls` and inflate the count under
+        # pytest-randomly ordering — a real flake. Filtering by command makes
+        # every count assertion order-independent without changing intent.
+        cmd = a[0] if a else k.get("args")
+        if cmd == ["empirica", "plugin-sync"]:
+            calls.append((a, k))
+        return subprocess.CompletedProcess(cmd or [], 0, b"", b"")
 
     monkeypatch.setattr(subprocess, "run", _run)
     return {"home": home, "plugin": plugin, "calls": calls}


### PR DESCRIPTION
## Problem

`test_plugin_autosync`'s harness monkeypatched the module-global `subprocess.run` to a spy that recorded **every** call, then asserted exact totals (`len(calls)==1` / `calls==[]`). Under `pytest-randomly` ordering, a background daemon thread (the loop-scheduler heartbeat/liveness/listener threads) shelling out to git could fire mid-test and land in the spy — inflating the count and failing the assertion. Order-dependent and intermittent (bit CI repeatedly this cycle).

## Fix

The spy now records **only** the `["empirica", "plugin-sync"]` invocation under test, and returns a fake `CompletedProcess` for any other call (so a leaked background subprocess is harmless). Every count assertion is now order-independent and tests the actual contract — *did it shell out to `plugin-sync`?* — without changing intent.

`_maybe_autosync_plugin` itself makes exactly one `subprocess.run` (plugin-sync, on drift), so this is purely test-harness robustness; production behavior is unchanged.

## Verification

- 14 autosync tests green isolated and under `-p randomly`.
- Randomized broad run (autosync + plugin_sync + daemon_project_resolver + noetic_batch_executor, seed 42): 79 passed.
- Test-only change; no user-facing behavior, no CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)