### PR TITLE
fix(registry): projects-sync upserts by path, not append (+ governed CVE waiver)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.12.10] — 2026-07-02
 
 ### Fixed
+- **`projects-sync` upserts by path, not append** — `upsert_project` matched only
+  on `project_id`, so re-syncing a project whose id changed (slug→canonical-UUID
+  promotion, or a re-clone) at the same path **appended a second `registry.yaml`
+  entry** instead of updating the existing one. Two UUID-keyed entries at one
+  path is a state `dedupe_registry` refuses to auto-resolve → per-request "dedup
+  skipping conflict" log spam on every daemon request (surfaced by mesh-support
+  on a managed box that accumulated 6 duplicate practices). `upsert_project` now
+  matches on the resolved realpath first (then `project_id`) and updates in
+  place, with a canonical-identity guard so a same-path re-sync never downgrades
+  a UUID to a slug.
 - **`empirica note` scratchpad notes now resurface until triaged** — `note --list`
   and the POSTFLIGHT retrospective were scoped to the *current transaction_id*, so
   a note jotted in one transaction was invisible from the next (and lost across a

--- a/empirica/api/registry.py
+++ b/empirica/api/registry.py
@@ -220,6 +220,17 @@ def dedupe_registry(
     return deduped, removed
 
 
+def _resolve_path_key(path: Any) -> str | None:
+    """Symlink-following normalized path key (matches prune_stale / the daemon
+    resolver). Returns None for empty/unresolvable paths so they never match."""
+    if not path or not isinstance(path, str):
+        return None
+    try:
+        return str(Path(path).resolve(strict=False))
+    except (OSError, RuntimeError):
+        return None
+
+
 def upsert_project(
     registry: dict[str, Any],
     *,
@@ -232,8 +243,16 @@ def upsert_project(
 ) -> dict[str, Any]:
     """Insert or update a registry entry. Returns the modified registry.
 
-    Matches on project_id. If project_id already present, updates the entry
-    in place. Updates `last_seen` to now() if not provided.
+    Matches on the resolved realpath of ``path`` FIRST, then on ``project_id``.
+    Path-first is the fix for registry.yaml drift: a re-keyed project (same
+    path, NEW project_id — e.g. a slug→canonical-UUID promotion, or a re-clone)
+    must UPDATE its existing entry in place, not append a fresh-UUID duplicate.
+    Appending created two entries at one path; when both are UUID-keyed,
+    ``dedupe_registry`` refuses to auto-resolve → per-request "dedup skipping
+    conflict" spam on every daemon request (surfaced by mesh-support on Philipp's
+    box). Canonical-identity guard: a same-path match never DOWNGRADES an
+    existing canonical UUID to a slug (UUID-keyed wins, per ser_542199e3).
+    Updates ``last_seen`` to now() if not provided.
     """
     entry = {
         "project_id": project_id,
@@ -245,8 +264,13 @@ def upsert_project(
     }
 
     projects = registry.setdefault("projects", [])
+    target_key = _resolve_path_key(path)
     for i, existing in enumerate(projects):
-        if existing.get("project_id") == project_id:
+        same_path = target_key is not None and _resolve_path_key(existing.get("path")) == target_key
+        if same_path or existing.get("project_id") == project_id:
+            # Don't let a same-path re-sync clobber a canonical UUID with a slug.
+            if same_path and _is_canonical_uuid(existing.get("project_id")) and not _is_canonical_uuid(project_id):
+                entry["project_id"] = existing["project_id"]
             projects[i] = entry
             return registry
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1053,19 +1053,46 @@ brew install empirica
             log(f"  {line}")
         return False
 
+    # Governed CVE-waiver list. STRICT by default (any un-waived CVE hard-fails).
+    # A waiver here is a documented, reviewed risk-acceptance for a CVE that is
+    # (a) assessed non-exploitable in Empirica's usage, AND (b) has no available
+    # fix. Each MUST carry a rationale and a `retire_when` condition. The gate
+    # prints active waivers every run so they stay visible, not hidden. Keep this
+    # in sync with `empirica security-audit` (unify: goal — shared waiver source).
+    PIP_AUDIT_WAIVERS: list[dict] = [
+        {
+            "id": "PYSEC-2026-597",  # CVE-2026-12243
+            "package": "nltk",
+            "rationale": (
+                "path-traversal arbitrary-file-READ via attacker-controlled resource names to "
+                "nltk.data.load()/find(). nltk is transitive ONLY via the optional [prose] extra "
+                "(textstat, en_US syllable counts); Empirica calls it with FIXED internal resource "
+                "names on user text and never exposes the resource-name argument to user input, so "
+                "the vuln is unreachable. Not in CISA KEV (empirica security-audit passes)."
+            ),
+            "retire_when": "textstat drops nltk OR nltk ships a fixed release (none exists; all <=3.9.4 affected).",
+        },
+    ]
+
     def run_pip_audit(self) -> bool:
-        """CVE scan — mirrors the CI pip-audit step (hard fail on CVEs)."""
+        """CVE scan — mirrors the CI pip-audit step. STRICT (hard fail on CVEs)
+        except for the governed, documented PIP_AUDIT_WAIVERS."""
         log("\n" + "=" * 60)
         log("🔒 pip-audit (CVE gate)")
         log("=" * 60)
 
+        ignore_args: list[str] = []
+        for w in self.PIP_AUDIT_WAIVERS:
+            ignore_args += ["--ignore-vuln", w["id"]]
+            warning(f"CVE waiver ACTIVE: {w['id']} ({w['package']}) — {w['rationale']} [retire: {w['retire_when']}]")
+
         if self.dry_run:
-            info("Would run: pip-audit --skip-editable")
+            info(f"Would run: pip-audit --skip-editable {' '.join(ignore_args)}")
             return True
 
         try:
             result = subprocess.run(
-                ["pip-audit", "--skip-editable"],
+                ["pip-audit", "--skip-editable", *ignore_args],
                 capture_output=True, text=True, timeout=300,
                 cwd=str(self.repo_root),
             )

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -122,6 +122,35 @@ def test_upsert_preserves_explicit_last_seen():
     assert reg["projects"][0]["last_seen"] == "2026-01-01T00:00:00+00:00"
 
 
+_UUID_A = "2273f11d-0000-4000-8000-000000000000"
+
+
+def test_upsert_by_path_rekey_updates_not_appends():
+    """The registry-drift fix: re-syncing a project at the SAME path with a NEW
+    project_id (slug→UUID promotion) must UPDATE the existing entry, not append a
+    fresh-UUID duplicate (which produced the dedup-conflict spam)."""
+    reg = {
+        "version": 1,
+        "projects": [{"project_id": "grants", "slug": "grants", "name": "Grants", "path": "/tmp/grants"}],
+    }
+    upsert_project(reg, project_id=_UUID_A, slug="grants", name="Grants", path="/tmp/grants")
+    assert len(reg["projects"]) == 1  # updated in place — NOT two entries
+    assert reg["projects"][0]["project_id"] == _UUID_A  # canonical UUID took over
+
+
+def test_upsert_by_path_does_not_downgrade_canonical_uuid_to_slug():
+    """Canonical-identity guard: a same-path re-sync must not clobber a UUID
+    entry with a slug (UUID-keyed wins)."""
+    reg = {
+        "version": 1,
+        "projects": [{"project_id": _UUID_A, "slug": "grants", "name": "Grants", "path": "/tmp/grants"}],
+    }
+    upsert_project(reg, project_id="grants", slug="grants", name="Grants Renamed", path="/tmp/grants")
+    assert len(reg["projects"]) == 1
+    assert reg["projects"][0]["project_id"] == _UUID_A  # UUID preserved
+    assert reg["projects"][0]["name"] == "Grants Renamed"  # other fields still updated
+
+
 # ─── find_by_project_id ────────────────────────────────────────────────
 
 


### PR DESCRIPTION
Two things for **1.12.10** (David: "grab that, include it, then ship").

## 1. projects-sync registry drift (mesh-support / Philipp repro — `prop_vyhxxbhl`)
`upsert_project` matched **only on `project_id`**, so re-syncing a project whose id changed (slug→canonical-UUID promotion, or a re-clone) **at the same path appended a second `registry.yaml` entry** instead of updating. Two UUID-keyed entries at one path is a state `dedupe_registry` refuses to auto-resolve → **per-request "dedup skipping conflict" spam** on every daemon request (Philipp's box accumulated 6 duplicate practices).

Fix: `upsert_project` now matches **resolved-realpath first** (then `project_id`) and updates in place, with a **canonical-identity guard** so a same-path re-sync never downgrades a UUID to a slug. Tests: re-key updates-not-appends; downgrade guard. 27 registry tests green.

## 2. Governed CVE-waiver in release.py's pip-audit gate
The `--publish` gate is now **strict by default** (any un-waived CVE hard-fails) + a documented `PIP_AUDIT_WAIVERS` list (rationale + `retire_when`, **printed every run**). Waives `nltk` **PYSEC-2026-597 / CVE-2026-12243** — path-traversal file-*read*, no fix, transitive via the *optional* `[prose]` extra (textstat), **unreachable in our path** (fixed internal resource names, never user input), not CISA KEV.

Follow-up goals logged: swap textstat→nltk-free (retire the waiver) + unify `security-audit` to strict with a shared waiver source ("make our audit equally strict", done properly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)