### PR TITLE
feat(entities): ?parent_org filter — scope contacts to an org

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`?parent_org=<org_id>` on `GET /api/v1/entities`** — scope the contact list to
+  one organization (the extension org-detail contacts subset). Backed by
+  `entity_memberships` (active affiliation, `left_at IS NULL`) — the populated,
+  vendored contact→org linkage, consistent with the existing org→engagement
+  `ticket_of` scoping. An unknown org returns `[]` (honest-empty, no leak).
+  Contact rows in the feed now also carry `parent_org_id` (their affiliated org),
+  resolved via the same source so filter and enrichment agree.
+
 ### Changed
 - **Engagement listing is active-by-default** (SER #183 part-2) — the daemon
   feed `GET /api/v1/engagements` and `empirica engagement-list` now exclude

--- a/empirica/api/routes/entities.py
+++ b/empirica/api/routes/entities.py
@@ -107,6 +107,11 @@ def _list_subtitle(row: dict, meta: dict) -> str | None:
 async def list_entities(
     type: str | None = Query(None, description="Filter by entity_type (contact, organization, engagement, ...)"),
     status: str = Query("active", description="Status filter; 'all' returns every status"),
+    parent_org: str | None = Query(
+        None,
+        description="Scope to CONTACTS affiliated with this organization id (active affiliation). "
+        "Implies a contact scope; an unknown org returns []. Backed by entity_memberships.",
+    ),
     limit: int = Query(100, ge=1, le=500),
 ):
     """List entities from the workspace registry (extension entity-list backing).
@@ -124,7 +129,10 @@ async def list_entities(
         # the whole org set (small: umbrella + brands), not per-row — preserves
         # the single-query intent that deferred the broader v1.1 enrichment.
         org_parents = repo.get_org_parent_map()
-        for row in repo.list_entities(entity_type=type, status=status, limit=limit):
+        # Contact→org affiliation map — same source as the parent_org filter
+        # (entity_memberships), so the filter and this enrichment agree.
+        contact_orgs = repo.get_contact_org_map()
+        for row in repo.list_entities(entity_type=type, status=status, parent_org=parent_org, limit=limit):
             et, eid = row["entity_type"], row["entity_id"]
             meta = _parse_metadata(row.get("metadata"))
             entry = {
@@ -137,10 +145,13 @@ async def list_entities(
                 "linked_artifact_count": repo.count_entity_artifacts(et, eid),
                 "updated_at": row.get("updated_at"),
             }
-            # Org rows carry their parent org (null for umbrella roots). Only
-            # organization rows get the field — the extension tree-builder keys
-            # off it; non-org rows omit it.
+            # parent_org_id carries the entity's owning org so the extension
+            # tree/drill can key off it: org rows → parent ORG (umbrella, null for
+            # roots); contact rows → affiliated org. Both resolve via
+            # entity_memberships; other types omit the field.
             if et == "organization":
                 entry["parent_org_id"] = org_parents.get(eid)
+            elif et == "contact":
+                entry["parent_org_id"] = contact_orgs.get(eid)
             out.append(entry)
     return {"ok": True, "count": len(out), "entities": out}

--- a/empirica/data/repositories/workspace_db.py
+++ b/empirica/data/repositories/workspace_db.py
@@ -680,6 +680,7 @@ class WorkspaceDBRepository(BaseRepository):
         self,
         entity_type: str | None = None,
         status: str = "active",
+        parent_org: str | None = None,
         limit: int = 100,
     ) -> list[dict[str, Any]]:
         """List entities from the registry.
@@ -688,20 +689,40 @@ class WorkspaceDBRepository(BaseRepository):
             entity_type: Optional filter by entity_type (project, contact, ...).
                          None = all types.
             status: 'active' (default), 'inactive', 'archived', or 'all'.
+            parent_org: Optional org_id — scope to CONTACTS affiliated with that
+                        organization. Backed by entity_memberships (the populated,
+                        vendored contact→org linkage: group_type='organization',
+                        left_at IS NULL = active affiliation). NOTE: the
+                        workspace `contact_organizations` junction is unpopulated;
+                        entity_memberships is the canonical live source and is
+                        consistent with the org→engagement ticket_of scoping. An
+                        unknown org matches nothing → honest-empty (no leak).
+                        Implies a contact scope; pairing it with a non-contact
+                        entity_type returns []. `is_primary` is not expressible
+                        via entity_memberships, so scope = any active affiliation.
             limit: Max rows to return.
         """
         params: list[Any] = []
         where: list[str] = []
-        if entity_type:
-            where.append("entity_type = ?")
+        join = ""
+        if parent_org is not None:
+            if entity_type not in (None, "contact"):
+                return []  # parent_org is a contact filter; other types can't match
+            join = " JOIN entity_memberships m ON m.entity_type = e.entity_type AND m.entity_id = e.entity_id"
+            where.append("e.entity_type = 'contact'")
+            where.append("m.group_type = 'organization' AND m.group_id = ? AND m.left_at IS NULL")
+            params.append(parent_org)
+        elif entity_type:
+            where.append("e.entity_type = ?")
             params.append(entity_type)
         if status != "all":
-            where.append("status = ?")
+            where.append("e.status = ?")
             params.append(status)
         where_clause = ("WHERE " + " AND ".join(where)) if where else ""
         params.append(limit)
         cursor = self._execute(
-            f"SELECT * FROM entity_registry {where_clause} ORDER BY updated_at DESC, created_at DESC LIMIT ?",
+            f"SELECT e.* FROM entity_registry e{join} {where_clause} "
+            "ORDER BY e.updated_at DESC, e.created_at DESC LIMIT ?",
             tuple(params),
         )
         return [dict(row) for row in cursor.fetchall()]
@@ -911,6 +932,27 @@ class WorkspaceDBRepository(BaseRepository):
                ORDER BY joined_at ASC"""
         )
         # ASC + dict overwrite → the most recent (latest joined_at) edge wins.
+        return {row["entity_id"]: row["group_id"] for row in cursor.fetchall()}
+
+    def get_contact_org_map(self) -> dict[str, str]:
+        """Map contact_id → affiliated org_id from active contact→org edges.
+
+        The populated, canonical contact→org linkage is an active
+        ``entity_membership`` (entity is the contact, group is an organization,
+        ``left_at IS NULL``). Mirrors ``get_org_parent_map`` so the ``parent_org``
+        FILTER (in ``list_entities``) and the per-contact ``parent_org_id``
+        ENRICHMENT resolve via the SAME source — keeping filter and enrichment in
+        agreement (the consistency requirement). A contact in several orgs
+        collapses to the most recent active edge (ASC + dict overwrite); there is
+        no ``is_primary`` on entity_memberships, so this is "any active
+        affiliation, latest wins", not "primary org".
+        """
+        cursor = self._execute(
+            """SELECT entity_id, group_id FROM entity_memberships
+               WHERE entity_type = 'contact' AND group_type = 'organization'
+                 AND left_at IS NULL
+               ORDER BY joined_at ASC"""
+        )
         return {row["entity_id"]: row["group_id"] for row in cursor.fetchall()}
 
     def upsert_entity_membership(

--- a/tests/test_org_parent_map.py
+++ b/tests/test_org_parent_map.py
@@ -76,3 +76,73 @@ def test_multiple_orgs(repo):
     _membership(repo, "organization", "brand-b", "organization", "umbrella")
     m = repo.get_org_parent_map()
     assert m == {"brand-a": "umbrella", "brand-b": "umbrella"}
+
+
+# ── get_contact_org_map (contact→org affiliation, the populated linkage) ──────
+
+
+def test_contact_org_map_empty_when_no_edges(repo):
+    assert repo.get_contact_org_map() == {}
+
+
+def test_contact_org_map_maps_active_affiliation(repo):
+    _membership(repo, "contact", "c-carly", "organization", "empirica-foundation", role="admiral")
+    assert repo.get_contact_org_map() == {"c-carly": "empirica-foundation"}
+
+
+def test_contact_org_map_ignores_closed_affiliation(repo):
+    _membership(repo, "contact", "c-x", "organization", "old-org", left_at=time.time())
+    assert repo.get_contact_org_map() == {}
+
+
+def test_contact_org_map_ignores_non_org_groups(repo):
+    # contact→engagement membership is not a contact→org affiliation.
+    _membership(repo, "contact", "c-x", "engagement", "e1", role="member")
+    assert repo.get_contact_org_map() == {}
+
+
+def test_contact_org_map_latest_active_wins(repo):
+    _membership(repo, "contact", "c-x", "organization", "org-old", joined=100.0)
+    _membership(repo, "contact", "c-x", "organization", "org-new", joined=200.0)
+    assert repo.get_contact_org_map()["c-x"] == "org-new"
+
+
+# ── list_entities ?parent_org scoping (contacts in an org, honest-empty) ─────
+
+
+def _contact(repo, eid, name="C"):
+    now = time.time()
+    repo._execute(
+        "INSERT INTO entity_registry (entity_type, entity_id, display_name, source_db, source_table, "
+        "status, created_at, updated_at) VALUES ('contact', ?, ?, 'test', 'test', 'active', ?, ?)",
+        (eid, name, now, now),
+    )
+
+
+def test_parent_org_scopes_contacts_to_org(repo):
+    _contact(repo, "c1")
+    _contact(repo, "c2")
+    _membership(repo, "contact", "c1", "organization", "acme", role="member")
+    # c2 has no affiliation
+    rows = repo.list_entities(parent_org="acme")
+    assert {r["entity_id"] for r in rows} == {"c1"}
+
+
+def test_parent_org_unknown_is_honest_empty(repo):
+    _contact(repo, "c1")
+    _membership(repo, "contact", "c1", "organization", "acme", role="member")
+    # A bogus org must NOT leak the full set — it returns nothing.
+    assert repo.list_entities(parent_org="BOGUS-NOPE") == []
+
+
+def test_parent_org_excludes_closed_affiliation(repo):
+    _contact(repo, "c1")
+    _membership(repo, "contact", "c1", "organization", "acme", role="member", left_at=time.time())
+    assert repo.list_entities(parent_org="acme") == []
+
+
+def test_parent_org_with_non_contact_type_is_empty(repo):
+    _contact(repo, "c1")
+    _membership(repo, "contact", "c1", "organization", "acme", role="member")
+    # parent_org implies a contact scope — pairing it with type=organization is contradictory.
+    assert repo.list_entities(entity_type="organization", parent_org="acme") == []


### PR DESCRIPTION
Helping extension land the **contact half of org-scoping** (thread under `ser_5aeddc9d`; David: *"help out extension"*). org→engagements is live (#205); this adds org→contacts.

## Change
`GET /api/v1/entities` gains **`?parent_org=<org_id>`** → returns only contacts affiliated with that org. Contact rows now also carry **`parent_org_id`** (their affiliated org), so the feed is self-describing.

## Data-model finding (heads-up for @workspace)
Workspace's spine note (`prop_io4bkmgr7`) said *"JOIN `contact_organizations`"*. But on the **live daemon DB that table is empty (0 rows)** — the populated, canonical contact→org linkage is **`entity_memberships`** (`entity_type='contact'`, `group_type='organization'`, `left_at IS NULL`). Verified row: `c-carly-r-anderson-empirica-foundation → empirica-foundation`.

So I built against `entity_memberships`, because it is:
1. the **populated** source (`contact_organizations` would always return empty),
2. **vendored** into core's `_ensure_workspace_schema` → the daemon works on core-only installs (`contact_organizations` isn't vendored, and it FKs `contacts`/`organizations` tables core doesn't have),
3. **consistent** with the existing org→engagement `ticket_of` scoping (same junction).

Filter + `parent_org_id` enrichment both resolve via `get_contact_org_map` (one source → they agree). Unknown org → **honest-empty** (no leak — the d0831fd4 class). `is_primary` isn't on `entity_memberships`, so scope = any active affiliation (latest wins).

@workspace: if you intend `contact_organizations` to become the canonical populated junction, flag it and I'll switch/union + we can vendor it into core. For now entity_memberships is ground truth.

## Verification
Validated against the **live** workspace.db: `?parent_org=empirica-foundation` → the one affiliated contact; `?parent_org=BOGUS` → `[]`. 69 entity tests green (incl. new: contact-org-map active/closed/non-org/latest-wins; parent_org scope/honest-empty/closed-excluded/non-contact-type). ruff check + format clean.

@extension: once merged + daemon restarted, `?parent_org=` server-scopes the contacts subset → flip `ORG_CONTACTS_SCOPING_LIVE`. Lower-pri `?contact=` on /engagements deferred (you flagged non-blocking).

🤖 Generated with [Claude Code](https://claude.com/claude-code)