### PR TITLE
fix(note): scratchpad notes resurface project-wide until triaged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **`empirica note` scratchpad notes now resurface until triaged** — `note --list`
+  and the POSTFLIGHT retrospective were scoped to the *current transaction_id*, so
+  a note jotted in one transaction was invisible from the next (and lost across a
+  session_id rotation on compaction). The whole point is "capture now, classify
+  *later*" — and "later" is almost always a different transaction — so
+  cross-transaction follow-ups silently stranded (usage audit: 60–100% of notes
+  left untriaged across practices, because the review moment never showed them).
+  Both surfaces are now scoped by **`project_id`** (durable), so the backlog
+  reliably reappears for triage; falls back to session scope for pre-project
+  notes. The PREFLIGHT partial-credit signal stays transaction-scoped (it asks
+  "did you capture intent during the work you just did?", which is correctly
+  per-transaction).
 - **Local machines no longer falsely trip `REMOTE:SSH:UNTRUSTED`** — `SSH_CONNECTION`/
   `SSH_CLIENT`/`SSH_TTY` are inherited by tmux/screen servers, so a pane whose
   multiplexer was started over a since-closed SSH login carried those vars

--- a/empirica/cli/command_handlers/_workflow_shared.py
+++ b/empirica/cli/command_handlers/_workflow_shared.py
@@ -628,17 +628,25 @@ def _build_retrospective(session_id: str, transaction_id: str | None) -> dict:
 def _maybe_add_untriaged_notes(cursor, session_id: str, transaction_id, retro: dict) -> None:
     """Surface scratchpad notes-to-self for triage at the retrospective.
 
-    The POSTFLIGHT review moment: untriaged notes from this transaction (or the
-    session, if no transaction) are surfaced so the AI can promote them to
-    artifacts/goals or discard them (then `empirica note --clear`). Scoped,
-    metadata-only, non-fatal. Tolerates the table not existing on older DBs.
+    The POSTFLIGHT review moment: EVERY untriaged note for the PROJECT is
+    surfaced (not just this transaction's) so the "capture now, classify later"
+    backlog reliably resurfaces and gets promoted/cleared. Scoped by project_id
+    (durable across transaction/session rotation — the transaction/session
+    scoping used to strand cross-transaction notes); falls back to session_id
+    when the session has no project. Metadata-only, non-fatal. Tolerates the
+    table not existing on older DBs.
     """
     try:
-        if transaction_id:
+        project_id = None
+        try:
+            prow = cursor.execute("SELECT project_id FROM sessions WHERE session_id = ?", (session_id,)).fetchone()
+            project_id = prow[0] if prow else None
+        except Exception:
+            project_id = None  # sessions table absent (older DB) → session-scope fallback
+        if project_id:
             rows = cursor.execute(
-                "SELECT text, tag FROM notes WHERE session_id = ? AND "
-                "transaction_id = ? AND triaged = 0 ORDER BY created_at",
-                (session_id, transaction_id),
+                "SELECT text, tag FROM notes WHERE project_id = ? AND triaged = 0 ORDER BY created_at",
+                (project_id,),
             ).fetchall()
         else:
             rows = cursor.execute(
@@ -649,7 +657,7 @@ def _maybe_add_untriaged_notes(cursor, session_id: str, transaction_id, retro: d
             return
         retro["untriaged_notes"] = [{"text": r[0], "tag": r[1]} for r in rows]
         retro["untriaged_notes_hint"] = (
-            f"{len(rows)} untriaged note(s)-to-self from this transaction. "
+            f"{len(rows)} untriaged note(s)-to-self for this project. "
             "Promote any worth keeping to a finding/decision/goal, then "
             "`empirica note --clear`."
         )

--- a/empirica/cli/command_handlers/note_commands.py
+++ b/empirica/cli/command_handlers/note_commands.py
@@ -1,16 +1,22 @@
 """Note command — fast scratchpad / note-to-self.
 
-Low-friction, transaction-scoped jottings captured mid-flow and reviewed at the
-POSTFLIGHT retrospective. The complement to the structured ``*-log`` artifacts:
-capture now, classify later. Pure metadata — NOT shared, NOT embedded in Qdrant,
-NOT written to git notes. The durability win (survives context compaction) is
-why these live in sessions.db rather than in-context.
+Low-friction jottings captured mid-flow and reviewed later. The complement to the
+structured ``*-log`` artifacts: capture now, classify later. Pure metadata — NOT
+shared, NOT embedded in Qdrant, NOT written to git notes. The durability win
+(survives context compaction) is why these live in sessions.db rather than
+in-context.
+
+**Resurface scope is the PROJECT, not the transaction.** ``--list`` and the
+POSTFLIGHT retrospective surface every untriaged note for the project until it is
+triaged — a note left in one transaction must reappear in the next (and after a
+compaction/session rotation), or "classify later" never happens. ``--clear``
+marks the project's untriaged notes triaged.
 
 Usage:
     empirica note "static query should stay static, not f-string"
     empirica note "ask cortex if gap1 overlaps R3" --tag followup
-    empirica note --list      # review untriaged notes (the retrospective moment)
-    empirica note --clear     # mark this transaction's notes triaged
+    empirica note --list      # review the project's untriaged notes (any transaction)
+    empirica note --clear     # mark the project's untriaged notes triaged
 """
 
 from __future__ import annotations
@@ -107,13 +113,21 @@ def handle_note_command(args) -> dict | int | None:
 
 
 def _query_untriaged(conn, ctx):
-    """Untriaged notes for the active transaction (or whole session if none)."""
-    if ctx["transaction_id"]:
+    """Untriaged notes for the current PROJECT — resurface until triaged.
+
+    Scoped by ``project_id``, NOT transaction/session. This is the fix for the
+    stranding bug: the whole point of a note is "capture now, classify LATER",
+    and "later" is almost always a different transaction (and often a different
+    session — the empirica session_id rotates on compaction). Transaction/session
+    scoping meant a note jotted in transaction A was invisible from B, so
+    cross-transaction follow-ups never resurfaced. Project scope makes them
+    durable. Falls back to session_id only when the note/context predates
+    project_id.
+    """
+    if ctx.get("project_id"):
         rows = conn.execute(
-            "SELECT note_id, text, tag, created_at FROM notes "
-            "WHERE session_id = ? AND transaction_id = ? AND triaged = 0 "
-            "ORDER BY created_at",
-            (ctx["session_id"], ctx["transaction_id"]),
+            "SELECT note_id, text, tag, created_at FROM notes WHERE project_id = ? AND triaged = 0 ORDER BY created_at",
+            (ctx["project_id"],),
         ).fetchall()
     else:
         rows = conn.execute(

--- a/tests/test_note_command.py
+++ b/tests/test_note_command.py
@@ -1,8 +1,9 @@
 """Tests for the `empirica note` scratchpad.
 
 Covers the storage/query logic and the POSTFLIGHT retrospective surfacing
-directly (no full session needed): notes are transaction-scoped, triage-aware,
-and degrade safely when the table is absent on older DBs.
+directly (no full session needed): notes resurface PROJECT-wide until triaged
+(not transaction-scoped — that stranded cross-transaction follow-ups), are
+triage-aware, and degrade safely when the table is absent on older DBs.
 """
 
 from __future__ import annotations
@@ -21,17 +22,17 @@ def _conn():
     return conn
 
 
-def _add(conn, text, session_id="s1", transaction_id="t1", tag=None, triaged=0):
+def _add(conn, text, session_id="s1", transaction_id="t1", project_id="p", tag=None, triaged=0):
     conn.execute(
         "INSERT INTO notes (note_id, session_id, transaction_id, project_id, "
         "ai_id, text, tag, created_at, triaged) VALUES (?,?,?,?,?,?,?,?,?)",
-        (text, session_id, transaction_id, "p", "a", text, tag, time.time(), triaged),
+        (text, session_id, transaction_id, project_id, "a", text, tag, time.time(), triaged),
     )
     conn.commit()
 
 
-def _ctx(session_id="s1", transaction_id="t1"):
-    return {"session_id": session_id, "transaction_id": transaction_id}
+def _ctx(session_id="s1", transaction_id="t1", project_id="p"):
+    return {"session_id": session_id, "transaction_id": transaction_id, "project_id": project_id}
 
 
 # --- schema ---------------------------------------------------------------- #
@@ -40,23 +41,34 @@ def test_notes_table_in_schema():
 
 
 # --- query logic ----------------------------------------------------------- #
-def test_query_untriaged_scoped_to_transaction():
+def test_query_untriaged_resurfaces_across_transactions():
+    """The fix: notes captured in ANY transaction of the project resurface —
+    a note left in t1 must be visible while working in t2 (and vice versa)."""
     conn = _conn()
     _add(conn, "a", transaction_id="t1")
     _add(conn, "b", transaction_id="t1")
-    _add(conn, "c", transaction_id="t2")  # other transaction
-    _add(conn, "d", transaction_id="t1", triaged=1)  # already triaged
-    rows = nc._query_untriaged(conn, _ctx(transaction_id="t1"))
-    texts = sorted(r[1] for r in rows)
-    assert texts == ["a", "b"]
+    _add(conn, "c", transaction_id="t2")  # different transaction — must STILL surface
+    _add(conn, "d", transaction_id="t1", triaged=1)  # already triaged — excluded
+    # Querying from a THIRD transaction still sees the whole project backlog.
+    rows = nc._query_untriaged(conn, _ctx(transaction_id="t3"))
+    assert sorted(r[1] for r in rows) == ["a", "b", "c"]
 
 
-def test_query_untriaged_session_scope_when_no_transaction():
+def test_query_untriaged_project_scoped_excludes_other_projects():
     conn = _conn()
-    _add(conn, "a", transaction_id="t1")
-    _add(conn, "b", transaction_id=None)
-    rows = nc._query_untriaged(conn, _ctx(transaction_id=None))
-    assert {r[1] for r in rows} == {"a", "b"}  # all untriaged for the session
+    _add(conn, "mine", project_id="p")
+    _add(conn, "theirs", project_id="other")
+    rows = nc._query_untriaged(conn, _ctx(project_id="p"))
+    assert {r[1] for r in rows} == {"mine"}
+
+
+def test_query_untriaged_session_fallback_when_no_project():
+    conn = _conn()
+    _add(conn, "a", project_id=None, transaction_id="t1")
+    _add(conn, "b", project_id=None, transaction_id="t2")
+    # No project_id in ctx → fall back to session scope (both surface).
+    rows = nc._query_untriaged(conn, _ctx(project_id=None, transaction_id=None))
+    assert {r[1] for r in rows} == {"a", "b"}
 
 
 def test_clear_marks_triaged():
@@ -89,3 +101,21 @@ def test_retrospective_tolerates_missing_table():
     retro: dict = {}
     _maybe_add_untriaged_notes(conn.cursor(), "s1", "t1", retro)  # must not raise
     assert retro == {}
+
+
+def test_retrospective_resurfaces_project_backlog_across_transactions():
+    """POSTFLIGHT surfaces the whole PROJECT backlog, not just this transaction's
+    — so notes left in earlier transactions reliably reappear for triage."""
+    conn = _conn()
+    conn.execute("CREATE TABLE sessions (session_id TEXT PRIMARY KEY, project_id TEXT)")
+    conn.execute("INSERT INTO sessions VALUES ('s1', 'p')")
+    conn.commit()
+    _add(conn, "left in t1", transaction_id="t1")
+    _add(conn, "left in t2", transaction_id="t2")
+    _add(conn, "done", transaction_id="t1", triaged=1)
+    retro: dict = {}
+    # POSTFLIGHTing t3 still surfaces t1 + t2's untriaged notes (project-scoped).
+    _maybe_add_untriaged_notes(conn.cursor(), "s1", "t3", retro)
+    texts = sorted(n["text"] for n in retro["untriaged_notes"])
+    assert texts == ["left in t1", "left in t2"]
+    assert "for this project" in retro["untriaged_notes_hint"]


### PR DESCRIPTION
David flagged `empirica note` as "basically unused" — worth dropping or investigating. **Investigated: the premise flips.**

## The data
`note` isn't unused — it's under-**triaged**. Usage audit across practices: **67+ notes captured** (empirica 25, extension 14, outreach 9, autonomy/cortex/mesh-support 7/3/2, ecodex 7), but **60–100% left untriaged** everywhere except outreach.

## Root cause
"Capture now, classify **later**" fails at "later." Both resurface surfaces — `note --list` and the POSTFLIGHT retrospective — scoped to the **current `transaction_id`**. A note jotted in transaction A is invisible from transaction B (and lost across a `session_id` rotation on compaction). Since "later" is almost always a *different* transaction, cross-transaction follow-ups silently stranded — the review moment never showed them, so practitioners experienced notes as a write-only void. (Confirmed live: my own 5 notes this session are stranded in closed transactions; `note --list` reported "none.")

## Fix
Scope both resurface surfaces by **`project_id`** (durable across transaction/session rotation), falling back to session scope for pre-project notes. The backlog now reliably reappears at `--list` and every POSTFLIGHT until triaged.

The PREFLIGHT partial-credit gate (`_feedback_count_untriaged_notes`) **stays transaction-scoped on purpose** — it measures "did you capture intent during the work you *just* did?", which is correctly per-transaction, not a resurface surface.

## Verification
9 note tests: cross-transaction resurface, project-isolation, session fallback, POSTFLIGHT project-backlog surfacing (+ missing-sessions-table degrade). ruff check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)