### PR TITLE
feat(engagements): active-by-default org→engagement scoping (SER #183 part-2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Engagement listing is active-by-default** (SER #183 part-2) — the daemon
+  feed `GET /api/v1/engagements` and `empirica engagement-list` now exclude
+  terminal (`closed`) engagements unless you opt in. The org→engagement drill is
+  a "who are we working with now" view; terminal history belongs in the dedicated
+  Engagements area. Opt into the full set with `?include_closed=true` /
+  `--include-closed`, or target a specific state with `?lifecycle=` / `--lifecycle`
+  (an explicit state always wins, so `lifecycle=closed` still returns closed). New
+  `ENGAGEMENT_TERMINAL_STATES` constant makes the terminal set explicit.
+
 ### Added
 - **`empirica off` / `empirica on`** — user-facing Sentinel toggle. `empirica off`
   pauses the noetic firewall for the current instance (off-the-record);

--- a/empirica/api/routes/engagements.py
+++ b/empirica/api/routes/engagements.py
@@ -41,6 +41,11 @@ async def list_engagements(
     org: str | None = Query(None, description="Filter to engagements ticket_of this organization id"),
     domain: str | None = Query(None, description="Filter by engagement domain (support, sales, ...)"),
     lifecycle: str | None = Query(None, description="Filter by lifecycle_state (open, in_progress, blocked, closed)"),
+    include_closed: bool = Query(
+        False,
+        description="Include terminal (closed) engagements. Default false — the feed is "
+        "active-by-default (SER#183 part-2). Ignored when an explicit `lifecycle` is given.",
+    ),
     limit: int = Query(100, ge=1, le=500),
 ):
     """List engagements as EngagementMin[] for the board daemon feed.
@@ -57,7 +62,13 @@ async def list_engagements(
     out: list[dict] = []
     with WorkspaceDBRepository.open() as repo:
         try:
-            rows = repo.list_engagements(org_id=org, domain=domain, lifecycle_state=lifecycle, limit=limit)
+            rows = repo.list_engagements(
+                org_id=org,
+                domain=domain,
+                lifecycle_state=lifecycle,
+                include_closed=include_closed,
+                limit=limit,
+            )
         except ValueError as e:
             # invalid lifecycle_state — surface as a 422, never a 500.
             raise HTTPException(status_code=422, detail=str(e)) from e

--- a/empirica/cli/command_handlers/engagement_commands.py
+++ b/empirica/cli/command_handlers/engagement_commands.py
@@ -111,6 +111,7 @@ def handle_engagement_list_command(args):
                     domain=getattr(args, "domain", None),
                     lifecycle_state=getattr(args, "lifecycle", None),
                     org_id=getattr(args, "org", None),
+                    include_closed=getattr(args, "include_closed", False),
                     limit=getattr(args, "limit", 100),
                 )
         except ValueError as ve:

--- a/empirica/cli/parsers/checkpoint_parsers.py
+++ b/empirica/cli/parsers/checkpoint_parsers.py
@@ -666,13 +666,20 @@ def add_checkpoint_parsers(subparsers):
 
     engagement_list_parser = subparsers.add_parser(
         "engagement-list",
-        help="List engagements, filtered by --domain / --lifecycle / --org.",
+        help="List engagements (active-by-default) filtered by --domain / --lifecycle / --org; "
+        "--include-closed for terminal ones.",
     )
     engagement_list_parser.add_argument("--domain", help="Filter by domain")
     engagement_list_parser.add_argument(
         "--lifecycle", help="Filter by lifecycle_state (open|in_progress|blocked|closed)"
     )
     engagement_list_parser.add_argument("--org", help="Scope to an organization's tickets (role='ticket_of')")
+    engagement_list_parser.add_argument(
+        "--include-closed",
+        action="store_true",
+        help="Include terminal (closed) engagements. Default: active-only "
+        "(open|in_progress|blocked). Ignored when --lifecycle is given.",
+    )
     engagement_list_parser.add_argument("--limit", type=int, default=100, help="Max rows (default: 100)")
     engagement_list_parser.add_argument("--output", choices=["human", "json"], default="human", help="Output format")
     engagement_list_parser.add_argument("--verbose", action="store_true", help="Verbose output")

--- a/empirica/data/repositories/workspace_db.py
+++ b/empirica/data/repositories/workspace_db.py
@@ -244,6 +244,12 @@ _DEFAULT_ENGAGEMENT_STAGES = [
 # (sqlite ALTER can't add CHECK), so lifecycle/outcome validity lives at the repo
 # layer; domain/stage validity is checked against the definition tables.
 ENGAGEMENT_LIFECYCLE_STATES = frozenset({"open", "in_progress", "blocked", "closed"})
+# Terminal states — excluded by default from org/contact engagement scoping
+# (SER#183 part-2: the drill is a "who are we working with now" view; terminal
+# engagements belong in the dedicated Engagements area). Add new terminal states
+# here so the default-active filter picks them up; the complement (open,
+# in_progress, blocked) is "active".
+ENGAGEMENT_TERMINAL_STATES = frozenset({"closed"})
 ENGAGEMENT_OUTCOMES = frozenset({"won", "lost", "resolved", "wont_fix", "defer", "superseded"})
 
 
@@ -1100,6 +1106,7 @@ class WorkspaceDBRepository(BaseRepository):
         domain: str | None = None,
         lifecycle_state: str | None = None,
         org_id: str | None = None,
+        include_closed: bool = False,
         limit: int = 100,
     ) -> list[dict[str, Any]]:
         """List engagements, optionally filtered.
@@ -1107,6 +1114,14 @@ class WorkspaceDBRepository(BaseRepository):
         ``org_id`` scopes to engagements that are members of that organization
         with role='ticket_of' (the canonical org→ticket linkage), joining
         entity_memberships. ``lifecycle_state`` must be a valid state.
+
+        Active-by-default (SER#183 part-2): when no explicit ``lifecycle_state``
+        is given, terminal engagements (``ENGAGEMENT_TERMINAL_STATES``, i.e.
+        closed) are excluded — the org/contact drill is a "who are we working
+        with now" view. Opt into the full set with ``include_closed=True`` or by
+        requesting a specific ``lifecycle_state`` (an explicit state always wins,
+        so ``lifecycle_state='closed'`` still returns closed). The Engagements
+        area surfaces terminal history via these opt-ins.
         """
         if lifecycle_state is not None and lifecycle_state not in ENGAGEMENT_LIFECYCLE_STATES:
             raise ValueError(
@@ -1125,8 +1140,14 @@ class WorkspaceDBRepository(BaseRepository):
             where.append("e.domain = ?")
             params.append(domain)
         if lifecycle_state is not None:
+            # Explicit state wins — including an explicit request for closed.
             where.append("e.lifecycle_state = ?")
             params.append(lifecycle_state)
+        elif not include_closed and ENGAGEMENT_TERMINAL_STATES:
+            # Default-active: exclude terminal states unless opted in.
+            placeholders = ", ".join("?" for _ in ENGAGEMENT_TERMINAL_STATES)
+            where.append(f"e.lifecycle_state NOT IN ({placeholders})")
+            params.extend(sorted(ENGAGEMENT_TERMINAL_STATES))
         where_clause = ("WHERE " + " AND ".join(where)) if where else ""
         params.append(limit)
         cursor = self._execute(

--- a/tests/test_engagement_repository.py
+++ b/tests/test_engagement_repository.py
@@ -93,6 +93,51 @@ def test_list_org_scoped_via_ticket_of_membership(repo):
     assert {e["engagement_id"] for e in scoped} == {"t1"}
 
 
+# ── active-by-default (SER#183 part-2) ────────────────────────────────────────
+
+
+def test_list_defaults_to_active_excludes_closed(repo):
+    """No explicit lifecycle filter → terminal (closed) engagements are excluded."""
+    repo.create_engagement("a1", "active", domain="support")
+    repo.create_engagement("c1", "done", domain="support")
+    repo.update_engagement("c1", lifecycle_state="closed", outcome="won")
+    assert {e["engagement_id"] for e in repo.list_engagements()} == {"a1"}
+
+
+def test_list_include_closed_returns_terminal_too(repo):
+    """include_closed=True restores the full set (the Engagements-area opt-in)."""
+    repo.create_engagement("a1", "active", domain="support")
+    repo.create_engagement("c1", "done", domain="support")
+    repo.update_engagement("c1", lifecycle_state="closed", outcome="won")
+    assert {e["engagement_id"] for e in repo.list_engagements(include_closed=True)} == {"a1", "c1"}
+
+
+def test_list_explicit_closed_overrides_default(repo):
+    """An explicit lifecycle_state always wins — even for a terminal state."""
+    repo.create_engagement("a1", "active", domain="support")
+    repo.create_engagement("c1", "done", domain="support")
+    repo.update_engagement("c1", lifecycle_state="closed", outcome="won")
+    # Explicit closed returns closed despite active-by-default; include_closed is moot.
+    assert {e["engagement_id"] for e in repo.list_engagements(lifecycle_state="closed")} == {"c1"}
+
+
+def test_list_org_scoped_is_active_by_default(repo):
+    """The org→engagement drill excludes closed unless opted in (the X2 'who now' view)."""
+    repo.create_engagement("t1", "active acme ticket", domain="support")
+    repo.create_engagement("t2", "closed acme ticket", domain="support")
+    repo.update_engagement("t2", lifecycle_state="closed", outcome="won")
+    now = time.time()
+    for eid in ("t1", "t2"):
+        repo.conn.execute(
+            "INSERT INTO entity_memberships (entity_type, entity_id, group_type, group_id, role, joined_at, created_at) "
+            "VALUES ('engagement', ?, 'organization', 'acme', 'ticket_of', ?, ?)",
+            (eid, now, now),
+        )
+    repo.conn.commit()
+    assert {e["engagement_id"] for e in repo.list_engagements(org_id="acme")} == {"t1"}
+    assert {e["engagement_id"] for e in repo.list_engagements(org_id="acme", include_closed=True)} == {"t1", "t2"}
+
+
 # ── update + enum enforcement ────────────────────────────────────────────────
 
 

--- a/tests/test_engagements_endpoint.py
+++ b/tests/test_engagements_endpoint.py
@@ -183,6 +183,27 @@ def test_route_invalid_lifecycle_422(client):
     assert r.status_code == 422
 
 
+def test_route_active_by_default_excludes_closed(client):
+    """SER#183 part-2: the feed defaults to active; closed needs an explicit opt-in.
+
+    Seeded e1 is open. Add a closed engagement and assert the three behaviors:
+    default excludes it, ?include_closed=true restores it, ?lifecycle=closed
+    targets it.
+    """
+    cid = client.post("/api/v1/engagements", json={"domain": "support", "title": "old issue"}).json()["engagement_id"]
+    assert client.patch(f"/api/v1/engagements/{cid}", json={"lifecycle_state": "closed"}).status_code == 200
+
+    default_ids = {e["id"] for e in client.get("/api/v1/engagements").json()["engagements"]}
+    assert cid not in default_ids  # closed excluded by default
+    assert "e1" in default_ids  # the open one stays
+
+    full_ids = {e["id"] for e in client.get("/api/v1/engagements?include_closed=true").json()["engagements"]}
+    assert cid in full_ids and "e1" in full_ids  # opt-in restores the full set
+
+    closed_ids = {e["id"] for e in client.get("/api/v1/engagements?lifecycle=closed").json()["engagements"]}
+    assert closed_ids == {cid}  # explicit lifecycle targets the terminal one
+
+
 # ---- POST /api/v1/engagements (C3 create) ----------------------------------
 
 


### PR DESCRIPTION
Helping extension land the **SER #183 part-2** acceptance criterion (collab `prop_box2jt5`, David: *"help out extension"*).

## Why
The extension's org→contact drill is a *"who are we working with now"* view. Today `GET /api/v1/engagements?org=<id>` (and `empirica engagement-list`) return **all** engagements including `closed` when no lifecycle filter is given — so terminal engagements clutter the active drill. Extension keeps `ORG_SCOPING_LIVE=false` until the daemon both scopes **and** active-filters.

## Change
- `repo.list_engagements` gains `include_closed` (default `False`). With no explicit `lifecycle_state`, terminal states are excluded; an explicit `lifecycle_state` always wins (so `closed` is still reachable); `include_closed=True` restores the full set.
- New `ENGAGEMENT_TERMINAL_STATES = {"closed"}` constant — makes "terminal" explicit and future-proof (add a state in one place). Answers the proposal's "@workspace confirm which values are terminal": active = `open|in_progress|blocked`, terminal = `closed`.
- Daemon route: `?include_closed=true`.
- CLI `engagement-list`: `--include-closed` (same active-by-default semantic, for consistency across surfaces).
- No schema change — `lifecycle_state` is the existing E1 sidecar column.

## Behavior change note
Both the daemon feed **and** the CLI now default to active. The CLI default flip is deliberate (one consistent semantic) and recoverable via `--include-closed`; called out in CHANGELOG.

## Verification
53 engagement tests green (repo + endpoint + cli + serve-scoping). Repo: default-active / include_closed / explicit-closed-wins / org-scoped-active. Route: 3-way (default excludes → include_closed restores → explicit lifecycle targets). ruff check + format clean.

@extension — once this lands, the daemon scopes **and** active-filters; safe to flip `ORG_SCOPING_LIVE`. @workspace — terminal-state confirmation: only `closed` is terminal (status `completed|lost` + outcome corroborate but `lifecycle_state` is the gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)