### PR TITLE
feat(daemon-crm): richer contact projection + GET /engagements/{id}/tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Daemon CRM projection — richer contacts + engagement tasks.** `GET /api/v1/entities?type=contact`
+  now projects the full CRM detail per contact — `email`/`phone`/`title`
+  (`contacts.email_primary`/`phone_primary`/`organization_title`), `tags`
+  (JSON-parsed), `notes`, `contact_type`, `lifecycle_stage`, plus `role` and
+  `parent_org_name` resolved from the contact→org `entity_membership` (role is a
+  free-text verb; org name joins `entity_registry.display_name`). New
+  `GET /api/v1/engagements/{id}/tasks` surfaces the workspace `engagement_tasks`
+  (task_id/title/status/assigned_to/due_at/…, oldest first, honest-empty).
+  Three new `WorkspaceDBRepository` maps (`get_contact_org_details_map`,
+  `get_contact_detail_map`, `get_engagement_tasks`); all field sources verified
+  against the live workspace.db.
 - **Calibration config — settable epistemic weights + Sentinel thresholds (per-practice + global).**
   A new `empirica/core/calibration_config.py` declares the tunable surface (the 4
   dimension weights + 4 Sentinel thresholds — the same shape personas use as

--- a/empirica/api/routes/engagements.py
+++ b/empirica/api/routes/engagements.py
@@ -225,3 +225,18 @@ async def patch_engagement(engagement_id: str, req: EngagementPatchRequest):
         if patch:
             repo.update_entity_metadata("engagement", engagement_id, patch)
     return {"ok": True, "engagement_id": engagement_id, "engagement": updated}
+
+
+@router.get("/engagements/{engagement_id}/tasks", dependencies=[Depends(verify_mint_bearer)])
+async def list_engagement_tasks(engagement_id: str):
+    """List an engagement's tasks (workspace ``engagement_tasks``) for the board.
+
+    Per row: task_id, title, description, status, assigned_to, due_at,
+    completed_at, blocked_by, created_at (oldest first). Unknown/empty engagement
+    → ``tasks: []`` (honest-empty; the board renders 0 rather than erroring).
+    """
+    from empirica.data.repositories.workspace_db import WorkspaceDBRepository
+
+    with WorkspaceDBRepository.open() as repo:
+        tasks = repo.get_engagement_tasks(engagement_id)
+    return {"ok": True, "engagement_id": engagement_id, "count": len(tasks), "tasks": tasks}

--- a/empirica/api/routes/entities.py
+++ b/empirica/api/routes/entities.py
@@ -129,9 +129,11 @@ async def list_entities(
         # the whole org set (small: umbrella + brands), not per-row — preserves
         # the single-query intent that deferred the broader v1.1 enrichment.
         org_parents = repo.get_org_parent_map()
-        # Contact→org affiliation map — same source as the parent_org filter
-        # (entity_memberships), so the filter and this enrichment agree.
-        contact_orgs = repo.get_contact_org_map()
+        # Contact→org affiliation (id + name + role) + richer CRM detail fields.
+        # Same entity_memberships source as the parent_org filter, so filter and
+        # enrichment agree.
+        contact_org_details = repo.get_contact_org_details_map()
+        contact_details = repo.get_contact_detail_map()
         for row in repo.list_entities(entity_type=type, status=status, parent_org=parent_org, limit=limit):
             et, eid = row["entity_type"], row["entity_id"]
             meta = _parse_metadata(row.get("metadata"))
@@ -152,6 +154,17 @@ async def list_entities(
             if et == "organization":
                 entry["parent_org_id"] = org_parents.get(eid)
             elif et == "contact":
-                entry["parent_org_id"] = contact_orgs.get(eid)
+                cod = contact_org_details.get(eid) or {}
+                cd = contact_details.get(eid) or {}
+                entry["parent_org_id"] = cod.get("org_id")
+                entry["parent_org_name"] = cod.get("org_name")
+                entry["role"] = cod.get("role")
+                entry["email"] = cd.get("email")
+                entry["phone"] = cd.get("phone")
+                entry["title"] = cd.get("title")
+                entry["tags"] = cd.get("tags")
+                entry["notes"] = cd.get("notes")
+                entry["contact_type"] = cd.get("contact_type")
+                entry["lifecycle_stage"] = cd.get("lifecycle_stage")
             out.append(entry)
     return {"ok": True, "count": len(out), "entities": out}

--- a/empirica/data/repositories/workspace_db.py
+++ b/empirica/data/repositories/workspace_db.py
@@ -975,6 +975,74 @@ class WorkspaceDBRepository(BaseRepository):
         )
         return {row["entity_id"]: row["group_id"] for row in cursor.fetchall()}
 
+    def get_contact_org_details_map(self) -> dict[str, dict[str, Any]]:
+        """Map contact_id → {org_id, org_name, role} from active contact→org edges.
+
+        Extends ``get_contact_org_map`` with the org's ``display_name`` (joined
+        from entity_registry) and the free-text membership ``role``, so the
+        contact projection can surface parent_org_name + role in one query.
+        Latest active edge wins (ASC + dict overwrite).
+        """
+        cursor = self._execute(
+            """SELECT m.entity_id, m.group_id, m.role,
+                      r.display_name AS org_name
+               FROM entity_memberships m
+               LEFT JOIN entity_registry r
+                 ON r.entity_id = m.group_id AND r.entity_type = 'organization'
+               WHERE m.entity_type = 'contact' AND m.group_type = 'organization'
+                 AND m.left_at IS NULL
+               ORDER BY m.joined_at ASC"""
+        )
+        return {
+            row["entity_id"]: {"org_id": row["group_id"], "org_name": row["org_name"], "role": row["role"]}
+            for row in cursor.fetchall()
+        }
+
+    def get_contact_detail_map(self) -> dict[str, dict[str, Any]]:
+        """Map contact_id → the richer CRM projection fields from the ``contacts``
+        table (email/phone/title/tags/notes/contact_type/lifecycle_stage). One
+        query; ``tags`` is JSON-parsed to a list (honest-empty on malformed).
+        """
+        import json
+
+        cursor = self._execute(
+            """SELECT contact_id, email_primary, phone_primary, organization_title,
+                      tags, notes, contact_type, lifecycle_stage
+               FROM contacts"""
+        )
+        out: dict[str, dict[str, Any]] = {}
+        for row in cursor.fetchall():
+            tags = row["tags"]
+            if isinstance(tags, str):
+                try:
+                    tags = json.loads(tags)
+                except (ValueError, TypeError):
+                    tags = []
+            out[row["contact_id"]] = {
+                "email": row["email_primary"],
+                "phone": row["phone_primary"],
+                "title": row["organization_title"],
+                "tags": tags if isinstance(tags, list) else [],
+                "notes": row["notes"],
+                "contact_type": row["contact_type"],
+                "lifecycle_stage": row["lifecycle_stage"],
+            }
+        return out
+
+    def get_engagement_tasks(self, engagement_id: str) -> list[dict[str, Any]]:
+        """List an engagement's tasks from workspace ``engagement_tasks`` (task_id,
+        title, status, assigned_to, due_at, completed_at, blocked_by, …), oldest
+        first. Empty list when the engagement has none.
+        """
+        cursor = self._execute(
+            """SELECT task_id, engagement_id, title, description, status,
+                      assigned_to, due_at, completed_at, blocked_by, created_at
+               FROM engagement_tasks WHERE engagement_id = ?
+               ORDER BY created_at ASC""",
+            (engagement_id,),
+        )
+        return [dict(row) for row in cursor.fetchall()]
+
     def upsert_entity_membership(
         self,
         entity_type: str,

--- a/empirica/data/repositories/workspace_db.py
+++ b/empirica/data/repositories/workspace_db.py
@@ -998,12 +998,28 @@ class WorkspaceDBRepository(BaseRepository):
             for row in cursor.fetchall()
         }
 
+    def _table_exists(self, name: str) -> bool:
+        """True iff a table named ``name`` exists in the connected DB.
+
+        Lets the CRM projection queries degrade to empty on older/minimal
+        workspace DBs — a schema predating the ``contacts`` / ``engagement_tasks``
+        tables (or a test fixture that only seeds the entity tables) returns []/{}
+        instead of raising ``OperationalError: no such table``.
+        """
+        cursor = self._execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name=? LIMIT 1",
+            (name,),
+        )
+        return cursor.fetchone() is not None
+
     def get_contact_detail_map(self) -> dict[str, dict[str, Any]]:
         """Map contact_id → the richer CRM projection fields from the ``contacts``
         table (email/phone/title/tags/notes/contact_type/lifecycle_stage). One
         query; ``tags`` is JSON-parsed to a list (honest-empty on malformed).
+        Returns ``{}`` when the ``contacts`` table is absent.
         """
-        import json
+        if not self._table_exists("contacts"):
+            return {}
 
         cursor = self._execute(
             """SELECT contact_id, email_primary, phone_primary, organization_title,
@@ -1032,8 +1048,12 @@ class WorkspaceDBRepository(BaseRepository):
     def get_engagement_tasks(self, engagement_id: str) -> list[dict[str, Any]]:
         """List an engagement's tasks from workspace ``engagement_tasks`` (task_id,
         title, status, assigned_to, due_at, completed_at, blocked_by, …), oldest
-        first. Empty list when the engagement has none.
+        first. Empty list when the engagement has none, or when the
+        ``engagement_tasks`` table is absent (older/minimal workspace DBs).
         """
+        if not self._table_exists("engagement_tasks"):
+            return []
+
         cursor = self._execute(
             """SELECT task_id, engagement_id, title, description, status,
                       assigned_to, due_at, completed_at, blocked_by, created_at

--- a/tests/test_workspace_crm_projection.py
+++ b/tests/test_workspace_crm_projection.py
@@ -1,0 +1,99 @@
+"""Tests for the richer contact projection + engagement_tasks repo methods
+(daemon-CRM: goals 8996f378 + the engagement_tasks route).
+
+Uses an in-memory workspace.db with the minimal tables the queries read, so the
+projection logic (tags JSON-parse, org name+role join, task scoping/ordering) is
+pinned without touching the live DB.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from empirica.data.repositories.workspace_db import WorkspaceDBRepository
+
+
+@pytest.fixture()
+def repo() -> WorkspaceDBRepository:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.executescript(
+        """
+        CREATE TABLE contacts (
+            contact_id TEXT PRIMARY KEY, email_primary TEXT, phone_primary TEXT,
+            organization_title TEXT, tags TEXT, notes TEXT, contact_type TEXT, lifecycle_stage TEXT
+        );
+        CREATE TABLE entity_registry (entity_type TEXT, entity_id TEXT, display_name TEXT);
+        CREATE TABLE entity_memberships (
+            entity_type TEXT, entity_id TEXT, group_type TEXT, group_id TEXT,
+            role TEXT, joined_at TEXT, left_at TEXT
+        );
+        CREATE TABLE engagement_tasks (
+            task_id TEXT, engagement_id TEXT, title TEXT, description TEXT, status TEXT,
+            assigned_to TEXT, due_at TEXT, completed_at TEXT, blocked_by TEXT, created_at TEXT
+        );
+
+        INSERT INTO contacts VALUES
+            ('c-carly','carly@x.com','+1','Admiral','["vip","founder"]','deep notes','person','live'),
+            ('c-bad',NULL,NULL,NULL,'not-json',NULL,NULL,NULL);
+        INSERT INTO entity_registry VALUES ('organization','empirica-foundation','Empirica Foundation');
+        INSERT INTO entity_memberships VALUES
+            ('contact','c-carly','organization','empirica-foundation','admiral','2026-01-01',NULL),
+            ('contact','c-closed','organization','empirica-foundation','member','2026-01-01','2026-03-01');
+        INSERT INTO engagement_tasks VALUES
+            ('t1','eng-1','Provision seat','d','open','carly',NULL,NULL,NULL,'2026-01-01'),
+            ('t2','eng-1','Verify','d','done','carly',NULL,'2026-02-01',NULL,'2026-01-02'),
+            ('t3','eng-2','Other','d','open','x',NULL,NULL,NULL,'2026-01-01');
+        """
+    )
+    return WorkspaceDBRepository(conn)
+
+
+# ── contact detail map ────────────────────────────────────────────────────────
+
+
+def test_contact_detail_map_projects_crm_fields(repo):
+    m = repo.get_contact_detail_map()
+    c = m["c-carly"]
+    assert c["email"] == "carly@x.com"
+    assert c["phone"] == "+1"
+    assert c["title"] == "Admiral"
+    assert c["tags"] == ["vip", "founder"]  # JSON-parsed to a list
+    assert c["notes"] == "deep notes"
+    assert c["contact_type"] == "person" and c["lifecycle_stage"] == "live"
+
+
+def test_contact_detail_map_malformed_tags_is_empty_list(repo):
+    assert repo.get_contact_detail_map()["c-bad"]["tags"] == []
+
+
+# ── contact→org details (name + role) ─────────────────────────────────────────
+
+
+def test_contact_org_details_resolves_name_and_role(repo):
+    m = repo.get_contact_org_details_map()
+    assert m["c-carly"] == {
+        "org_id": "empirica-foundation",
+        "org_name": "Empirica Foundation",  # joined from entity_registry.display_name
+        "role": "admiral",  # free-text role
+    }
+
+
+def test_contact_org_details_excludes_closed_edges(repo):
+    # c-closed has left_at set → not an active affiliation
+    assert "c-closed" not in repo.get_contact_org_details_map()
+
+
+# ── engagement tasks ──────────────────────────────────────────────────────────
+
+
+def test_get_engagement_tasks_scoped_and_ordered(repo):
+    tasks = repo.get_engagement_tasks("eng-1")
+    assert [t["task_id"] for t in tasks] == ["t1", "t2"]  # only eng-1, oldest first
+    assert tasks[0]["status"] == "open" and tasks[1]["completed_at"] == "2026-02-01"
+
+
+def test_get_engagement_tasks_empty_for_unknown(repo):
+    assert repo.get_engagement_tasks("nope") == []

--- a/tests/test_workspace_crm_projection.py
+++ b/tests/test_workspace_crm_projection.py
@@ -97,3 +97,32 @@ def test_get_engagement_tasks_scoped_and_ordered(repo):
 
 def test_get_engagement_tasks_empty_for_unknown(repo):
     assert repo.get_engagement_tasks("nope") == []
+
+
+# ── resilience: optional tables absent (older/minimal workspace DBs) ───────────
+
+
+def test_crm_projections_degrade_when_optional_tables_absent():
+    """A workspace DB predating the ``contacts`` / ``engagement_tasks`` tables
+    (or a fixture that only seeds the entity tables) must NOT raise
+    ``OperationalError: no such table`` — the CRM projections degrade to empty.
+    This is what a GET /api/v1/entities against such a DB relies on to 200
+    instead of 500 (regression guard for the daemon-crm contact projection).
+    """
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    # Only the entity tables — deliberately NO `contacts`, NO `engagement_tasks`.
+    conn.executescript(
+        """
+        CREATE TABLE entity_registry (entity_type TEXT, entity_id TEXT, display_name TEXT);
+        CREATE TABLE entity_memberships (
+            entity_type TEXT, entity_id TEXT, group_type TEXT, group_id TEXT,
+            role TEXT, joined_at TEXT, left_at TEXT
+        );
+        """
+    )
+    repo = WorkspaceDBRepository(conn)
+    assert repo.get_contact_detail_map() == {}
+    assert repo.get_engagement_tasks("eng-1") == []
+    # entity_memberships IS present → the org-details map still works (returns {}).
+    assert repo.get_contact_org_details_map() == {}


### PR DESCRIPTION
## What

The daemon-CRM T1 items (goal `8996f378` + the `engagement_tasks` route, mesh-committed with extension).

## Contact projection (`GET /entities?type=contact`)
Now projects the full CRM detail per contact: `email`/`phone`/`title`, `tags` (JSON-parsed), `notes`, `contact_type`, `lifecycle_stage`, plus `role` + `parent_org_name` from the contact→org `entity_membership` (role is a **free-text verb**; org name joins `entity_registry.display_name`).

## New route (`GET /engagements/{id}/tasks`)
Surfaces the workspace `engagement_tasks` table (task_id/title/status/assigned_to/due_at/completed_at/blocked_by, oldest first, **honest-empty**).

## Verified against the live workspace.db first
Per the parent_org lesson, I queried the real DB before building — every field-map column exists (contacts has email_primary/organization_title/tags/notes/…; `entity_memberships.role` free-text; `entity_registry.display_name`; `engagement_tasks` 74 rows). No schema surprises this time.

## How
3 new `WorkspaceDBRepository` maps following the existing single-query-per-enrichment pattern; both routes FastAPI (entities/engagements family).

## Verification
- `pytest` → 6 new tests (temp workspace.db: tags JSON-parse, org name+role join, closed-edge exclusion, task scoping/ordering)
- Live-tested against the real DB (27 contacts, 24 org-details, task scoping)
- ruff + format + pyright clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)