### PR TITLE
docs(prompt): state the noetic toolchain in the lean core (global recon set)

### DIFF
--- a/empirica/plugins/claude-code-integration/templates/empirica-system-prompt-lean.md
+++ b/empirica/plugins/claude-code-integration/templates/empirica-system-prompt-lean.md
@@ -276,6 +276,32 @@ test to reason about a tool you haven't seen before, rather than memorizing a li
   `sqlite3 "INSERT/UPDATE/DROP…"`. A tool being on the noetic list does NOT make a
   mutating invocation noetic — the Sentinel inspects the flags, not just the name.
 
+### Noetic Toolchain — prefer the power tools
+
+Beyond the base shell, a sharper read-only recon set is installed for nuanced
+work. **Reach for these over their base equivalents** — they're all
+Sentinel-noetic (flow free, any phase), just faster / more precise:
+
+| Reach for | Instead of | For |
+|-----------|-----------|-----|
+| `rg` (ripgrep) | `grep -r` | fast, gitignore-aware content search |
+| `fd` | `find` | fast, gitignore-aware file find |
+| `ast-grep` | regex greps | **structural** (by-syntax/AST) code search — match code shape, not text |
+| `jq` / `yq` / `gron` | hand-parsing | JSON / YAML query · flatten JSON to greppable paths |
+| `tokei` / `scc` | `wc -l` | LOC + complexity stats |
+| `bat` | `cat` | syntax-highlighted, line-numbered view |
+
+`empirica doctor` reports which are installed — absence is a WARN, not a failure
+(fall back to `grep`/`find`); `noetic-batch` already uses `rg` under the hood. The
+write/exec MODES (`fd -x`, `yq -i`, `ast-grep --rewrite`) are praxic — the Sentinel
+gates those by flag, so the read forms stay free.
+
+**Scope.** This recon set is GLOBAL — every practitioner gets it. *Practice-scoped*
+tools (a practice's domain CLIs / MCP servers — e.g. outreach's publishing stack)
+are declared per-practice via autonomy's onboarding, not here. Keep this section to
+the universal set; if a tool only helps one practice, it belongs in that practice's
+scope, not the lean core.
+
 ### Batch Noetic Work
 
 When you have **≥3** investigation operations to run together,


### PR DESCRIPTION
David's ask: the installed noetic bash tools (rg/fd/ast-grep/jq/yq/gron/bat/tokei/scc) were **installed** (`doctor` checks them) and **Sentinel-allowed** (`SAFE_BASH_PREFIXES` + write-flag guards) — but **nowhere stated in the system prompt**, so practitioners defaulted to `grep`/`find` and the tools sat unused (except indirectly via `noetic-batch`'s internal `rg`).

## Change
Adds a **"Noetic Toolchain — prefer the power tools"** subsection to the NOETIC FIREWALL in the lean-core template: a reach-for/instead-of table + the doctor-reports-installed / noetic-batch-uses-rg notes + the write-mode gating reminder.

## The global-vs-per-practice split (David's steer)
- **GLOBAL** (this section, lean core, every practitioner): the universal read-only recon set — `rg` > grep, `fd` > find, `ast-grep` for structural, `jq`/`yq`/`gron` for structured data, `tokei`/`scc` stats, `bat` view.
- **PER-PRACTICE** (autonomy's onboarding, not here): a practice's domain CLIs / MCP servers (e.g. outreach's publishing stack). The section says this explicitly so the lean core doesn't accrete practice-specific tooling. Routed to autonomy alongside the MCP-allowlist registry (`prop_bzu4kk3k`).

## Note for @david
Your deployed `~/.claude/empirica-system-prompt.md` is **stale (`v1.12.5`)** — it predates even the firewall tool list. `empirica setup-claude-code --force` refreshes it to current (`v1.12.9` template + this section). The template is Jinja-rendered (`{{ empirica_version }}`), so the version updates automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)