### PR TITLE
fix(sentinel): local machine no longer falsely reads as untrusted-remote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Local machines no longer falsely trip `REMOTE:SSH:UNTRUSTED`** — `SSH_CONNECTION`/
+  `SSH_CLIENT`/`SSH_TTY` are inherited by tmux/screen servers, so a pane whose
+  multiplexer was started over a since-closed SSH login carried those vars
+  forever, making a now-local machine read as an untrusted remote (reported on a
+  local Mac). `detect_environment` now treats SSH env as **stale** when `SSH_TTY`
+  points at a torn-down pty (device gone) and does not classify it as remote.
+  Advisory annotation only — no gating behavior changed. (Non-interactive remote,
+  `SSH_CONNECTION` without `SSH_TTY`, is unchanged.)
+
 ### Added
 - **`?parent_org=<org_id>` on `GET /api/v1/entities`** — scope the contact list to
   one organization (the extension org-detail contacts subset). Backed by

--- a/empirica/plugins/claude-code-integration/lib/project_resolver.py
+++ b/empirica/plugins/claude-code-integration/lib/project_resolver.py
@@ -189,7 +189,14 @@ def detect_environment() -> dict:
     import socket
 
     hostname = socket.gethostname()
-    is_remote = bool(os.environ.get("SSH_CONNECTION") or os.environ.get("SSH_CLIENT") or os.environ.get("SSH_TTY"))
+    # Stale, multiplexer-inherited SSH_* env on a now-local machine is NOT a live
+    # remote session — a tmux/screen server started over a since-closed SSH login
+    # keeps SSH_* forever, whose SSH_TTY pty is gone. Mirror of the canonical
+    # session_resolver.detect_environment fix (this is the ImportError fallback).
+    _ssh_env = os.environ.get("SSH_CONNECTION") or os.environ.get("SSH_CLIENT") or os.environ.get("SSH_TTY")
+    _ssh_tty = os.environ.get("SSH_TTY")
+    _ssh_stale = bool(_ssh_tty) and not os.path.exists(_ssh_tty)
+    is_remote = bool(_ssh_env) and not _ssh_stale
     is_container = os.path.exists("/.dockerenv") or os.path.exists("/run/.containerenv")
     is_ci = bool(os.environ.get("CI") or os.environ.get("GITHUB_ACTIONS") or os.environ.get("GITLAB_CI"))
 

--- a/empirica/utils/session_resolver.py
+++ b/empirica/utils/session_resolver.py
@@ -2555,6 +2555,28 @@ def _scan_workspace_for_project(instance_id: str | None) -> Path | None:
     return best_match
 
 
+def _ssh_env_is_stale() -> bool:
+    """True when SSH_* env vars are present but reflect a DEAD session.
+
+    SSH_CONNECTION/SSH_CLIENT/SSH_TTY are inherited by tmux/screen servers, so a
+    pane whose multiplexer server was started over an SSH login that has since
+    logged out carries those vars forever — falsely reading as "remote" on a
+    now-local machine (reported: a local Mac tripping REMOTE:SSH:UNTRUSTED). A
+    LIVE interactive SSH session's SSH_TTY device exists; an inherited/stale one
+    points at a pty that was torn down when the login ended. Device-existence is
+    the discriminator that works in the hook subprocess (which has no controlling
+    tty of its own to compare SSH_TTY against). SSH_CONNECTION/SSH_CLIENT without
+    any SSH_TTY is left as-is (non-interactive remote, e.g. scp/forced command).
+    """
+    ssh_tty = os.environ.get("SSH_TTY")
+    if ssh_tty:
+        try:
+            return not os.path.exists(ssh_tty)
+        except OSError:
+            return True
+    return False
+
+
 def detect_environment() -> dict:
     """Detect execution environment for Sentinel context awareness.
 
@@ -2565,7 +2587,10 @@ def detect_environment() -> dict:
     import socket
 
     hostname = socket.gethostname()
-    is_remote = bool(os.environ.get("SSH_CONNECTION") or os.environ.get("SSH_CLIENT") or os.environ.get("SSH_TTY"))
+    _ssh_env = os.environ.get("SSH_CONNECTION") or os.environ.get("SSH_CLIENT") or os.environ.get("SSH_TTY")
+    # Stale, multiplexer-inherited SSH_* env on a local machine is NOT a remote
+    # session — don't emit REMOTE:UNTRUSTED for it (advisory annotation only).
+    is_remote = bool(_ssh_env) and not _ssh_env_is_stale()
     is_container = os.path.exists("/.dockerenv") or os.path.exists("/run/.containerenv")
     is_ci = bool(os.environ.get("CI") or os.environ.get("GITHUB_ACTIONS") or os.environ.get("GITLAB_CI"))
 

--- a/tests/test_detect_environment.py
+++ b/tests/test_detect_environment.py
@@ -1,0 +1,92 @@
+"""detect_environment() — Sentinel remote/trust classification.
+
+Regression focus: a LOCAL machine must not read as an untrusted remote when the
+SSH_* env vars are stale (inherited by a tmux/screen server whose SSH login has
+since logged out). A local Mac was tripping `REMOTE:SSH:UNTRUSTED` this way
+(autonomy bug report). The discriminator is SSH_TTY device-existence: a live
+session's pty exists; a stale-inherited one is gone.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from empirica.utils.session_resolver import _ssh_env_is_stale, detect_environment
+
+_SSH_VARS = ("SSH_CONNECTION", "SSH_CLIENT", "SSH_TTY")
+
+
+@pytest.fixture(autouse=True)
+def _clear_ssh_env(monkeypatch):
+    for v in _SSH_VARS:
+        monkeypatch.delenv(v, raising=False)
+    # Don't let a real ~/.empirica/trusted_hosts leak into trust assertions.
+    monkeypatch.setenv("CI", "")  # ensure is_ci stays false unless a test sets it
+    monkeypatch.delenv("CI", raising=False)
+    monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+    monkeypatch.delenv("GITLAB_CI", raising=False)
+
+
+# ── _ssh_env_is_stale ─────────────────────────────────────────────────────────
+
+
+def test_stale_false_when_no_ssh_tty(monkeypatch):
+    monkeypatch.setenv("SSH_CONNECTION", "1.2.3.4 5555 6.7.8.9 22")
+    # SSH_CONNECTION without SSH_TTY: non-interactive remote, not classified stale.
+    assert _ssh_env_is_stale() is False
+
+
+def test_stale_true_when_ssh_tty_device_missing(monkeypatch):
+    monkeypatch.setenv("SSH_TTY", "/dev/pts/nonexistent-99999")
+    assert _ssh_env_is_stale() is True
+
+
+def test_stale_false_when_ssh_tty_device_exists(monkeypatch, tmp_path):
+    live = tmp_path / "ptylike"
+    live.write_text("")  # a path that exists stands in for a live pty device
+    monkeypatch.setenv("SSH_TTY", str(live))
+    assert _ssh_env_is_stale() is False
+
+
+# ── detect_environment: is_remote ─────────────────────────────────────────────
+
+
+def test_local_no_ssh_is_not_remote():
+    assert detect_environment()["is_remote"] is False
+
+
+def test_stale_ssh_tty_reads_local_not_remote(monkeypatch):
+    # THE bug: tmux-inherited SSH_* on a now-local machine (pty gone).
+    monkeypatch.setenv("SSH_CONNECTION", "1.2.3.4 5555 6.7.8.9 22")
+    monkeypatch.setenv("SSH_TTY", "/dev/pts/gone-12345")
+    env = detect_environment()
+    assert env["is_remote"] is False
+    # …and therefore no untrusted-remote trust verdict is computed.
+    assert env["is_trusted"] is None
+
+
+def test_live_ssh_tty_is_remote(monkeypatch, tmp_path):
+    live = tmp_path / "livepty"
+    live.write_text("")
+    monkeypatch.setenv("SSH_CONNECTION", "1.2.3.4 5555 6.7.8.9 22")
+    monkeypatch.setenv("SSH_TTY", str(live))
+    assert detect_environment()["is_remote"] is True
+
+
+def test_noninteractive_ssh_connection_still_remote(monkeypatch):
+    # SSH_CONNECTION with no SSH_TTY (scp / forced command) is left as remote.
+    monkeypatch.setenv("SSH_CONNECTION", "1.2.3.4 5555 6.7.8.9 22")
+    assert detect_environment()["is_remote"] is True
+
+
+# ── trust verdict still works for a genuine remote ────────────────────────────
+
+
+def test_live_remote_untrusted_without_trusted_hosts(monkeypatch, tmp_path):
+    live = tmp_path / "pty"
+    live.write_text("")
+    monkeypatch.setenv("SSH_TTY", str(live))
+    monkeypatch.setattr("empirica.utils.session_resolver.Path.home", staticmethod(lambda: tmp_path))
+    env = detect_environment()
+    assert env["is_remote"] is True
+    assert env["is_trusted"] is False  # no trusted_hosts file → untrusted (unchanged)


### PR DESCRIPTION
The secondary bug from autonomy's report (`prop_vpqbclmx`): a **local Mac** tripped `[REMOTE:SSH:UNTRUSTED — add <host> to trusted_hosts]`, cleared only by manually creating `~/.empirica/trusted_hosts`.

## Cause
`SSH_CONNECTION`/`SSH_CLIENT`/`SSH_TTY` are inherited by tmux/screen servers. A pane whose multiplexer was started over an SSH login that has **since logged out** carries those vars forever, so `detect_environment` read `is_remote=True` on a now-local machine.

## Fix
`_ssh_env_is_stale()` — a **live** interactive SSH session's `SSH_TTY` device exists; a stale-inherited one points at a torn-down pty. Device-existence is the discriminator (works in the hook subprocess, which has no controlling tty of its own to compare `SSH_TTY` against). `is_remote` now requires SSH env **and** not-stale.

- Applied to the canonical `session_resolver.detect_environment` **and** mirrored in the hook's `project_resolver` copy (the ImportError fallback) — kept in sync (two-source guard).
- `SSH_CONNECTION` without `SSH_TTY` (non-interactive remote: scp / forced command) is **unchanged** — not declassified.

## Risk
Low. `env_annotation` is only **appended to gate-decision messages** — it never blocks. This is advisory noise-reduction, not a gating change. Worst case of a mis-classification is a missing/extra annotation.

## Verification
8 tests (`tests/test_detect_environment.py`): stale-tty→local, live-tty→remote, no-ssh→local, connection-only→remote, live-remote-untrusted trust verdict unchanged. ruff check + format clean.

@autonomy: retest on next release. If a local session STILL trips it, send `env | grep -i ssh` at repro — your exact SSH_* set (e.g. `SSH_CONNECTION` without `SSH_TTY`) would tell me whether to broaden the staleness check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)