### PR TITLE
fix(resolver): get_instance_id() no longer mis-warns on UUIDv7 practitioner_ids

### DIFF
--- a/empirica/utils/session_resolver.py
+++ b/empirica/utils/session_resolver.py
@@ -857,18 +857,25 @@ def get_instance_id() -> str | None:
     if explicit_id:
         tmux_pane = os.environ.get("TMUX_PANE")
         if tmux_pane:
-            # Slot-shaped IDs (lowercase alphanumeric + dashes, no special chars)
-            # are the cockpit-blessed override pattern — stable per pane across
-            # restart. Log at debug, not warning, since this is intentional.
-            # Other shapes (e.g. set globally in .bashrc, contains %, ':', etc.)
-            # still get the warning because they break per-pane isolation.
+            # Slot-shaped OR UUID-shaped IDs are both intentional, stable
+            # override patterns → log at debug, not warning.
+            #   - cockpit slot: `[a-z][a-z0-9_-]*` (lowercase alnum + dashes)
+            #   - UUID (incl. UUIDv7): 8-4-4-4-12 hex. A codex/ecodex fork wires
+            #     its thread_id (a UUIDv7, which STARTS WITH A DIGIT) into
+            #     EMPIRICA_INSTANCE_ID so it becomes the practitioner_id keying
+            #     per-practitioner calibration. That's deliberate, not a mistake.
+            # Other shapes (set globally in .bashrc, contains %, ':', etc.) still
+            # warn — they genuinely break per-pane isolation. The old guard only
+            # accepted cockpit slots, so a UUIDv7 fell through to a misleading
+            # "unset EMPIRICA_INSTANCE_ID" warning that, if followed, would sever
+            # the ecodex practitioner_id → calibration mapping.
             import re as _re
 
-            looks_like_cockpit_slot = bool(_re.fullmatch(r"[a-z][a-z0-9_-]*", explicit_id))
-            if looks_like_cockpit_slot:
+            looks_intentional = bool(_re.fullmatch(r"[a-z][a-z0-9_-]*", explicit_id)) or _is_uuid_format(explicit_id)
+            if looks_intentional:
                 logger.debug(
                     f"EMPIRICA_INSTANCE_ID='{explicit_id}' overrides TMUX_PANE='{tmux_pane}' "
-                    f"(cockpit-style slot override — intentional)"
+                    f"(cockpit-slot or UUID override — intentional)"
                 )
             else:
                 logger.warning(

--- a/tests/test_session_resolver.py
+++ b/tests/test_session_resolver.py
@@ -7,12 +7,14 @@ dev's live ~/.empirica/sessions.db is empty.
 
 from __future__ import annotations
 
+import logging
 import time
 import uuid
 
 import pytest
 
 from empirica.utils.session_resolver import (
+    get_instance_id,
     get_latest_session_id,
     is_session_alias,
     resolve_session_id,
@@ -262,6 +264,45 @@ class TestGetActiveProjectPath:
 
         result = get_active_project_path()
         assert result == str(cwd_project)
+
+
+class TestGetInstanceIdOverrideWarning:
+    """get_instance_id() Priority-1 override warning behavior under tmux.
+
+    An explicit EMPIRICA_INSTANCE_ID overrides TMUX_PANE. Intentional, stable
+    shapes — a cockpit slot (`[a-z][a-z0-9_-]*`) OR a UUID (incl. UUIDv7) — log
+    at debug; other shapes warn that they break per-pane isolation. Regression
+    guard for the codex/ecodex UUIDv7 practitioner_id false-positive: a UUIDv7
+    starts with a digit, so the old leading-lowercase-letter guard mis-warned
+    and advised unsetting the id (which would sever the practitioner→calibration
+    mapping). The override always RESOLVES correctly; only the warning misfired.
+    """
+
+    def _warnings(self, caplog):
+        return [r for r in caplog.records if r.levelno >= logging.WARNING]
+
+    def test_uuidv7_override_resolves_without_warning(self, monkeypatch, caplog):
+        uuidv7 = "019f23cf-2b49-7f21-96bf-b7280bbafbc4"  # starts with a digit
+        monkeypatch.setenv("TMUX_PANE", "%11")
+        monkeypatch.setenv("EMPIRICA_INSTANCE_ID", uuidv7)
+        with caplog.at_level(logging.DEBUG, logger="empirica.utils.session_resolver"):
+            assert get_instance_id() == uuidv7
+        assert self._warnings(caplog) == []
+
+    def test_cockpit_slot_override_does_not_warn(self, monkeypatch, caplog):
+        monkeypatch.setenv("TMUX_PANE", "%11")
+        monkeypatch.setenv("EMPIRICA_INSTANCE_ID", "cockpit-slot-3")
+        with caplog.at_level(logging.DEBUG, logger="empirica.utils.session_resolver"):
+            assert get_instance_id() == "cockpit-slot-3"
+        assert self._warnings(caplog) == []
+
+    def test_non_slot_override_still_warns(self, monkeypatch, caplog):
+        # A globally-set id with special chars genuinely breaks per-pane isolation.
+        monkeypatch.setenv("TMUX_PANE", "%11")
+        monkeypatch.setenv("EMPIRICA_INSTANCE_ID", "GLOBAL:%bad")
+        with caplog.at_level(logging.DEBUG, logger="empirica.utils.session_resolver"):
+            assert get_instance_id() == "GLOBAL:%bad"
+        assert len(self._warnings(caplog)) == 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Bug (flagged by ecodex via mesh collab)

`get_instance_id()`'s tmux Priority-1 override guard (`session_resolver.py:867`) treated only **cockpit-slot** ids (`[a-z][a-z0-9_-]*`, leading lowercase letter) as intentional overrides worth logging at `debug`. Everything else fell to a `logger.warning`:

> `EMPIRICA_INSTANCE_ID='019f23cf-…' overrides TMUX_PANE='%11'. This breaks per-pane isolation. Unset EMPIRICA_INSTANCE_ID if using tmux.`

A **UUIDv7 starts with a digit**, so it failed the guard. A codex/ecodex fork wires its `thread_id` (a UUIDv7) into `EMPIRICA_INSTANCE_ID` so it becomes the `practitioner_id` keying per-practitioner calibration/Brier. Two harms:
1. **Noise** on every codex-family shell-out under tmux.
2. **Actively harmful advice** — an agent that followed "unset EMPIRICA_INSTANCE_ID" would sever its own `practitioner_id → calibration` mapping.

Resolution was **already correct** — Priority-1 returns the id (line 878). Only the warning misfired.

## Fix

Guard now accepts cockpit-slot **or** UUID-shaped ids, reusing the existing `_is_uuid_format()` helper (8-4-4-4-12 hex, case-insensitive → covers UUIDv7) → `logger.debug`. Non-slot/non-UUID shapes (globally-set ids with `%`/`:` etc.) still warn — they genuinely break per-pane isolation.

```python
looks_intentional = bool(_re.fullmatch(r"[a-z][a-z0-9_-]*", explicit_id)) or _is_uuid_format(explicit_id)
```

No two-sources drift: the plugin copy (`project_resolver.py:107`) delegates to the canonical resolver and its own fallback has no warning.

## Tests
3 new in `TestGetInstanceIdOverrideWarning`: UUIDv7 + cockpit-slot resolve without warning; a special-char global id still warns. 23 pass locally; ruff + format + pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)