### PR TITLE
feat(calibration): settable epistemic weights + Sentinel thresholds (source + resolver + daemon API)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Calibration config — settable epistemic weights + Sentinel thresholds (per-practice + global).**
+  A new `empirica/core/calibration_config.py` declares the tunable surface (the 4
+  dimension weights + 4 Sentinel thresholds — the same shape personas use as
+  `EpistemicConfig`) and an **overlay resolver** that layers `base → persona
+  preset → global override → practice override` (sparse overrides stored in a
+  dedicated `.empirica/calibration.yaml` per scope, never touching `project.yaml`).
+  New daemon endpoints `GET/PATCH /api/v1/calibration/config?scope=&practice_id=`
+  expose it (validated, range-clamped, reset-to-default via `null`) for the
+  extension's "Sentinel Tuning" tab. This is the settable *source* + read/write
+  surface; migrating the scattered runtime gate checks to read the resolver is a
+  tracked follow-up. Extension owns the UI slice.
+
 ### Security
 - **nltk removed from the dependency tree** — the `[prose]` evidence extra pulled
   `textstat`, which pulled `nltk` (`nltk` was `Required-by` textstat *only*), and

--- a/docs/reference/api/SERVE_API.md
+++ b/docs/reference/api/SERVE_API.md
@@ -671,6 +671,63 @@ curl -X POST http://localhost:8000/api/v1/artifacts/resolve \
 
 ---
 
+## Calibration Config (v1.13+)
+
+The settable epistemic **dimension weights** (Foundation / Comprehension /
+Execution / Engagement — a sum-to-1 group) and **Sentinel thresholds**
+(`engagement_gate`, `uncertainty_trigger`, `confidence_to_proceed`,
+`signal_quality_min`). Backed by an overlay resolver
+(`empirica/core/calibration_config.py`) that layers
+`base → persona preset → global override → practice override`. Overrides are
+sparse and stored per-scope in a dedicated `.empirica/calibration.yaml`.
+
+### GET /api/v1/calibration/config
+
+Query: `practice_id` (optional). Returns the effective (global→practice-layered)
+config for that practice, plus the field schema, preset names, and the raw
+per-scope override blocks.
+
+```jsonc
+{
+  "ok": true,
+  "weights": {"foundation": 0.35, "comprehension": 0.25, "execution": 0.25, "engagement": 0.15},
+  "thresholds": {"engagement_gate": 0.6, "uncertainty_trigger": 0.4, "confidence_to_proceed": 0.75, "signal_quality_min": 0.6},
+  "preset": null,                                  // effective persona preset, or null
+  "sources": {"thresholds.engagement_gate": "default"},  // default | preset:<name> | global | practice
+  "overridden": [],                                // keys set above the default
+  "schema": [{"key": "engagement_gate", "group": "thresholds", "default": 0.6, "min": 0.0, "max": 1.0, "label": "Engagement gate", "is_gate": true}, ...],
+  "presets": ["architecture", "code_review", "performance", "security", "sentinel", "ux"],
+  "overrides": {"global": {...}, "practice": {...}} // raw sparse blocks per scope
+}
+```
+
+### PATCH /api/v1/calibration/config
+
+Query: `scope=global|practice` (default `practice`), `practice_id` (required for
+practice scope). Body is a sparse override — any subset of
+`{"weights": {...}, "thresholds": {...}, "preset": "<name>|null"}`. Values are
+range-clamped; a `null` value **resets** that key to default. Unknown keys /
+presets → `422`; practice scope without a resolvable `practice_id` → `400`/`404`.
+Returns the new effective config (same shape as GET).
+
+```bash
+# Global: raise the engagement gate
+curl -X PATCH "$API/api/v1/calibration/config?scope=global" \
+  -H 'Content-Type: application/json' -d '{"thresholds": {"engagement_gate": 0.7}}'
+
+# Practice: adopt the 'security' preset, then reset one key to default
+curl -X PATCH "$API/api/v1/calibration/config?scope=practice&practice_id=empirica" \
+  -H 'Content-Type: application/json' -d '{"preset": "security"}'
+curl -X PATCH "$API/api/v1/calibration/config?scope=practice&practice_id=empirica" \
+  -H 'Content-Type: application/json' -d '{"thresholds": {"engagement_gate": null}}'
+```
+
+> Scope note: this is the settable *source* + read/write surface. Migrating the
+> runtime gate checks to read the resolver is a tracked follow-up, so writes are
+> persisted and resolvable today but do not yet alter live enforcement.
+
+---
+
 ## Models
 
 ### HealthResponse

--- a/empirica/api/app.py
+++ b/empirica/api/app.py
@@ -71,12 +71,13 @@ def create_app() -> Flask:
 
     # Register blueprints
     from .auth import APIKeyMiddleware
-    from .routes import comparison, deltas, heatmaps, project, sessions, verification
+    from .routes import calibration, comparison, deltas, heatmaps, project, sessions, verification
 
     # Apply API key authentication middleware
     app.wsgi_app = APIKeyMiddleware(app.wsgi_app, prefix="/api/v1")  # type: ignore[method-assign]
 
     app.register_blueprint(sessions.bp, url_prefix="/api/v1")
+    app.register_blueprint(calibration.bp, url_prefix="/api/v1")
     app.register_blueprint(deltas.bp, url_prefix="/api/v1")
     app.register_blueprint(verification.bp, url_prefix="/api/v1")
     app.register_blueprint(heatmaps.bp, url_prefix="/api/v1")

--- a/empirica/api/routes/calibration.py
+++ b/empirica/api/routes/calibration.py
@@ -1,0 +1,113 @@
+"""Calibration-config endpoints — the settable epistemic weights + Sentinel
+thresholds surfaced to the extension's "Sentinel Tuning" tab.
+
+    GET   /api/v1/calibration/config?practice_id=<id>
+    PATCH /api/v1/calibration/config?scope=global|practice&practice_id=<id>
+
+GET returns the effective (global→practice-layered) config for a practice, plus
+the field schema, preset names, and the raw per-scope override blocks so the UI
+can show what's set where. PATCH validates a sparse body ({weights?, thresholds?,
+preset?}; a null value resets a key) and writes it to the requested scope's
+``.empirica/calibration.yaml``.
+"""
+
+import logging
+import os
+from pathlib import Path
+
+from flask import Blueprint, jsonify, request
+
+from empirica.core import calibration_config as cc
+
+bp = Blueprint("calibration", __name__)
+logger = logging.getLogger(__name__)
+
+_DEBUG_MODE = os.environ.get("FLASK_DEBUG", "false").lower() == "true"
+
+
+def _safe_error(error: Exception) -> str:
+    return str(error) if _DEBUG_MODE else "An internal error occurred"
+
+
+def _global_dir() -> Path:
+    return Path.home()
+
+
+def _resolve_practice_dir(practice_id: str) -> Path | None:
+    """Resolve a practice_id (project_id / name / ai_id) to its project dir via
+    the daemon registry. Returns None if unresolved."""
+    try:
+        from empirica.api.registry import load_registry
+
+        reg = load_registry()
+    except Exception as e:
+        logger.debug(f"calibration: registry load failed: {e}")
+        return None
+    for proj in reg.get("projects", []):
+        if not isinstance(proj, dict):
+            continue
+        ids = {str(proj.get(k)) for k in ("project_id", "id", "name", "ai_id") if proj.get(k)}
+        if practice_id in ids:
+            path = proj.get("path") or proj.get("root") or proj.get("project_path") or proj.get("realpath")
+            return Path(path) if path else None
+    return None
+
+
+def _effective(practice_id: str | None) -> dict:
+    """Resolve the effective config: global override always applies; practice
+    override layers on top when the practice_id resolves."""
+    global_ov = cc.read_override(_global_dir())
+    practice_ov: dict = {}
+    if practice_id:
+        d = _resolve_practice_dir(practice_id)
+        if d is not None:
+            practice_ov = cc.read_override(d)
+    resolved = cc.resolve(global_ov, practice_ov)
+    resolved["schema"] = cc.schema_json()
+    resolved["presets"] = sorted(cc.preset_names())
+    resolved["overrides"] = {"global": global_ov, "practice": practice_ov}
+    return resolved
+
+
+@bp.route("/calibration/config", methods=["GET"])
+def get_config():
+    """Effective calibration config for a practice (or global-only if no id)."""
+    try:
+        practice_id = request.args.get("practice_id")
+        return jsonify({"ok": True, **_effective(practice_id)})
+    except Exception as e:
+        logger.error(f"calibration GET failed: {e}", exc_info=True)
+        return jsonify({"ok": False, "error": _safe_error(e)}), 500
+
+
+@bp.route("/calibration/config", methods=["PATCH"])
+def patch_config():
+    """Write a sparse override to a scope's .empirica/calibration.yaml."""
+    try:
+        scope = request.args.get("scope", "practice")
+        practice_id = request.args.get("practice_id")
+
+        if scope == "global":
+            scope_dir: Path | None = _global_dir()
+        elif scope == "practice":
+            if not practice_id:
+                return jsonify({"ok": False, "error": "practice scope requires practice_id"}), 400
+            scope_dir = _resolve_practice_dir(practice_id)
+            if scope_dir is None:
+                return jsonify({"ok": False, "error": f"unknown practice_id: {practice_id}"}), 404
+        else:
+            return jsonify({"ok": False, "error": f"invalid scope: {scope!r} (global|practice)"}), 400
+
+        body = request.get_json(silent=True) or {}
+        if not isinstance(body, dict):
+            return jsonify({"ok": False, "error": "body must be a JSON object"}), 400
+
+        clean, errors = cc.validate_patch(body)
+        if errors:
+            return jsonify({"ok": False, "error": "validation failed", "details": errors}), 422
+
+        cc.apply_patch(scope_dir, clean)
+        return jsonify({"ok": True, "scope": scope, **_effective(practice_id if scope == "practice" else None)})
+    except Exception as e:
+        logger.error(f"calibration PATCH failed: {e}", exc_info=True)
+        return jsonify({"ok": False, "error": _safe_error(e)}), 500

--- a/empirica/core/calibration_config.py
+++ b/empirica/core/calibration_config.py
@@ -1,0 +1,309 @@
+"""Calibration config — the user-settable epistemic weights + Sentinel thresholds.
+
+A thin **overlay resolver** over empirica's existing config systems. It declares
+the tunable surface (4 dimension weights + 4 Sentinel thresholds — the same shape
+personas already use as ``EpistemicConfig``) and resolves an effective config by
+layering, low→high precedence::
+
+    base defaults → persona preset → global override → practice override
+
+Each override layer is a **sparse** dict (only the keys a scope actually changed),
+optionally carrying a ``preset`` naming a built-in persona template. Storage is a
+dedicated ``.empirica/calibration.yaml`` per scope (practice = ``<project>/.empirica``,
+global = ``~/.empirica``) — deliberately NOT embedded in ``project.yaml``, whose
+comments/canonical fields we must not rewrite.
+
+The extension's "Sentinel Tuning" tab reads/writes this via the daemon
+(``GET/PATCH /api/v1/calibration/config``).
+
+Scope note: this layer is the single *settable source* + read/write surface. It
+does not yet change runtime enforcement — migrating the scattered gate checks to
+read ``resolve()`` is a tracked follow-up.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+@dataclass(frozen=True)
+class FieldSpec:
+    """One tunable field: its group, default, valid range, and display label."""
+
+    key: str
+    group: str  # "weights" | "thresholds"
+    default: float
+    minimum: float
+    maximum: float
+    label: str
+    is_gate: bool = False
+
+
+# The settable surface — mirrors persona EpistemicConfig (weights + thresholds).
+# Defaults match the current base config (reflex_exporter overall weights +
+# persona/UniversalConstraints threshold defaults). Extensible: add rows here
+# (e.g. comprehension.high) as the tuning surface grows.
+SCHEMA: tuple[FieldSpec, ...] = (
+    # Dimension weights — a sum-to-1 group (the confidence-rollup weighting).
+    FieldSpec("foundation", "weights", 0.35, 0.0, 1.0, "Foundation"),
+    FieldSpec("comprehension", "weights", 0.25, 0.0, 1.0, "Comprehension"),
+    FieldSpec("execution", "weights", 0.25, 0.0, 1.0, "Execution"),
+    FieldSpec("engagement", "weights", 0.15, 0.0, 1.0, "Engagement"),
+    # Sentinel thresholds.
+    FieldSpec("engagement_gate", "thresholds", 0.60, 0.0, 1.0, "Engagement gate", is_gate=True),
+    FieldSpec("uncertainty_trigger", "thresholds", 0.40, 0.0, 1.0, "Uncertainty trigger"),
+    FieldSpec("confidence_to_proceed", "thresholds", 0.75, 0.0, 1.0, "Confidence to proceed"),
+    FieldSpec("signal_quality_min", "thresholds", 0.60, 0.0, 1.0, "Signal quality min"),
+)
+
+GROUPS: tuple[str, ...] = ("weights", "thresholds")
+WEIGHT_KEYS: tuple[str, ...] = tuple(f.key for f in SCHEMA if f.group == "weights")
+_SPEC_BY_GROUP_KEY: dict[tuple[str, str], FieldSpec] = {(f.group, f.key): f for f in SCHEMA}
+
+_CALIBRATION_FILENAME = "calibration.yaml"
+
+
+# ── schema helpers ───────────────────────────────────────────────────────────
+
+
+def schema_json() -> list[dict[str, Any]]:
+    """The schema as JSON-serializable field specs (for the extension UI)."""
+    return [
+        {
+            "key": f.key,
+            "group": f.group,
+            "default": f.default,
+            "min": f.minimum,
+            "max": f.maximum,
+            "label": f.label,
+            "is_gate": f.is_gate,
+        }
+        for f in SCHEMA
+    ]
+
+
+def default_config() -> dict[str, dict[str, float]]:
+    """The base config from SCHEMA defaults, grouped by weights/thresholds."""
+    out: dict[str, dict[str, float]] = {g: {} for g in GROUPS}
+    for f in SCHEMA:
+        out[f.group][f.key] = f.default
+    return out
+
+
+def preset_names() -> set[str]:
+    """Names of the built-in persona presets (empty set if unavailable)."""
+    try:
+        from empirica.core.persona.templates import BUILTIN_TEMPLATES
+
+        return set(BUILTIN_TEMPLATES)
+    except Exception:
+        return set()
+
+
+def _preset_layer(name: str | None) -> dict[str, dict[str, float]] | None:
+    """Return {weights, thresholds} for a persona preset, or None if unknown."""
+    if not name:
+        return None
+    try:
+        from empirica.core.persona.templates import BUILTIN_TEMPLATES
+    except Exception:
+        return None
+    tpl = BUILTIN_TEMPLATES.get(name)
+    if not isinstance(tpl, dict):
+        return None
+    layer: dict[str, dict[str, float]] = {"weights": {}, "thresholds": {}}
+    for group in ("weights", "thresholds"):
+        block = tpl.get(group)
+        if not isinstance(block, dict):
+            continue
+        for k, v in block.items():
+            try:
+                layer[group][str(k)] = float(v)
+            except (TypeError, ValueError):
+                continue
+    return layer
+
+
+def _clamp(spec: FieldSpec, value: Any) -> float | None:
+    """Coerce+clamp a value to the spec's range, or None if not a number."""
+    try:
+        v = float(value)
+    except (TypeError, ValueError):
+        return None
+    return max(spec.minimum, min(spec.maximum, v))
+
+
+def normalize_weights(weights: dict[str, float]) -> dict[str, float]:
+    """Normalize the weight group to sum to 1.0. Falls back to equal weights if
+    the sum is non-positive."""
+    total = sum(float(weights.get(k, 0.0)) for k in WEIGHT_KEYS)
+    if total <= 0:
+        return {k: 1.0 / len(WEIGHT_KEYS) for k in WEIGHT_KEYS}
+    return {k: float(weights.get(k, 0.0)) / total for k in WEIGHT_KEYS}
+
+
+def _apply_overlay(
+    resolved: dict[str, dict[str, float]],
+    source_map: dict[tuple[str, str], str],
+    overlay: dict[str, dict[str, float]] | None,
+    source_label: str,
+) -> None:
+    """Overlay a sparse {weights, thresholds} dict onto resolved, clamping to
+    spec range and stamping source_map. Unknown keys are ignored."""
+    if not overlay:
+        return
+    for group in GROUPS:
+        for key, value in (overlay.get(group) or {}).items():
+            spec = _SPEC_BY_GROUP_KEY.get((group, key))
+            if spec is None:
+                continue
+            clamped = _clamp(spec, value)
+            if clamped is None:
+                continue
+            resolved[group][key] = clamped
+            source_map[(group, key)] = source_label
+
+
+def resolve(
+    global_override: dict | None = None,
+    practice_override: dict | None = None,
+    normalize: bool = True,
+) -> dict[str, Any]:
+    """Resolve the effective config by layering base → global → practice.
+
+    Each ``*_override`` is a sparse dict, optionally with a ``preset`` key naming
+    a persona template. Within a scope, the preset applies first, then the
+    scope's per-key overrides. Returns::
+
+        {
+          "weights": {...}, "thresholds": {...},
+          "preset": <effective preset name or None>,
+          "sources": {"<group>.<key>": "default|preset:<name>|global|practice"},
+          "overridden": ["<group>.<key>", ...],   # keys set above the default
+        }
+    """
+    resolved = default_config()
+    source_map: dict[tuple[str, str], str] = {(f.group, f.key): "default" for f in SCHEMA}
+    effective_preset: str | None = None
+
+    for scope_label, override in (("global", global_override), ("practice", practice_override)):
+        override = override or {}
+        preset_name = override.get("preset")
+        preset = _preset_layer(preset_name)
+        if preset:
+            effective_preset = preset_name
+            _apply_overlay(resolved, source_map, preset, f"preset:{preset_name}")
+        sparse = {g: (override.get(g) or {}) for g in GROUPS}
+        _apply_overlay(resolved, source_map, sparse, scope_label)
+
+    if normalize:
+        resolved["weights"] = normalize_weights(resolved["weights"])
+
+    sources = {f"{g}.{k}": src for (g, k), src in source_map.items()}
+    overridden = sorted(f"{g}.{k}" for (g, k), src in source_map.items() if src != "default")
+    return {
+        "weights": resolved["weights"],
+        "thresholds": resolved["thresholds"],
+        "preset": effective_preset,
+        "sources": sources,
+        "overridden": overridden,
+    }
+
+
+# ── sparse-override store (dedicated .empirica/calibration.yaml per scope) ─────
+
+
+def override_path(scope_dir: str | Path) -> Path:
+    """The calibration override file inside a scope's .empirica dir."""
+    return Path(scope_dir) / ".empirica" / _CALIBRATION_FILENAME
+
+
+def read_override(scope_dir: str | Path) -> dict[str, Any]:
+    """Read a scope's sparse override ({} if absent/unreadable)."""
+    p = override_path(scope_dir)
+    if not p.exists():
+        return {}
+    try:
+        data = yaml.safe_load(p.read_text(encoding="utf-8")) or {}
+    except Exception:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def validate_patch(patch: dict) -> tuple[dict, list[str]]:
+    """Validate a sparse PATCH body ({weights?, thresholds?, preset?}). Returns
+    (clean, errors). Clamps numbers to spec range; a ``None`` value is a valid
+    reset-to-default signal; unknown keys/presets are errors."""
+    clean: dict[str, Any] = {}
+    errors: list[str] = []
+
+    if "preset" in patch:
+        name = patch["preset"]
+        if name is None or (isinstance(name, str) and name in preset_names()):
+            clean["preset"] = name
+        else:
+            errors.append(f"unknown preset: {name!r}")
+
+    for group in GROUPS:
+        block = patch.get(group)
+        if block is None:
+            continue
+        if not isinstance(block, dict):
+            errors.append(f"{group} must be an object")
+            continue
+        for key, value in block.items():
+            spec = _SPEC_BY_GROUP_KEY.get((group, key))
+            if spec is None:
+                errors.append(f"unknown {group} key: {key}")
+                continue
+            if value is None:
+                clean.setdefault(group, {})[key] = None  # reset-to-default
+                continue
+            clamped = _clamp(spec, value)
+            if clamped is None:
+                errors.append(f"{group}.{key} must be a number in [{spec.minimum}, {spec.maximum}]")
+                continue
+            clean.setdefault(group, {})[key] = clamped
+
+    return clean, errors
+
+
+def apply_patch(scope_dir: str | Path, patch: dict) -> dict[str, Any]:
+    """Merge a validated sparse patch into a scope's override file (creating it
+    if absent). A ``None`` value removes that key (reset-to-default). Returns the
+    resulting override block. Callers should ``validate_patch`` first."""
+    p = override_path(scope_dir)
+    block = read_override(scope_dir)
+
+    if "preset" in patch:
+        if patch["preset"] is None:
+            block.pop("preset", None)
+        else:
+            block["preset"] = patch["preset"]
+
+    for group in GROUPS:
+        if group not in patch:
+            continue
+        gblock = block.get(group)
+        if not isinstance(gblock, dict):
+            gblock = {}
+        for key, value in patch[group].items():
+            if value is None:
+                gblock.pop(key, None)
+            else:
+                gblock[key] = value
+        if gblock:
+            block[group] = gblock
+        else:
+            block.pop(group, None)
+
+    p.parent.mkdir(parents=True, exist_ok=True)
+    if block:
+        p.write_text(yaml.safe_dump(block, default_flow_style=False, sort_keys=False), encoding="utf-8")
+    elif p.exists():
+        p.unlink()  # nothing left to override → remove the file
+    return block

--- a/tests/core/test_calibration_config.py
+++ b/tests/core/test_calibration_config.py
@@ -1,0 +1,149 @@
+"""Tests for the calibration-config overlay resolver + sparse-override store.
+
+Covers the settable schema, the layering resolver (base → preset → global →
+practice), weight normalization, PATCH validation, and the dedicated
+.empirica/calibration.yaml store (roundtrip, reset-to-default, file cleanup).
+"""
+
+from __future__ import annotations
+
+from empirica.core import calibration_config as cc
+
+# ── schema + defaults ─────────────────────────────────────────────────────────
+
+
+def test_schema_has_weights_and_thresholds():
+    groups = {f.group for f in cc.SCHEMA}
+    assert groups == {"weights", "thresholds"}
+    assert cc.WEIGHT_KEYS == ("foundation", "comprehension", "execution", "engagement")
+
+
+def test_default_config_matches_spec_defaults():
+    d = cc.default_config()
+    assert d["weights"] == {"foundation": 0.35, "comprehension": 0.25, "execution": 0.25, "engagement": 0.15}
+    assert d["thresholds"]["engagement_gate"] == 0.60
+    assert d["thresholds"]["uncertainty_trigger"] == 0.40
+
+
+def test_schema_json_is_serializable_field_specs():
+    rows = cc.schema_json()
+    assert len(rows) == len(cc.SCHEMA)
+    gate = next(r for r in rows if r["key"] == "engagement_gate")
+    assert gate["is_gate"] is True and gate["group"] == "thresholds" and gate["default"] == 0.60
+
+
+# ── resolver ──────────────────────────────────────────────────────────────────
+
+
+def test_resolve_no_overrides_is_defaults_all_sourced_default():
+    r = cc.resolve()
+    assert r["weights"]["foundation"] == 0.35  # already sums to 1.0 → unchanged
+    assert r["preset"] is None
+    assert r["overridden"] == []
+    assert set(r["sources"].values()) == {"default"}
+
+
+def test_resolve_global_preset_applies_persona_values():
+    r = cc.resolve(global_override={"preset": "security"})
+    # security template: engagement_gate 0.70, foundation weight 0.40
+    assert r["preset"] == "security"
+    assert r["thresholds"]["engagement_gate"] == 0.70
+    assert r["sources"]["thresholds.engagement_gate"] == "preset:security"
+    # weights renormalized but foundation still the largest
+    assert r["weights"]["foundation"] == max(r["weights"].values())
+
+
+def test_practice_override_wins_over_global_preset():
+    r = cc.resolve(
+        global_override={"preset": "security"},  # engagement_gate 0.70
+        practice_override={"thresholds": {"engagement_gate": 0.5}},
+    )
+    assert r["thresholds"]["engagement_gate"] == 0.5
+    assert r["sources"]["thresholds.engagement_gate"] == "practice"
+    assert "thresholds.engagement_gate" in r["overridden"]
+
+
+def test_resolve_clamps_out_of_range_and_ignores_unknown_keys():
+    r = cc.resolve(
+        practice_override={
+            "thresholds": {"engagement_gate": 5.0, "bogus": 0.9},  # 5.0 clamps to 1.0; bogus ignored
+        },
+        normalize=False,
+    )
+    assert r["thresholds"]["engagement_gate"] == 1.0
+    assert "bogus" not in r["thresholds"]
+
+
+def test_normalize_weights_sums_to_one():
+    out = cc.normalize_weights({"foundation": 2, "comprehension": 1, "execution": 1, "engagement": 0})
+    assert abs(sum(out.values()) - 1.0) < 1e-9
+    assert out["foundation"] == 0.5
+
+
+def test_normalize_weights_zero_sum_falls_back_equal():
+    out = cc.normalize_weights(dict.fromkeys(cc.WEIGHT_KEYS, 0.0))
+    assert all(abs(v - 0.25) < 1e-9 for v in out.values())
+
+
+# ── PATCH validation ──────────────────────────────────────────────────────────
+
+
+def test_validate_patch_clamps_and_accepts_reset_none():
+    clean, errors = cc.validate_patch({"thresholds": {"engagement_gate": 2.0, "signal_quality_min": None}})
+    assert errors == []
+    assert clean["thresholds"]["engagement_gate"] == 1.0
+    assert clean["thresholds"]["signal_quality_min"] is None  # reset signal preserved
+
+
+def test_validate_patch_rejects_unknown_key_and_preset():
+    _clean, errors = cc.validate_patch({"weights": {"nope": 0.5}, "preset": "not-a-persona"})
+    assert any("unknown weights key" in e for e in errors)
+    assert any("unknown preset" in e for e in errors)
+
+
+def test_validate_patch_rejects_non_number():
+    _clean, errors = cc.validate_patch({"thresholds": {"engagement_gate": "high"}})
+    assert any("must be a number" in e for e in errors)
+
+
+def test_validate_patch_accepts_null_preset_reset():
+    clean, errors = cc.validate_patch({"preset": None})
+    assert errors == [] and clean["preset"] is None
+
+
+# ── store roundtrip ───────────────────────────────────────────────────────────
+
+
+def test_apply_patch_roundtrip_and_read(tmp_path):
+    cc.apply_patch(tmp_path, {"thresholds": {"engagement_gate": 0.7}, "preset": "security"})
+    ov = cc.read_override(tmp_path)
+    assert ov["thresholds"]["engagement_gate"] == 0.7
+    assert ov["preset"] == "security"
+    assert cc.override_path(tmp_path).exists()
+
+
+def test_read_override_absent_is_empty(tmp_path):
+    assert cc.read_override(tmp_path) == {}
+
+
+def test_apply_patch_none_resets_key_and_cleans_empty_file(tmp_path):
+    cc.apply_patch(tmp_path, {"thresholds": {"engagement_gate": 0.7}})
+    assert cc.read_override(tmp_path)["thresholds"]["engagement_gate"] == 0.7
+    # reset the only key → block empties → file removed
+    cc.apply_patch(tmp_path, {"thresholds": {"engagement_gate": None}})
+    assert cc.read_override(tmp_path) == {}
+    assert not cc.override_path(tmp_path).exists()
+
+
+def test_apply_patch_clear_preset(tmp_path):
+    cc.apply_patch(tmp_path, {"preset": "ux"})
+    assert cc.read_override(tmp_path)["preset"] == "ux"
+    cc.apply_patch(tmp_path, {"preset": None})
+    assert "preset" not in cc.read_override(tmp_path)
+
+
+def test_store_then_resolve_end_to_end(tmp_path):
+    cc.apply_patch(tmp_path, {"thresholds": {"engagement_gate": 0.8}})
+    r = cc.resolve(practice_override=cc.read_override(tmp_path))
+    assert r["thresholds"]["engagement_gate"] == 0.8
+    assert "thresholds.engagement_gate" in r["overridden"]

--- a/tests/test_calibration_route.py
+++ b/tests/test_calibration_route.py
@@ -1,0 +1,94 @@
+"""Route tests for GET/PATCH /api/v1/calibration/config.
+
+Registers just the calibration blueprint on a bare Flask app (bypassing the
+daemon's auth middleware + DB), and monkeypatches the scope dirs to tmp so no
+real ~/.empirica or project files are touched.
+"""
+
+from __future__ import annotations
+
+import pytest
+from flask import Flask
+
+from empirica.api.routes import calibration
+
+
+@pytest.fixture()
+def client(tmp_path, monkeypatch):
+    global_dir = tmp_path / "global"
+    practice_dir = tmp_path / "practice-A"
+    global_dir.mkdir()
+    practice_dir.mkdir()
+
+    monkeypatch.setattr(calibration, "_global_dir", lambda: global_dir)
+    monkeypatch.setattr(
+        calibration,
+        "_resolve_practice_dir",
+        lambda pid: practice_dir if pid == "practice-A" else None,
+    )
+
+    app = Flask(__name__)
+    app.register_blueprint(calibration.bp, url_prefix="/api/v1")
+    return app.test_client()
+
+
+def test_get_returns_schema_presets_and_defaults(client):
+    resp = client.get("/api/v1/calibration/config")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["ok"] is True
+    assert body["weights"]["foundation"] == 0.35
+    assert body["thresholds"]["engagement_gate"] == 0.60
+    assert len(body["schema"]) == 8
+    assert "security" in body["presets"]
+    assert body["overridden"] == []
+
+
+def test_patch_global_persists_and_reflects(client):
+    resp = client.patch("/api/v1/calibration/config?scope=global", json={"thresholds": {"engagement_gate": 0.7}})
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["ok"] is True
+    assert body["thresholds"]["engagement_gate"] == 0.7
+    # a fresh GET sees the persisted global override
+    body2 = client.get("/api/v1/calibration/config").get_json()
+    assert body2["thresholds"]["engagement_gate"] == 0.7
+    assert "thresholds.engagement_gate" in body2["overridden"]
+
+
+def test_patch_practice_layers_over_global(client):
+    client.patch("/api/v1/calibration/config?scope=global", json={"thresholds": {"engagement_gate": 0.7}})
+    client.patch(
+        "/api/v1/calibration/config?scope=practice&practice_id=practice-A",
+        json={"thresholds": {"engagement_gate": 0.9}},
+    )
+    body = client.get("/api/v1/calibration/config?practice_id=practice-A").get_json()
+    assert body["thresholds"]["engagement_gate"] == 0.9  # practice wins
+    assert body["sources"]["thresholds.engagement_gate"] == "practice"
+
+
+def test_patch_invalid_key_is_422(client):
+    resp = client.patch("/api/v1/calibration/config?scope=global", json={"thresholds": {"bogus": 0.5}})
+    assert resp.status_code == 422
+    assert "details" in resp.get_json()
+
+
+def test_patch_practice_without_id_is_400(client):
+    resp = client.patch("/api/v1/calibration/config?scope=practice", json={"thresholds": {"engagement_gate": 0.7}})
+    assert resp.status_code == 400
+
+
+def test_patch_unknown_practice_is_404(client):
+    resp = client.patch(
+        "/api/v1/calibration/config?scope=practice&practice_id=nope",
+        json={"thresholds": {"engagement_gate": 0.7}},
+    )
+    assert resp.status_code == 404
+
+
+def test_patch_reset_key_restores_default(client):
+    client.patch("/api/v1/calibration/config?scope=global", json={"thresholds": {"engagement_gate": 0.7}})
+    client.patch("/api/v1/calibration/config?scope=global", json={"thresholds": {"engagement_gate": None}})
+    body = client.get("/api/v1/calibration/config").get_json()
+    assert body["thresholds"]["engagement_gate"] == 0.60  # back to default
+    assert body["overridden"] == []


### PR DESCRIPTION
## What

The empirica backend for the **Sentinel Tuning** feature (goal `3e03fd86`, David-directed). Makes the epistemic **dimension weights** + **Sentinel thresholds** a single settable source, scoped **per-practice + global**, with a daemon API the extension's tab binds to. Extension owns the UI slice (handed off, accepted).

## Why an overlay, not a rewrite

The config was scattered across ~5 systems (`thresholds.py`/`cascade_styles`, `confidence_weights`, persona `EpistemicConfig`, `profile_loader`/`investigation_profiles`, sentinel `DomainProfile`), with `engagement_gate` duplicated across 4. A full unification is high-risk. This adds a thin **overlay resolver** on top instead.

## How (slices 1→2→3)

1. **`empirica/core/calibration_config.py`** — declares the tunable surface (4 weights + 4 thresholds, mirroring persona `EpistemicConfig`; each `min/max/default/label`) + an **overlay resolver** layering `base → persona preset → global override → practice override`, with sum-to-1 weight normalization + range clamping.
2. **Sparse-override store** — overrides live in a **dedicated `.empirica/calibration.yaml`** per scope (global = `~/.empirica`, practice = `<project>/.empirica`) — deliberately *not* embedded in `project.yaml` (the #211 gitignored-canonical lesson). `null` value = reset-to-default; empties clean up the file.
3. **Daemon `GET/PATCH /api/v1/calibration/config?scope=&practice_id=`** — GET returns effective config + schema + presets + per-scope override blocks; PATCH validates (`422` unknown key/preset, `400/404` practice resolution).

## Verification

- `pytest` → **25 pass** (18 core: resolver/layering/clamp/normalize/validate/store-roundtrip/reset; 7 route: GET/PATCH/scope/validation/reset)
- `ruff check` + `ruff format --check` → clean · `pyright` → 0 errors

## Scope / follow-up

This ships the settable **source + read/write surface** — writes persist and resolve today. **Migrating the runtime gate checks to read the resolver** (so overrides alter live enforcement) is the tracked follow-up (goal task 4). The extension tab can build against this contract now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)