### PR TITLE
fix(schema+autoinit): pre-E1 workspace-DB crash + auto-init project.yaml clobber (1.12.10 blockers)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.12.10] — 2026-07-02
 
 ### Fixed
+- **Workspace-DB open no longer hard-crashes on pre-E1 databases** — a
+  `workspace.db` whose `engagements` table predated the E1 sidecar columns
+  (`lifecycle_state`/`stage`/`domain`/`updated_at`) was never migrated:
+  `CREATE TABLE IF NOT EXISTS` no-ops on an existing table, then
+  `CREATE INDEX idx_engagements_lifecycle ON engagements(lifecycle_state)`
+  crashed with `no such column` on **every** workspace-DB open — bricking
+  session-create / project-switch / project-list / SessionStart auto-init.
+  `_apply_engagement_substrate` now runs an additive-migration pass
+  (`PRAGMA table_info` → `ALTER TABLE ADD COLUMN` for any missing sidecar column)
+  before the index block, self-healing old DBs on open. (mesh-support/Philipp
+  repro; surfaced by the 1.12.10 rollout on managed boxes.)
+- **`session-create --auto-init` no longer clobbers an existing `project.yaml`** —
+  the guard checked `config.yaml` but the overwrite target was `project.yaml`, so
+  a project with `project.yaml` present (canonical `project_id` + type/domain/
+  tenant/calibration_weights, gitignored → only copy) but `config.yaml` absent
+  got regenerated with defaults + a **random** `project_id`. Auto-init now
+  reuses an existing `project.yaml`'s `project_id` and never overwrites it.
 - **`projects-sync` upserts by path, not append** — `upsert_project` matched only
   on `project_id`, so re-syncing a project whose id changed (slug→canonical-UUID
   promotion, or a re-clone) at the same path **appended a second `registry.yaml`

--- a/empirica/cli/command_handlers/session_create.py
+++ b/empirica/cli/command_handlers/session_create.py
@@ -305,6 +305,26 @@ def _handle_auto_init(args, output_format, project_id):
     # relying on the resolver chain that doesn't yet know about the new project.
     auto_init_project_path = str(git_root)
 
+    # Data-loss guard (mesh-support/Philipp repro): NEVER clobber an existing
+    # project.yaml. It holds the canonical project_id + type/domain/tenant/
+    # calibration_weights and is gitignored (so it's the only copy). The old
+    # guard checked config.yaml, but project-init OVERWRITES project.yaml — so a
+    # project with project.yaml present but config.yaml absent (or a project_id
+    # not yet in the local registry) got regenerated with defaults + a RANDOM
+    # project_id, blowing away canonical identity. If project.yaml exists, REUSE
+    # its project_id and skip re-init entirely.
+    project_yaml = git_root / ".empirica" / "project.yaml"
+    if project_yaml.exists():
+        try:
+            import yaml as _yaml
+
+            existing = _yaml.safe_load(project_yaml.read_text()) or {}
+            if isinstance(existing, dict) and existing.get("project_id"):
+                project_id = existing["project_id"]
+        except Exception:
+            pass  # unreadable project.yaml → still never overwrite it
+        return auto_init_performed, project_id, auto_init_project_path
+
     empirica_config = git_root / ".empirica" / "config.yaml"
     if not empirica_config.exists():
         if output_format != "json":

--- a/empirica/data/repositories/workspace_db.py
+++ b/empirica/data/repositories/workspace_db.py
@@ -344,6 +344,26 @@ def _apply_engagement_substrate(cursor: sqlite3.Cursor) -> None:
         )
         """
     )
+    # Additive migration (self-heal on open). CREATE TABLE IF NOT EXISTS is a
+    # no-op when an OLD engagements table exists — one created before the E1
+    # sidecar columns (lifecycle_state/stage/domain/updated_at, commit 3af4815) —
+    # so those columns are never added, and the idx_engagements_lifecycle index
+    # below then HARD-CRASHES with `no such column: lifecycle_state` on every
+    # workspace-DB open (session-create / project-switch / auto-init all fail).
+    # PRAGMA the actual columns and ALTER-ADD any missing sidecar column BEFORE
+    # the index block. sqlite ALTER ADD COLUMN can't carry a CHECK; the enums are
+    # enforced at the API layer, matching the CREATE above.
+    _existing_engagement_cols = {row[1] for row in cursor.execute("PRAGMA table_info(engagements)").fetchall()}
+    for _col, _ddl in (
+        ("lifecycle_state", "lifecycle_state TEXT DEFAULT 'open'"),
+        ("stage", "stage TEXT"),
+        ("domain", "domain TEXT"),
+        ("updated_at", "updated_at REAL"),
+        ("outcome", "outcome TEXT"),
+        ("engagement_type", "engagement_type TEXT DEFAULT 'outreach'"),
+    ):
+        if _col not in _existing_engagement_cols:
+            cursor.execute(f"ALTER TABLE engagements ADD COLUMN {_ddl}")
     for idx in (
         "CREATE INDEX IF NOT EXISTS idx_stage_def_domain ON stage_definitions(domain, ordinal)",
         "CREATE INDEX IF NOT EXISTS idx_practice_domains_practice ON practice_domains(practice_id)",

--- a/tests/test_engagement_substrate_schema.py
+++ b/tests/test_engagement_substrate_schema.py
@@ -42,6 +42,24 @@ def test_apply_creates_substrate_tables():
     assert _tables(conn) >= _SUBSTRATE_TABLES
 
 
+def test_additive_migration_heals_pre_e1_engagements_table():
+    """Regression (1.12.10 hard-crash, mesh-support/Philipp repro): a workspace.db
+    whose `engagements` table predates the E1 sidecar columns must be
+    ALTER-migrated on open — CREATE TABLE IF NOT EXISTS no-ops on the existing
+    table, so without the additive pass the idx_engagements_lifecycle index below
+    crashes with `no such column: lifecycle_state`."""
+    conn = _fresh_db()
+    # Pre-E1 engagements table: no lifecycle_state/stage/domain/updated_at.
+    conn.execute("CREATE TABLE engagements (engagement_id TEXT PRIMARY KEY, title TEXT, status TEXT)")
+    conn.commit()
+    wdb._apply_engagement_substrate(conn.cursor())  # must NOT raise
+    conn.commit()
+    assert {"lifecycle_state", "stage", "domain", "updated_at", "outcome"} <= _cols(conn, "engagements")
+    # The index that used to crash now exists.
+    idx = {r[1] for r in conn.execute("PRAGMA index_list(engagements)").fetchall()}
+    assert "idx_engagements_lifecycle" in idx
+
+
 def test_engagements_has_e1_cols_and_no_contacts_fk():
     conn = _fresh_db()
     wdb._apply_engagement_substrate(conn.cursor())

--- a/tests/test_session_create_auto_init_wiring.py
+++ b/tests/test_session_create_auto_init_wiring.py
@@ -61,6 +61,30 @@ def test_handle_auto_init_returns_path_even_when_already_initialized(tmp_path, m
     assert project_path == str(tmp_path)
 
 
+def test_handle_auto_init_never_clobbers_existing_project_yaml(tmp_path, monkeypatch):
+    """Data-loss guard (1.12.10, mesh-support/Philipp repro): an existing
+    project.yaml (canonical id, gitignored → only copy) must be REUSED, never
+    overwritten with defaults + a random project_id. The old code guarded on
+    config.yaml, so project.yaml-present-but-config.yaml-absent regenerated it."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".empirica").mkdir()
+    canonical = "2273f11d-0000-4000-8000-000000000000"
+    (tmp_path / ".empirica" / "project.yaml").write_text(f"project_id: {canonical}\ntype: engagement\n")
+    # config.yaml intentionally ABSENT — the scenario that used to overwrite.
+    args = Namespace(auto_init=True)
+
+    with (
+        patch("empirica.config.path_resolver.get_git_root", return_value=tmp_path),
+        patch("empirica.cli.command_handlers.project_init.handle_project_init_command") as init_mock,
+    ):
+        performed, project_id, _project_path = _handle_auto_init(args, output_format="json", project_id=None)
+
+    init_mock.assert_not_called()  # project-init (the overwriter) never ran
+    assert performed is False
+    assert project_id == canonical  # reused the canonical id, not a fresh random one
+    assert canonical in (tmp_path / ".empirica" / "project.yaml").read_text()  # file untouched
+
+
 def test_handle_auto_init_no_flag_returns_none_path():
     """Without --auto-init, the third element is None."""
     args = Namespace(auto_init=False)


### PR DESCRIPTION
**Two 1.12.10 blockers** (mesh-support/Philipp repro, live-confirmed — `prop_s7od6sne`). These held the 1.12.10 publish.

## BUG 1 — hard crash on pre-E1 workspace DBs
`_apply_engagement_substrate` used only `CREATE TABLE IF NOT EXISTS`, so an `engagements` table created before the E1 sidecar columns (`lifecycle_state`/`stage`/`domain`/`updated_at`) never got them — and `CREATE INDEX idx_engagements_lifecycle ON engagements(lifecycle_state)` then crashed with **`no such column`** on **every** workspace-DB open (session-create / project-switch / project-list / SessionStart auto-init all fail). The 1.12.10 mesh-support rollout surfaces it on every pre-E1 box.

Fix: an **additive-migration pass** (`PRAGMA table_info` → `ALTER TABLE ADD COLUMN` for any missing sidecar column) before the index block. Self-heals on open. Verified live on a simulated pre-E1 table.

## BUG 2 — auto-init clobbers project.yaml (data loss)
`session-create --auto-init` guarded on `config.yaml` but project-init **overwrites `project.yaml`** — so project.yaml-present-but-config.yaml-absent regenerated `project.yaml` with defaults + a **random `project_id`**, destroying the canonical id + type/domain/tenant/calibration_weights (gitignored → only copy). Auto-init now **reuses** an existing `project.yaml`'s id and never overwrites it.

## Tests
Pre-E1 migration heals + index created (no crash); auto-init never clobbers existing project.yaml + reuses its id. 16 tests green, ruff clean.