### PR TITLE
feat(security): unify security-audit gate with release gate (strict + shared waivers)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   alter live behavior.
 
 ### Security
+- **`empirica security-audit` is now STRICT and shares one governed waiver source
+  with the release gate.** Previously the audit `passed` gate failed only on
+  empirica-scoped findings that matched the CISA KEV catalog (actively-exploited);
+  an empirica-managed package with a plain critical CVE and no KEV match still
+  passed. The gate now fails on **any** empirica-scoped CVE that is not in the
+  governed waiver list — matching the release gate's strictness. A single
+  `empirica.core.security.waivers.CVE_WAIVERS` list is the sole waiver source both
+  `empirica security-audit` and `scripts/release.py` read, so the two gates can no
+  longer drift (release-time `PIP_AUDIT_WAIVERS` is now sourced from it, falling
+  back to empty — stricter, never looser — if empirica isn't importable). KEV
+  matches are **never** silently waivable (a waiver can't suppress an
+  actively-exploited finding). User-scoped CVEs remain informational (reported,
+  not gated). The waiver list is currently empty — the sole prior waiver was
+  retired when nltk left the tree (below). Each finding now carries a `waived`
+  flag and the per-scope summary a `waived` count.
 - **nltk removed from the dependency tree** — the `[prose]` evidence extra pulled
   `textstat`, which pulled `nltk` (`nltk` was `Required-by` textstat *only*), and
   nltk carried PYSEC-2026-597 / CVE-2026-12243 (path-traversal arbitrary-file

--- a/empirica/core/security/audit.py
+++ b/empirica/core/security/audit.py
@@ -23,6 +23,7 @@ from typing import Any
 
 from .kev_feed import KEVFeed
 from .scope import get_empirica_managed_packages
+from .waivers import is_waived
 
 logger = logging.getLogger(__name__)
 
@@ -102,8 +103,11 @@ def run_security_audit(
 
     return {
         "check": "security_audit",
-        # passed gates only on empirica-scoped KEV matches
-        "passed": summary["empirica"]["now"] == 0,
+        # STRICT: an empirica-scoped finding blocks the gate if it is KEV (never
+        # silently waivable — actively exploited) OR is not in the governed
+        # waiver source. Waived non-KEV empirica CVEs pass; user-scoped CVEs are
+        # informational (not gated). Shares the waiver list with release.py.
+        "passed": not any(f["scope"] == "empirica" and (f.get("kev") or not f.get("waived")) for f in findings),
         "scanned": audit_meta,
         "kev_metadata": kev_meta,
         "scope_metadata": {
@@ -193,6 +197,7 @@ def _classify_findings(
                     "kev": kev_match is not None,
                     "kev_entry": _summarize_kev_entry(kev_match) if kev_match else None,
                     "rotate_priority": _priority_for(kev_match, vuln),
+                    "waived": is_waived([vuln_id, *aliases, *cve_ids]),
                 }
             )
     # Sort: empirica scope first, then by priority within each scope
@@ -247,6 +252,7 @@ _PRIORITY_BUCKETS = ("now", "month", "monitor", "safe")
 def _empty_scope_summary() -> dict[str, int]:
     bucket: dict[str, int] = dict.fromkeys(_PRIORITY_BUCKETS, 0)
     bucket["total"] = 0
+    bucket["waived"] = 0
     return bucket
 
 
@@ -272,4 +278,6 @@ def _summarize(findings: list[dict[str, Any]]) -> dict[str, Any]:
         if priority in _PRIORITY_BUCKETS:
             bucket[priority] += 1
             bucket["total"] += 1
+        if f.get("waived"):
+            bucket["waived"] += 1
     return summary

--- a/empirica/core/security/waivers.py
+++ b/empirica/core/security/waivers.py
@@ -1,0 +1,42 @@
+"""Governed CVE-waiver source — the single list both the release gate
+(``scripts/release.py``) and ``empirica security-audit`` honor, so they can't
+drift.
+
+A waiver is a documented, reviewed **risk-acceptance** for a CVE that is (a)
+assessed NON-EXPLOITABLE in Empirica's usage, AND (b) has no available fix. Each
+entry MUST carry an ``id``, ``package``, ``rationale``, and ``retire_when``. Add
+an ``aliases`` list when the same vuln is tracked under multiple ids
+(PYSEC / GHSA / CVE) so a match on any alias waives it.
+
+Currently **EMPTY**: the sole prior waiver (PYSEC-2026-597 / CVE-2026-12243,
+nltk via textstat) was RETIRED by dropping textstat for the in-house readability
+module (#212) — nltk is gone from the tree, so the CVE is gone rather than
+waived. Both gates are STRICT by default: any un-waived empirica CVE fails, and
+``security-audit`` never waives a CISA-KEV (actively-exploited) match.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+# Each entry: {"id": str, "package": str, "rationale": str, "retire_when": str,
+#              "aliases"?: list[str]}
+CVE_WAIVERS: list[dict] = []
+
+
+def waived_ids() -> set[str]:
+    """Every id + alias across the governed waiver list (a flat lookup set)."""
+    ids: set[str] = set()
+    for w in CVE_WAIVERS:
+        wid = w.get("id")
+        if wid:
+            ids.add(wid)
+        ids.update(a for a in (w.get("aliases") or []) if a)
+    return ids
+
+
+def is_waived(finding_ids: Iterable[str]) -> bool:
+    """True iff any of a finding's ids (vulnerability_id / aliases / CVE ids) is
+    in the governed waiver list."""
+    waived = waived_ids()
+    return any(fid in waived for fid in finding_ids if fid)

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -20,6 +20,20 @@ import sys
 from pathlib import Path
 from typing import Optional
 
+
+def _load_shared_cve_waivers() -> list[dict]:
+    """The single governed CVE-waiver source, shared with ``empirica
+    security-audit`` (``empirica.core.security.waivers.CVE_WAIVERS``) so the two
+    gates can't drift. Falls back to ``[]`` if empirica isn't importable at
+    release time — which only makes this gate STRICTER, never looser."""
+    try:
+        from empirica.core.security.waivers import CVE_WAIVERS
+
+        return CVE_WAIVERS
+    except Exception:
+        return []
+
+
 # ANSI colors
 GREEN = "\033[92m"
 YELLOW = "\033[93m"
@@ -1060,12 +1074,12 @@ brew install empirica
     # prints active waivers every run so they stay visible, not hidden. Keep this
     # in sync with `empirica security-audit` (unify: goal — shared waiver source).
     #
-    # Currently EMPTY. The sole prior waiver — PYSEC-2026-597 (nltk, pulled
-    # transitively by textstat via the [prose] extra) — was RETIRED by dropping
-    # textstat for the in-house `readability` module (pyphen syllables). nltk is
-    # no longer in the tree, so the CVE is gone rather than waived. The mechanism
-    # stays wired for the next non-exploitable, no-fix CVE that may arise.
-    PIP_AUDIT_WAIVERS: list[dict] = []
+    # Sourced from the SHARED governed waiver list
+    # (empirica.core.security.waivers.CVE_WAIVERS) so this release gate and
+    # `empirica security-audit` can't drift. Currently EMPTY — the sole prior
+    # waiver (PYSEC-2026-597, nltk via textstat) was retired in #212 by dropping
+    # textstat; nltk is gone from the tree, so the CVE is gone, not waived.
+    PIP_AUDIT_WAIVERS: list[dict] = _load_shared_cve_waivers()
 
     def run_pip_audit(self) -> bool:
         """CVE scan — mirrors the CI pip-audit step. STRICT (hard fail on CVEs)

--- a/tests/test_security_audit.py
+++ b/tests/test_security_audit.py
@@ -175,23 +175,27 @@ def test_passed_false_when_empirica_kev_match(fake_pip_audit):
     assert report["passed"] is False
 
 
-def test_passed_true_when_only_user_kev_match(fake_pip_audit):
-    """If the KEV match is on a user-scoped package, empirica still passes."""
-    kev = _StubKEVFeed({"CVE-2024-44444"})  # only minorpkg's CVE
+def test_user_kev_does_not_gate_but_empirica_cve_does(fake_pip_audit):
+    """User-scoped KEV never contributes to the empirica verdict; but a non-KEV
+    empirica CVE now DOES fail the strict gate (was: only empirica-KEV failed)."""
+    kev = _StubKEVFeed({"CVE-2024-44444"})  # only minorpkg's CVE (user scope)
     report = _audit(kev, managed={"vulnpkg"})  # minorpkg is user
-    # minorpkg gets rotate=now (KEV) but it's user scope
     findings_by_pkg = {f["package"]: f for f in report["findings"]}
     assert findings_by_pkg["minorpkg"]["rotate_priority"] == "now"
     assert findings_by_pkg["minorpkg"]["scope"] == "user"
-    assert report["summary"]["empirica"]["now"] == 0
+    assert report["summary"]["empirica"]["now"] == 0  # user KEV doesn't add here
     assert report["summary"]["user"]["now"] == 1
-    assert report["passed"] is True  # gate is empirica-only
+    # STRICT: vulnpkg (empirica, critical CVE, non-KEV, un-waived) blocks the gate.
+    assert report["passed"] is False
 
 
-def test_passed_true_when_no_kev_matches(fake_pip_audit):
+def test_strict_fails_on_empirica_cve_without_kev(fake_pip_audit):
+    """STRICT gate: an un-waived empirica-scoped CVE fails even with no KEV match
+    (was: passed unless there was an empirica-KEV match)."""
     kev = _StubKEVFeed(set())
-    report = _audit(kev)
-    assert report["passed"] is True
+    report = _audit(kev)  # default managed includes vulnpkg (critical CVE)
+    assert report["passed"] is False
+    assert report["summary"]["empirica"]["month"] == 1
 
 
 def test_findings_sorted_empirica_first(fake_pip_audit):

--- a/tests/test_security_audit_strict.py
+++ b/tests/test_security_audit_strict.py
@@ -1,0 +1,105 @@
+"""Strict security-audit gate + shared governed waiver source (goal 15a4034b).
+
+`empirica security-audit` now fails on ANY un-waived empirica-scoped CVE (was:
+only CISA-KEV matches), sharing one governed waiver list with the release gate.
+KEV matches are never silently waivable. Tests inject a synthetic pip-audit
+payload + a fake KEV feed so no network/pip-audit is needed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from empirica.core.security import audit, waivers
+
+
+class _FakeKev:
+    """Minimal KEVFeed stand-in. ``kev_hits`` = set of CVE ids that are in KEV."""
+
+    def __init__(self, kev_hits: set[str] | None = None):
+        self._hits = kev_hits or set()
+
+    def refresh(self, force: bool = False) -> None:
+        pass
+
+    def catalog_metadata(self) -> dict:
+        return {"catalog_version": "test", "total_entries": len(self._hits)}
+
+    def lookup(self, cve_id: str):
+        return {"cveID": cve_id} if cve_id in self._hits else None
+
+
+def _payload(package: str, vuln_id: str, cve: str, severity: str = "high") -> dict:
+    return {
+        "dependencies": [
+            {
+                "name": package,
+                "version": "1.0.0",
+                "vulns": [{"id": vuln_id, "aliases": [cve], "severity": severity, "fix_versions": []}],
+            }
+        ]
+    }
+
+
+def _run(monkeypatch, payload, kev_hits=None, managed=frozenset({"pydantic"})):
+    monkeypatch.setattr(audit, "_run_pip_audit", lambda _root: (payload, {"tool": "pip-audit", "status": "ok"}))
+    return audit.run_security_audit(Path("."), kev_feed=_FakeKev(kev_hits), empirica_managed=set(managed))
+
+
+# ── strict gate ───────────────────────────────────────────────────────────────
+
+
+def test_unwaived_empirica_cve_now_fails(monkeypatch):
+    # Non-KEV, empirica-scoped, not waived → STRICT fail (old behavior: passed).
+    r = _run(monkeypatch, _payload("pydantic", "PYSEC-1", "CVE-2026-1"))
+    assert r["passed"] is False
+    assert r["summary"]["empirica"]["month"] == 1
+
+
+def test_user_scoped_cve_does_not_gate(monkeypatch):
+    # A vuln in a non-empirica-managed package is informational, not a blocker.
+    r = _run(monkeypatch, _payload("some-user-pkg", "PYSEC-2", "CVE-2026-2"), managed={"pydantic"})
+    assert r["passed"] is True
+    assert r["summary"]["user"]["total"] == 1
+
+
+def test_no_cves_passes(monkeypatch):
+    r = _run(monkeypatch, {"dependencies": []})
+    assert r["passed"] is True
+
+
+# ── waivers ───────────────────────────────────────────────────────────────────
+
+
+def test_waived_empirica_cve_passes(monkeypatch):
+    monkeypatch.setattr(audit, "is_waived", lambda ids: "CVE-2026-3" in ids)
+    r = _run(monkeypatch, _payload("pydantic", "PYSEC-3", "CVE-2026-3"))
+    assert r["passed"] is True
+    assert r["summary"]["empirica"]["waived"] == 1
+
+
+def test_kev_empirica_cve_fails_even_if_waived(monkeypatch):
+    # KEV = actively exploited → never silently waivable, even with a waiver.
+    monkeypatch.setattr(audit, "is_waived", lambda ids: True)
+    r = _run(monkeypatch, _payload("pydantic", "PYSEC-4", "CVE-2026-4"), kev_hits={"CVE-2026-4"})
+    assert r["passed"] is False
+    assert r["summary"]["empirica"]["now"] == 1
+
+
+# ── shared waiver source ──────────────────────────────────────────────────────
+
+
+def test_waiver_source_empty_by_default():
+    assert waivers.CVE_WAIVERS == []
+    assert waivers.waived_ids() == set()
+    assert waivers.is_waived(["CVE-2026-9999"]) is False
+
+
+def test_is_waived_matches_id_or_alias():
+    wl = [{"id": "PYSEC-X", "package": "p", "rationale": "r", "retire_when": "w", "aliases": ["CVE-2026-X"]}]
+    import unittest.mock
+
+    with unittest.mock.patch.object(waivers, "CVE_WAIVERS", wl):
+        assert waivers.is_waived(["CVE-2026-X"]) is True
+        assert waivers.is_waived(["PYSEC-X"]) is True
+        assert waivers.is_waived(["CVE-2026-OTHER"]) is False


### PR DESCRIPTION
## What

`empirica security-audit` and the release gate (`scripts/release.py`) now enforce the **same strict policy** from **one governed waiver source**, so they can't drift.

### Before
- `security-audit` `passed` failed only on empirica-scoped findings that matched the **CISA KEV** catalog (actively-exploited). An empirica-managed package with a plain critical CVE and **no KEV match still passed**.
- The release gate and the audit gate had **separate** waiver lists — a latent drift risk.

### After
- `security-audit` fails on **any** empirica-scoped CVE not in the governed waiver list — matching the release gate.
- A single `empirica.core.security.waivers.CVE_WAIVERS` list is the **sole** waiver source both gates read. `scripts/release.py` sources `PIP_AUDIT_WAIVERS` from it, **fail-safe to empty** (stricter, never looser) if empirica isn't importable at release time.
- **KEV matches are never silently waivable** — a waiver can't suppress an actively-exploited finding.
- **User-scoped** CVEs remain informational (reported, not gated).
- Each finding carries a `waived` flag; the per-scope summary carries a `waived` count.

The waiver list is currently **empty** — the sole prior waiver (PYSEC-2026-597, nltk via textstat) was retired in #212 when nltk left the tree.

## The gate

```python
"passed": not any(
    f["scope"] == "empirica" and (f.get("kev") or not f.get("waived"))
    for f in findings
)
```
An empirica finding blocks if it is KEV (never waivable) **or** not in the governed waiver source.

## Tests
- **7 new** in `tests/test_security_audit_strict.py`: strict-fail on un-waived empirica CVE, user-scope-not-gated, waived-passes, KEV-not-waivable-even-if-waived, empty-source, `is_waived` id/alias matching.
- **2 existing** tests in `tests/test_security_audit.py` updated to strict semantics (previously encoded the old KEV-only pass behavior).
- All 22 pass locally.

## Notes
- Files in CI scope (`empirica/`, `tests/`) pass `ruff check` + `ruff format --check`. `scripts/release.py` is outside CI lint scope; my added region is clean (pre-existing F541 in that file left untouched to keep this PR focused).

🤖 Generated with [Claude Code](https://claude.com/claude-code)