### PR TITLE
feat(calibration): wire ready_uncertainty + engagement_gate into live enforcement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,11 +23,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   **uncertainty-only** (`uncertainty ≤ ready_uncertainty_threshold`, default
   0.35, per the 2026-04-07 meta-uncertainty redesign) — so `engagement_gate`
   (0.6) does not gate CHECK at runtime. Added a settable **`ready_uncertainty`**
-  field (the real gate) and a runtime **`effective_for_session(project_path)`**
-  resolver (leaf helper, layers global→practice, defaults preserved exactly when
-  no override exists). Wiring these into the three live threshold accessors
-  (CLI `_check_load_dynamic_thresholds`, the hook, the evaluator) — so an
-  override actually shifts the gate — is the next, gating-critical step.
+  field (the real gate) and a runtime **`effective_for_session(project_path)`** /
+  **`override_thresholds(project_path)`** resolver (leaf helpers, layer
+  global→practice, defaults preserved exactly when no override exists). These are
+  **wired into the three live threshold accessors** (CLI
+  `_check_load_dynamic_thresholds`, the Sentinel hook `_get_dynamic_thresholds`,
+  the evaluator `_load_evaluator_thresholds`): a `ready_uncertainty` override
+  shifts the live CHECK gate and an `engagement_gate` override shifts the hook's
+  escalate-to-human threshold — **fail-safe** (a bad/missing `calibration.yaml`
+  can never widen a gate) with the **Brier overconfidence-floor still tightening
+  on top**. The comparison expressions are left textually intact (the override is
+  injected upstream as the base). The extension's "Sentinel Tuning" sliders now
+  alter live behavior.
 
 ### Security
 - **nltk removed from the dependency tree** — the `[prose]` evidence extra pulled

--- a/docs/reference/api/SERVE_API.md
+++ b/docs/reference/api/SERVE_API.md
@@ -722,9 +722,11 @@ curl -X PATCH "$API/api/v1/calibration/config?scope=practice&practice_id=empiric
   -H 'Content-Type: application/json' -d '{"thresholds": {"engagement_gate": null}}'
 ```
 
-> Scope note: this is the settable *source* + read/write surface. Migrating the
-> runtime gate checks to read the resolver is a tracked follow-up, so writes are
-> persisted and resolvable today but do not yet alter live enforcement.
+> Live enforcement: a `ready_uncertainty` override shifts the CHECK gate and an
+> `engagement_gate` override shifts the hook's escalate threshold — both read the
+> resolver at enforcement time (fail-safe; the Brier overconfidence-floor still
+> tightens on top). `engagement_gate` no longer gates CHECK directly (the live
+> gate is uncertainty-only) — it governs the escalate-to-human threshold.
 
 ---
 

--- a/empirica/cli/command_handlers/_workflow_check.py
+++ b/empirica/cli/command_handlers/_workflow_check.py
@@ -512,6 +512,20 @@ def _check_load_dynamic_thresholds(session_id):
     except Exception:
         pass
 
+    # Calibration-config override (practice → global): explicit per-practice/global
+    # tuning becomes the BASE gate; Brier still tightens on top. Fail-safe — a
+    # missing/bad calibration.yaml leaves the default 0.35 untouched.
+    try:
+        from empirica.core.calibration_config import override_thresholds
+
+        _cal = override_thresholds(R.project_path())
+        if "ready_uncertainty" in _cal:
+            ready_uncertainty_threshold = _cal["ready_uncertainty"]
+            profile_base_thresholds = dict(profile_base_thresholds or {})
+            profile_base_thresholds["ready_uncertainty_threshold"] = ready_uncertainty_threshold
+    except Exception:
+        pass
+
     # Dynamic thresholds from calibration history
     try:
         from empirica.core.post_test.dynamic_thresholds import compute_dynamic_thresholds

--- a/empirica/core/calibration_config.py
+++ b/empirica/core/calibration_config.py
@@ -16,9 +16,11 @@ comments/canonical fields we must not rewrite.
 The extension's "Sentinel Tuning" tab reads/writes this via the daemon
 (``GET/PATCH /api/v1/calibration/config``).
 
-Scope note: this layer is the single *settable source* + read/write surface. It
-does not yet change runtime enforcement — migrating the scattered gate checks to
-read ``resolve()`` is a tracked follow-up.
+Runtime enforcement: the live CHECK gate (uncertainty-only, per the 2026-04-07
+redesign) and the Sentinel hook's engagement escalate read
+``override_thresholds()`` — a practice/global ``ready_uncertainty`` or
+``engagement_gate`` override shifts the gate live, fail-safe (a bad/missing file
+never widens it) with the Brier overconfidence-floor still tightening on top.
 """
 
 from __future__ import annotations
@@ -335,3 +337,29 @@ def effective_for_session(project_path: str | Path | None = None) -> dict[str, A
     global_override = read_override(Path.home())
     practice_override = read_override(project_path) if project_path else {}
     return resolve(global_override, practice_override)
+
+
+def override_thresholds(project_path: str | Path | None = None) -> dict[str, float]:
+    """Return ONLY the threshold keys explicitly overridden (practice → global)
+    for the active practice, as ``{key: value}``.
+
+    Empty dict on no-override OR any error — **fail-safe by construction**, so a
+    missing or malformed ``calibration.yaml`` can never change a default. This is
+    the entry point for enforcement sites: they call it and honor only the keys
+    present, leaving their hardcoded default in place for everything else. The
+    returned value is the settable *base* — enforcement layers (Brier, env) still
+    apply on top.
+    """
+    try:
+        cfg = effective_for_session(project_path)
+        out: dict[str, float] = {}
+        for dotted in cfg.get("overridden", []):
+            if not dotted.startswith("thresholds."):
+                continue
+            key = dotted.split(".", 1)[1]
+            val = cfg["thresholds"].get(key)
+            if isinstance(val, (int, float)):
+                out[key] = float(val)
+        return out
+    except Exception:
+        return {}

--- a/empirica/core/canonical/empirica_git/sentinel_hooks.py
+++ b/empirica/core/canonical/empirica_git/sentinel_hooks.py
@@ -566,8 +566,17 @@ def default_epistemic_evaluator(checkpoint_data: dict[str, Any]) -> SentinelDeci
     # Load thresholds: dynamic (Brier-inflated) first, MCO/static fallback
     _, max_uncertainty = _load_evaluator_thresholds()
 
-    # Escalate if engagement too low
-    if engagement < 0.5:
+    # Escalate if engagement too low. Threshold settable via the calibration
+    # engagement_gate (practice → global); default 0.5, fail-safe.
+    _escalate_gate = 0.5
+    try:
+        from empirica.core.calibration_config import override_thresholds
+        from empirica.utils.session_resolver import InstanceResolver as R
+
+        _escalate_gate = override_thresholds(R.project_path()).get("engagement_gate", 0.5)
+    except Exception:
+        _escalate_gate = 0.5
+    if engagement < _escalate_gate:
         return SentinelDecision.ESCALATE
 
     # Gate uses META UNCERTAINTY ONLY (2026-04-07).
@@ -609,6 +618,20 @@ def _load_evaluator_thresholds() -> tuple:
         thresholds = _load_readiness_thresholds()
         return thresholds["min_know"], thresholds["max_uncertainty"]
 
+    # Calibration override (practice → global) sets the BASE uncertainty gate;
+    # Brier still tightens on top. Fail-safe — no override leaves defaults intact.
+    _cal_unc = None
+    try:
+        from empirica.core.calibration_config import override_thresholds
+        from empirica.utils.session_resolver import InstanceResolver as R
+
+        _cal_unc = override_thresholds(R.project_path()).get("ready_uncertainty")
+    except Exception:
+        _cal_unc = None
+    _cal_base = (
+        {"ready_know_threshold": 0.70, "ready_uncertainty_threshold": _cal_unc} if _cal_unc is not None else None
+    )
+
     # Try Brier-inflated dynamic thresholds (same as CHECK uses)
     try:
         from empirica.core.post_test.dynamic_thresholds import compute_dynamic_thresholds
@@ -616,7 +639,7 @@ def _load_evaluator_thresholds() -> tuple:
 
         db = SessionDatabase()
         try:
-            dt_result = compute_dynamic_thresholds(ai_id="claude-code", db=db)
+            dt_result = compute_dynamic_thresholds(ai_id="claude-code", db=db, base_thresholds=_cal_base)
             if dt_result.get("source") == "dynamic":
                 # Use noetic thresholds — the evaluator gates the
                 # investigation→action boundary, same as CHECK.
@@ -633,9 +656,9 @@ def _load_evaluator_thresholds() -> tuple:
     except Exception:
         pass  # Fall back to MCO/static
 
-    # Fallback: MCO config / static defaults
+    # Fallback: MCO config / static defaults (calibration override wins if set)
     thresholds = _load_readiness_thresholds()
-    return thresholds["min_know"], thresholds["max_uncertainty"]
+    return thresholds["min_know"], (_cal_unc if _cal_unc is not None else thresholds["max_uncertainty"])
 
 
 # Alias for backwards compatibility

--- a/empirica/plugins/claude-code-integration/hooks/sentinel-gate.py
+++ b/empirica/plugins/claude-code-integration/hooks/sentinel-gate.py
@@ -482,20 +482,36 @@ def _get_dynamic_thresholds(db) -> tuple:
     Falls back to static constants if dynamic computation fails or has insufficient data.
     Only the noetic phase thresholds are used for the sentinel gate (investigation → action).
     """
+    # Calibration override (practice → global) sets the BASE uncertainty gate;
+    # Brier still tightens on top. Fail-safe — no override leaves the static
+    # UNCERTAINTY_THRESHOLD untouched.
+    _cal_unc = None
+    try:
+        from empirica.core.calibration_config import override_thresholds
+        from empirica.utils.session_resolver import InstanceResolver as R
+
+        _cal_unc = override_thresholds(R.project_path()).get("ready_uncertainty")
+    except Exception:
+        _cal_unc = None
+    _cal_base = (
+        {"ready_know_threshold": KNOW_THRESHOLD, "ready_uncertainty_threshold": _cal_unc}
+        if _cal_unc is not None
+        else None
+    )
     try:
         from empirica.core.post_test.dynamic_thresholds import compute_dynamic_thresholds
         from empirica.utils.session_resolver import InstanceResolver as R
 
         # Brier thresholds are per-practice — resolve the canonical ai_id so a
         # multi-practice machine doesn't read 'claude-code' calibration for all.
-        dt_result = compute_dynamic_thresholds(ai_id=R.ai_id() or "claude-code", db=db)
+        dt_result = compute_dynamic_thresholds(ai_id=R.ai_id() or "claude-code", db=db, base_thresholds=_cal_base)
         if dt_result.get("source") == "dynamic":
             noetic = dt_result.get("noetic", {})
             if noetic.get("brier_score") is not None:
                 return (noetic["ready_know_threshold"], noetic["ready_uncertainty_threshold"])
     except Exception:
         pass
-    return (KNOW_THRESHOLD, UNCERTAINTY_THRESHOLD)
+    return (KNOW_THRESHOLD, _cal_unc if _cal_unc is not None else UNCERTAINTY_THRESHOLD)
 
 
 def _get_domain_scaled_thresholds(

--- a/tests/core/test_calibration_config.py
+++ b/tests/core/test_calibration_config.py
@@ -181,3 +181,39 @@ def test_effective_for_session_none_path_is_global_only(tmp_path, monkeypatch):
     eff = cc.effective_for_session(None)
     assert eff["thresholds"]["ready_uncertainty"] == 0.30
     assert eff["sources"]["thresholds.ready_uncertainty"] == "global"
+
+
+# ── override_thresholds (fail-safe enforcement helper) ────────────────────────
+
+
+def test_override_thresholds_empty_when_no_override(tmp_path, monkeypatch):
+    monkeypatch.setattr(cc.Path, "home", lambda: tmp_path / "home")
+    assert cc.override_thresholds(tmp_path / "proj") == {}
+
+
+def test_override_thresholds_returns_only_overridden_threshold_keys(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    practice = tmp_path / "proj"
+    home.mkdir()
+    practice.mkdir()
+    monkeypatch.setattr(cc.Path, "home", lambda: home)
+    cc.apply_patch(practice, {"thresholds": {"ready_uncertainty": 0.45, "engagement_gate": 0.7}})
+    assert cc.override_thresholds(practice) == {"ready_uncertainty": 0.45, "engagement_gate": 0.7}
+
+
+def test_override_thresholds_ignores_weight_overrides(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    practice = tmp_path / "proj"
+    home.mkdir()
+    practice.mkdir()
+    monkeypatch.setattr(cc.Path, "home", lambda: home)
+    cc.apply_patch(practice, {"weights": {"engagement": 0.2}, "thresholds": {"ready_uncertainty": 0.4}})
+    assert cc.override_thresholds(practice) == {"ready_uncertainty": 0.4}  # weights excluded
+
+
+def test_override_thresholds_failsafe_never_raises(monkeypatch):
+    def _boom(*_a, **_k):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(cc, "effective_for_session", _boom)
+    assert cc.override_thresholds("/whatever") == {}

--- a/tests/test_sentinel_calibration_override.py
+++ b/tests/test_sentinel_calibration_override.py
@@ -1,0 +1,58 @@
+"""The live Sentinel evaluator honors calibration overrides.
+
+Task 4 wired calibration_config into the enforcement path: the CHECK gate reads
+`ready_uncertainty` and the escalate reads `engagement_gate`. These tests pin the
+*decision behavior* — that an override actually flips the evaluator's verdict —
+by mocking the threshold loader (DB/Brier) and the override resolver.
+"""
+
+from __future__ import annotations
+
+from empirica.core import calibration_config as cc
+from empirica.core.canonical.empirica_git import sentinel_hooks as sh
+from empirica.core.canonical.empirica_git.sentinel_hooks import (
+    SentinelDecision,
+    default_epistemic_evaluator,
+)
+
+
+def _ev(uncertainty: float, engagement: float) -> SentinelDecision:
+    return default_epistemic_evaluator({"vectors": {"uncertainty": uncertainty, "engagement": engagement}})
+
+
+def test_gate_default_investigates_above_035(monkeypatch):
+    monkeypatch.setattr(sh, "_load_evaluator_thresholds", lambda: (0.70, 0.35))
+    monkeypatch.setattr(cc, "override_thresholds", lambda *a, **k: {})
+    assert _ev(uncertainty=0.42, engagement=0.9) == SentinelDecision.INVESTIGATE
+
+
+def test_ready_uncertainty_override_flips_gate_to_proceed(monkeypatch):
+    # Override loosened the gate to 0.45 (surfaced via the loader) → 0.42 proceeds.
+    monkeypatch.setattr(sh, "_load_evaluator_thresholds", lambda: (0.70, 0.45))
+    monkeypatch.setattr(cc, "override_thresholds", lambda *a, **k: {})  # no engagement override
+    assert _ev(uncertainty=0.42, engagement=0.9) == SentinelDecision.PROCEED
+
+
+def test_engagement_gate_default_05_does_not_escalate_at_06(monkeypatch):
+    monkeypatch.setattr(sh, "_load_evaluator_thresholds", lambda: (0.70, 0.35))
+    monkeypatch.setattr(cc, "override_thresholds", lambda *a, **k: {})  # default escalate 0.5
+    # engagement 0.6 >= 0.5 → no escalate; low uncertainty → proceed
+    assert _ev(uncertainty=0.2, engagement=0.6) == SentinelDecision.PROCEED
+
+
+def test_engagement_gate_override_raises_escalate_threshold(monkeypatch):
+    monkeypatch.setattr(sh, "_load_evaluator_thresholds", lambda: (0.70, 0.35))
+    monkeypatch.setattr(cc, "override_thresholds", lambda *a, **k: {"engagement_gate": 0.70})
+    # engagement 0.65 < 0.70 override → ESCALATE (would have proceeded at default 0.5)
+    assert _ev(uncertainty=0.2, engagement=0.65) == SentinelDecision.ESCALATE
+
+
+def test_evaluator_failsafe_when_override_raises(monkeypatch):
+    monkeypatch.setattr(sh, "_load_evaluator_thresholds", lambda: (0.70, 0.35))
+
+    def _boom(*_a, **_k):
+        raise RuntimeError("bad calibration.yaml")
+
+    monkeypatch.setattr(cc, "override_thresholds", _boom)
+    # A throwing override must never crash the gate — falls back to default 0.5 escalate.
+    assert _ev(uncertainty=0.2, engagement=0.6) == SentinelDecision.PROCEED


### PR DESCRIPTION
## What

Completes the **Sentinel Tuning** feature (goal `3e03fd86` task 4). The settable gate now **alters live behavior** — an override actually shifts the CHECK/escalate decision.

## How (deep-dive-verified)

The live CHECK gate is **uncertainty-only** (`_workflow_check.py:634`), read via three runtime accessors that all funnel `compute_dynamic_thresholds` (which accepts `base_thresholds`). So:

- **`calibration_config.override_thresholds(project_path)`** — fail-safe helper returning *only* explicitly-overridden threshold keys (`{}` on no-override or any error).
- **Injected as the BASE at all 3 accessors** — CLI `_check_load_dynamic_thresholds`, hook `_get_dynamic_thresholds`, evaluator `_load_evaluator_thresholds`. A `ready_uncertainty` override shifts the live gate while the **Brier overconfidence-floor still tightens on top** (never replaced — a loose override can't disable the safety mechanism).
- **`engagement_gate` → the hook's escalate** (default 0.5, only-if-overridden), *not* the CHECK gate, since the live gate is uncertainty-only.

## Safety properties

- **Fail-safe:** a bad/missing `calibration.yaml` can never *widen* a gate (every read is `try/except` → hardcoded default).
- **Brier preserved:** the override sets the base; Brier still tightens below it.
- **Only-if-overridden:** absent an override, the exact defaults (0.35 gate, 0.5 escalate) are untouched.
- **Comparison lines intact:** the override is injected upstream into the RHS variable, so `test_gate_semantic`'s source-string assertions stay green.

## Verification

- `pytest` → 44 calibration/sentinel + 20 at-risk (brier/cross-profile) green; **`test_gate_semantic` green** (no comparison-line changes)
- ruff + format + pyright → clean

## Notes

`engagement_gate` no longer gates CHECK (documented in SERVE_API + CHANGELOG) — it governs escalate-to-human. The extension's schema-driven tab picks this up automatically; the sliders now bite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)