### PR TITLE
feat(goals): goals-list shows 'N of M' when truncated by --limit

### DIFF
--- a/empirica/cli/command_handlers/goal_commands.py
+++ b/empirica/cli/command_handlers/goal_commands.py
@@ -1293,6 +1293,19 @@ def handle_goals_list_command(args):
         base_query += status_sql
         params.extend(status_params)
 
+        # Full match count (pre-LIMIT) for "N of M" truncation transparency.
+        total_matching = None
+        try:
+            count_query = (
+                "SELECT COUNT(*) FROM goals g "
+                "LEFT JOIN sessions s ON g.session_id = s.session_id "
+                "WHERE 1=1" + base_query.split("WHERE 1=1", 1)[1]
+            )
+            cursor.execute(count_query, list(params))
+            total_matching = cursor.fetchone()[0]
+        except Exception:
+            total_matching = None
+
         base_query += " ORDER BY g.created_timestamp DESC LIMIT ?"
         params.append(limit)
 
@@ -1337,6 +1350,9 @@ def handle_goals_list_command(args):
         result = {
             "ok": True,
             "goals_count": len(goals),
+            "total_matching": total_matching,
+            "truncated": bool(total_matching is not None and total_matching > len(goals)),
+            "limit": limit,
             "goals": goals,
             "filters": {
                 "project_id": project_id,
@@ -1359,7 +1375,13 @@ def handle_goals_list_command(args):
         else:
             # Human format - print here and return None so CLI core doesn't double-print
             print(f"{'=' * 70}")
-            print(f"🎯 GOALS ({status_desc.upper()}) - {len(goals)} found [{filter_desc}]")
+            if total_matching is not None and total_matching > len(goals):
+                print(
+                    f"🎯 GOALS ({status_desc.upper()}) - showing {len(goals)} of {total_matching} "
+                    f"[{filter_desc}] · raise --limit (now {limit}) to see more"
+                )
+            else:
+                print(f"🎯 GOALS ({status_desc.upper()}) - {len(goals)} found [{filter_desc}]")
             print(f"{'=' * 70}")
             print()
 


### PR DESCRIPTION
## What

Goal `2fa0d3be` — the pagination-transparency fix. `goals-list` capped at `--limit` (default 20) but showed only "N found", silently hiding the rest (this is literally how the 82-goal backlog stayed invisible).

## How
- pre-`LIMIT` `COUNT(*)` with the same WHERE → `total_matching`
- human header shows **"showing N of M [...] · raise --limit (now N) to see more"** when truncated, else the plain "N found"
- JSON result gains `total_matching` + `truncated` + `limit`
- fail-safe: the count is wrapped (`try/except → None`), falling back to the plain header

## Verification
- Live: `goals-list --limit 5` → **"showing 5 of 76"**; JSON `{goals_count:5, total_matching:76, truncated:true, limit:5}`
- ruff + format + pyright clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)