### PR TITLE
fix(listener): `off` recovers teardown handle via Monitor description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   gate must never block the verb that clears it.
 
 ### Fixed
+- **`empirica listener off` can always recover its teardown handle** — when the
+  optional `empirica listener arm <task_id>` step was skipped (e.g. the
+  SessionStart arming flow armed the Monitor but never recorded its id), the
+  active marker kept `monitor_task_id: null`. A live in-session tail Monitor is
+  then neither `TaskStop`-able by id nor reap-able (it isn't a PID-1 orphan
+  while its session lives), so `off` silently reported "never armed" while the
+  Monitor kept running. `listener on` now records the Monitor's `description`
+  in the marker, and `off` falls back to a `TaskList` → match-description →
+  `TaskStop` recovery next_step. The `arm` fast-path (record the id directly) is
+  unchanged.
 - **`/empirica off` no longer silently misses** — the slash command re-implemented
   instance resolution inline (`TMUX_PANE`/TTY only) and diverged from the
   canonical resolver the gate reads (which also honors

--- a/empirica/cli/command_handlers/cockpit_commands.py
+++ b/empirica/cli/command_handlers/cockpit_commands.py
@@ -2123,8 +2123,7 @@ def handle_listener_off_command(args) -> int:
         next_step = {
             "tool": "TaskList",
             "match_description": monitor_description,
-            "then": "TaskStop the matching Monitor task, then run "
-            f"`empirica listener unregister {name}`",
+            "then": f"TaskStop the matching Monitor task, then run `empirica listener unregister {name}`",
             "after_stop": f"empirica listener unregister {name}",
         }
     else:

--- a/empirica/cli/command_handlers/cockpit_commands.py
+++ b/empirica/cli/command_handlers/cockpit_commands.py
@@ -1839,21 +1839,13 @@ def handle_listener_on_command(args) -> int:
     except ValueError as e:
         return _emit(args, {"ok": False, "error": str(e)}, f"error: {e}")
 
-    # Write listener_active_*.json placeholder (monitor_task_id filled by `arm`)
+    # The listener_active_*.json placeholder is written AFTER the Monitor
+    # description is computed below, so the marker can carry monitor_description
+    # — the deterministic teardown handle `off` falls back to when the optional
+    # `arm` step (which records monitor_task_id) was skipped.
     active_path = listener_active_path(instance_id, name)
     active_path.parent.mkdir(parents=True, exist_ok=True)
     import time as _time
-
-    placeholder = {
-        "monitor_task_id": None,  # filled by `empirica listener arm <task_id>`
-        "curl_pid": None,
-        "armed_at": _time.time(),
-        "ai_id": ai_id,
-        "name": name,
-        "topic": entry.topic,
-        "mode": "tail" if persistent_active else "standalone",
-    }
-    active_path.write_text(_json.dumps(placeholder, indent=2), encoding="utf-8")
 
     # Pick the Monitor command based on detection above.
     #
@@ -1912,6 +1904,21 @@ def handle_listener_on_command(args) -> int:
             "(matches listener's relaunch-on-clean-exit design intent; "
             "no systemd/launchd needed)"
         )
+
+    placeholder = {
+        "monitor_task_id": None,  # filled by `empirica listener arm <task_id>`
+        "curl_pid": None,
+        "armed_at": _time.time(),
+        "ai_id": ai_id,
+        "name": name,
+        "topic": entry.topic,
+        "mode": "tail" if persistent_active else "standalone",
+        # The exact Monitor description. `off` uses this to recover the
+        # TaskStop handle (TaskList → match description → TaskStop) when the
+        # optional `arm` step was skipped and monitor_task_id is still null.
+        "monitor_description": description,
+    }
+    active_path.write_text(_json.dumps(placeholder, indent=2), encoding="utf-8")
 
     payload = {
         "ok": True,
@@ -2079,6 +2086,7 @@ def handle_listener_off_command(args) -> int:
         with open(active_path, encoding="utf-8") as f:
             data = _json.load(f)
         monitor_task_id = data.get("monitor_task_id")
+        monitor_description = data.get("monitor_description")
     except (OSError, _json.JSONDecodeError) as e:
         return _emit(
             args,
@@ -2097,19 +2105,44 @@ def handle_listener_off_command(args) -> int:
     except OSError:
         state_file_removed = False
 
+    # Teardown handle resolution, in order of precision:
+    #   1. monitor_task_id (recorded by `arm`)        → TaskStop directly
+    #   2. monitor_description (recorded by `on`)      → TaskList → match → TaskStop
+    #   3. neither (pre-fix marker / standalone)       → unregister-only
+    # Case 2 closes the silent gap: a live in-session Monitor whose `arm`
+    # step was skipped is neither TaskStop-able by id nor reap-able (it is
+    # not a PID-1 orphan while its session lives), so without the description
+    # fallback `off` would report "never armed" while the Monitor kept running.
+    if monitor_task_id:
+        next_step = {
+            "tool": "TaskStop",
+            "args": {"task_id": monitor_task_id},
+            "after_stop": f"empirica listener unregister {name}",
+        }
+    elif monitor_description:
+        next_step = {
+            "tool": "TaskList",
+            "match_description": monitor_description,
+            "then": "TaskStop the matching Monitor task, then run "
+            f"`empirica listener unregister {name}`",
+            "after_stop": f"empirica listener unregister {name}",
+        }
+    else:
+        next_step = {
+            "tool": None,
+            "after_stop": f"empirica listener unregister {name}",
+        }
+
     payload = {
         "ok": True,
         "instance_id": instance_id,
         "name": name,
         "monitor_task_id": monitor_task_id,
+        "monitor_description": monitor_description,
         "state_file": str(active_path),
         "state_file_removed": state_file_removed,
         "reaped_orphans": reaped,
-        "next_step": {
-            "tool": "TaskStop" if monitor_task_id else None,
-            "args": {"task_id": monitor_task_id} if monitor_task_id else None,
-            "after_stop": f"empirica listener unregister {name}",
-        },
+        "next_step": next_step,
     }
     reap_note = f" Reaped {len(reaped)} orphan process(es)." if reaped else ""
     if monitor_task_id:
@@ -2117,10 +2150,18 @@ def handle_listener_off_command(args) -> int:
             f'Listener "{name}" — TaskStop({monitor_task_id}), '
             f"then run `empirica listener unregister {name}`.{reap_note}"
         )
+    elif monitor_description:
+        summary = (
+            f'Listener "{name}" was armed but its monitor_task_id was never '
+            f"recorded (`arm` step skipped). Run TaskList, TaskStop the Monitor "
+            f'matching description "{monitor_description}", then '
+            f"`empirica listener unregister {name}`.{reap_note}"
+        )
     else:
         summary = (
-            f'Listener "{name}" has placeholder task_id (never armed). '
-            f"Run `empirica listener unregister {name}` to clean up.{reap_note}"
+            f'Listener "{name}" has no recorded Monitor handle (pre-fix marker). '
+            f"Run `empirica listener unregister {name}` to clean up; if a tail "
+            f"Monitor is still live, TaskList + TaskStop it manually.{reap_note}"
         )
     return _emit(args, payload, summary)
 

--- a/tests/test_listener_on_arm_off.py
+++ b/tests/test_listener_on_arm_off.py
@@ -445,8 +445,16 @@ def test_off_handles_no_state_file_gracefully(tmp_path, monkeypatch, capsys):
     assert "empirica listener unregister" in out["next_step"]["after_stop"]
 
 
-def test_off_handles_placeholder_task_id(tmp_path, monkeypatch, capsys):
-    """on without arm → state file has null task_id → off emits unregister-only."""
+def test_off_recovers_via_description_when_arm_skipped(tmp_path, monkeypatch, capsys):
+    """on without arm → null task_id → off recovers the teardown handle via
+    the Monitor description (TaskList → match → TaskStop).
+
+    This closes the silent gap: a live in-session Monitor whose `arm` step was
+    skipped is neither TaskStop-able by id (none recorded) nor reap-able (not a
+    PID-1 orphan while its session lives). Without the description fallback,
+    `off` would report 'never armed' while the Monitor kept running. `on` now
+    records monitor_description so `off` can always surface a stop handle.
+    """
     monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
     monkeypatch.setattr("empirica.core.cockpit.listener_registry.EMPIRICA_DIR", tmp_path / ".empirica")
     (tmp_path / ".empirica").mkdir()
@@ -459,7 +467,29 @@ def test_off_handles_placeholder_task_id(tmp_path, monkeypatch, capsys):
     rc = handle_listener_off_command(_make_args(ai_id="myai"))
     assert rc == 0
     out = json.loads(capsys.readouterr().out)
-    # No TaskStop emitted because task_id is null
+    ns = out["next_step"]
+    # Recovery path: no task_id, but the description gives a deterministic handle.
+    assert ns["tool"] == "TaskList"
+    assert ns["match_description"]  # the exact Monitor description to match
+    assert "myai" in ns["match_description"]
+    assert "unregister" in ns["after_stop"]
+
+
+def test_off_unregister_only_for_pre_fix_marker(tmp_path, monkeypatch, capsys):
+    """A pre-fix marker (no monitor_task_id AND no monitor_description) falls
+    back to unregister-only — the old markers that predate the description fix."""
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    monkeypatch.setattr("empirica.core.cockpit.listener_registry.EMPIRICA_DIR", tmp_path / ".empirica")
+    (tmp_path / ".empirica").mkdir()
+    # Hand-write a legacy marker with neither handle.
+    marker = tmp_path / ".empirica" / "listener_active_test_instance_myai-inbox.json"
+    marker.write_text(
+        json.dumps({"monitor_task_id": None, "ai_id": "myai", "name": "myai-inbox", "mode": "tail"}),
+        encoding="utf-8",
+    )
+    rc = handle_listener_off_command(_make_args(ai_id="myai"))
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
     assert out["next_step"]["tool"] is None
     assert "unregister" in out["next_step"]["after_stop"]
 


### PR DESCRIPTION
## The gap (David-spotted)

A live listener marker had `monitor_task_id: null` while a Monitor was clearly running (statusline "1 monitor"). Root cause: `empirica listener on` writes a placeholder marker and a **separate** `empirica listener arm <task_id>` call must record the real Monitor id back. When that step is skipped (e.g. the SessionStart arming flow arms the Monitor but never runs `arm`), the marker keeps `null`.

A live **in-session** tail Monitor is then un-teardownable by `listener off`:
- no `monitor_task_id` → can't `TaskStop` it
- not a PID-1 orphan (its session is alive) → `walk_orphan_listener_processes` won't reap it

So `off` silently reported "never armed, run unregister" while the Monitor kept tailing `loop_fires.log`. Silent.

## Fix

- `listener on` now records the Monitor's exact `description` in the marker.
- `off` resolves a teardown handle in order of precision: `monitor_task_id` (from `arm`) → `monitor_description` (from `on`) → neither (pre-fix marker). The middle case emits a `TaskList` → match-description → `TaskStop` recovery next_step, so `off` always surfaces a way to stop the Monitor.
- `arm` fast-path unchanged; pre-fix markers degrade to unregister-only.

## Other gaps found (logged as findings, not fixed here)

- **Gap B — vestigial `curl_pid`**: the marker field is *read* (pause / uninstall-request) but *never written* by any path → always null; teardown silently relies on the orphan ps-scan instead. Graceful degrade, but a field-that-lies. (finding `304c24be`)
- **Gap C — registry topic drift**: `listener status` reports the registry entry topic, which can be a stale legacy form while the live marker + persistent service use the canonical per-tenant topic. Wakes still work; status misleads. `register()` refreshes topic on re-register, so a fresh `listener on` self-heals it; `mesh migrate-topics` doesn't touch the registry entry. Low severity. (finding `287d7b32`)

Want either of B/C folded in? They're small and self-contained.

## Verification

80 listener tests green (`test_listener_on_arm_off` + `registry` + `processes`), ruff clean. Live proof the listener itself works: a mesh proposal arrived through this exact Monitor mid-investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)