### PR TITLE
feat(calibration): add ready_uncertainty (the real gate) + effective_for_session resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   extension's "Sentinel Tuning" tab. This is the settable *source* + read/write
   surface; migrating the scattered runtime gate checks to read the resolver is a
   tracked follow-up. Extension owns the UI slice.
+  A code-verified deep dive established that the live CHECK gate is
+  **uncertainty-only** (`uncertainty ≤ ready_uncertainty_threshold`, default
+  0.35, per the 2026-04-07 meta-uncertainty redesign) — so `engagement_gate`
+  (0.6) does not gate CHECK at runtime. Added a settable **`ready_uncertainty`**
+  field (the real gate) and a runtime **`effective_for_session(project_path)`**
+  resolver (leaf helper, layers global→practice, defaults preserved exactly when
+  no override exists). Wiring these into the three live threshold accessors
+  (CLI `_check_load_dynamic_thresholds`, the hook, the evaluator) — so an
+  override actually shifts the gate — is the next, gating-critical step.
 
 ### Security
 - **nltk removed from the dependency tree** — the `[prose]` evidence extra pulled

--- a/empirica/core/calibration_config.py
+++ b/empirica/core/calibration_config.py
@@ -53,7 +53,13 @@ SCHEMA: tuple[FieldSpec, ...] = (
     FieldSpec("comprehension", "weights", 0.25, 0.0, 1.0, "Comprehension"),
     FieldSpec("execution", "weights", 0.25, 0.0, 1.0, "Execution"),
     FieldSpec("engagement", "weights", 0.15, 0.0, 1.0, "Engagement"),
-    # Sentinel thresholds.
+    # Sentinel thresholds. ready_uncertainty is THE live CHECK gate
+    # (proceed when uncertainty <= this; default 0.35, per the 2026-04-07
+    # meta-uncertainty redesign). engagement_gate feeds the hook's escalate
+    # check; the rest feed personas/reports.
+    FieldSpec(
+        "ready_uncertainty", "thresholds", 0.35, 0.0, 1.0, "CHECK gate: max uncertainty to proceed", is_gate=True
+    ),
     FieldSpec("engagement_gate", "thresholds", 0.60, 0.0, 1.0, "Engagement gate", is_gate=True),
     FieldSpec("uncertainty_trigger", "thresholds", 0.40, 0.0, 1.0, "Uncertainty trigger"),
     FieldSpec("confidence_to_proceed", "thresholds", 0.75, 0.0, 1.0, "Confidence to proceed"),
@@ -307,3 +313,25 @@ def apply_patch(scope_dir: str | Path, patch: dict) -> dict[str, Any]:
     elif p.exists():
         p.unlink()  # nothing left to override → remove the file
     return block
+
+
+# ── runtime resolution (entry point for enforcement wiring) ──────────────────
+
+
+def effective_for_session(project_path: str | Path | None = None) -> dict[str, Any]:
+    """Resolve the effective calibration config for the active practice.
+
+    Layers global (``~/.empirica``) → practice (``<project_path>/.empirica``).
+    ``project_path=None`` resolves global-only. Returns the same shape as
+    ``resolve()``.
+
+    This is the runtime entry point for enforcement sites: the caller passes the
+    current session's project dir (which enforcement sites already resolve for
+    other reasons), so this module stays a leaf and never imports the session
+    resolver. Enforcement sites should read a value only when its key is in the
+    returned ``overridden`` list — absent an override the resolved value equals
+    the base default, so a bad/missing file can never widen a gate.
+    """
+    global_override = read_override(Path.home())
+    practice_override = read_override(project_path) if project_path else {}
+    return resolve(global_override, practice_override)

--- a/tests/core/test_calibration_config.py
+++ b/tests/core/test_calibration_config.py
@@ -21,6 +21,7 @@ def test_schema_has_weights_and_thresholds():
 def test_default_config_matches_spec_defaults():
     d = cc.default_config()
     assert d["weights"] == {"foundation": 0.35, "comprehension": 0.25, "execution": 0.25, "engagement": 0.15}
+    assert d["thresholds"]["ready_uncertainty"] == 0.35  # THE live CHECK gate default
     assert d["thresholds"]["engagement_gate"] == 0.60
     assert d["thresholds"]["uncertainty_trigger"] == 0.40
 
@@ -147,3 +148,36 @@ def test_store_then_resolve_end_to_end(tmp_path):
     r = cc.resolve(practice_override=cc.read_override(tmp_path))
     assert r["thresholds"]["engagement_gate"] == 0.8
     assert "thresholds.engagement_gate" in r["overridden"]
+
+
+# ── effective_for_session (runtime enforcement entry point) ───────────────────
+
+
+def test_effective_for_session_no_override_is_default(tmp_path, monkeypatch):
+    monkeypatch.setattr(cc.Path, "home", lambda: tmp_path / "home")
+    eff = cc.effective_for_session(tmp_path / "proj")  # neither dir has calibration.yaml
+    assert eff["thresholds"]["ready_uncertainty"] == 0.35  # exact default preserved
+    assert eff["overridden"] == []
+
+
+def test_effective_for_session_practice_wins_over_global(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    practice = tmp_path / "proj"
+    home.mkdir()
+    practice.mkdir()
+    monkeypatch.setattr(cc.Path, "home", lambda: home)
+    cc.apply_patch(home, {"thresholds": {"ready_uncertainty": 0.30}})
+    cc.apply_patch(practice, {"thresholds": {"ready_uncertainty": 0.45}})
+    eff = cc.effective_for_session(practice)
+    assert eff["thresholds"]["ready_uncertainty"] == 0.45  # practice overrides global
+    assert eff["sources"]["thresholds.ready_uncertainty"] == "practice"
+
+
+def test_effective_for_session_none_path_is_global_only(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(cc.Path, "home", lambda: home)
+    cc.apply_patch(home, {"thresholds": {"ready_uncertainty": 0.30}})
+    eff = cc.effective_for_session(None)
+    assert eff["thresholds"]["ready_uncertainty"] == 0.30
+    assert eff["sources"]["thresholds.ready_uncertainty"] == "global"

--- a/tests/test_calibration_route.py
+++ b/tests/test_calibration_route.py
@@ -39,7 +39,7 @@ def test_get_returns_schema_presets_and_defaults(client):
     assert body["ok"] is True
     assert body["weights"]["foundation"] == 0.35
     assert body["thresholds"]["engagement_gate"] == 0.60
-    assert len(body["schema"]) == 8
+    assert len(body["schema"]) == 9
     assert "security" in body["presets"]
     assert body["overridden"] == []
 


### PR DESCRIPTION
## What

Substrate for de-hardcoding the Sentinel gate (goal `3e03fd86` task 4), following a **code-verified deep dive**.

## The reframe (verified)

The live CHECK gate is **uncertainty-only** — `_workflow_check.py:621`/`:634`: `uncertainty <= ready_uncertainty_threshold` (default **0.35**, per the 2026-04-07 meta-uncertainty redesign), read via three runtime accessors (CLI `_check_load_dynamic_thresholds`, the sentinel-gate hook, the `sentinel_hooks` evaluator). So `calibration_config`'s `engagement_gate` (0.6) is a **dead knob** on the live path — the real settable gate is `ready_uncertainty`.

## This PR (pure-additive — no enforcement change)

- Adds the **`ready_uncertainty`** field (0.35, `is_gate=true`) — THE live CHECK gate.
- Adds **`effective_for_session(project_path)`** — a leaf runtime resolver that layers global (`~/.empirica`) → practice (`<project>/.empirica`). Absent any override it returns the exact base defaults (`overridden == []`), so a bad/missing file can never *widen* a gate. This is the entry point the enforcement sites will call.
- Keeps the module a **leaf** (caller passes `project_path`; no session-resolver import → no cycle).

## Not in this PR (the gating-critical follow-up)

Wiring `effective_for_session` into the three live accessors + reconciling `engagement_gate`→the hook escalate (David's call). That touches live CHECK gating for every practitioner, so it's a dedicated, carefully-tested PR — fail-safe, Brier-floor preserved, comparison lines left textually intact for the `test_gate_semantic.py` source assertions.

## Verification

- `pytest` calibration → **28 pass** (+4: ready_uncertainty default, effective_for_session no-override / practice-wins / global-only)
- ruff + format + pyright → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)