### PR TITLE
feat(daemon-crm): add tier + reporting_to_name to the contact projection

### DIFF
--- a/empirica/api/routes/entities.py
+++ b/empirica/api/routes/entities.py
@@ -134,6 +134,8 @@ async def list_entities(
         # enrichment agree.
         contact_org_details = repo.get_contact_org_details_map()
         contact_details = repo.get_contact_detail_map()
+        # Manager (reports_to edge) → the extension Profile's "Reports-to" row.
+        contact_reports_to = repo.get_contact_reports_to_map()
         for row in repo.list_entities(entity_type=type, status=status, parent_org=parent_org, limit=limit):
             et, eid = row["entity_type"], row["entity_id"]
             meta = _parse_metadata(row.get("metadata"))
@@ -166,5 +168,9 @@ async def list_entities(
                 entry["notes"] = cd.get("notes")
                 entry["contact_type"] = cd.get("contact_type")
                 entry["lifecycle_stage"] = cd.get("lifecycle_stage")
+                # tier lives in the registry metadata (already parsed into meta);
+                # reporting_to_name resolves the reports_to edge → manager's name.
+                entry["tier"] = meta.get("tier")
+                entry["reporting_to_name"] = contact_reports_to.get(eid)
             out.append(entry)
     return {"ok": True, "count": len(out), "entities": out}

--- a/empirica/data/repositories/workspace_db.py
+++ b/empirica/data/repositories/workspace_db.py
@@ -998,6 +998,27 @@ class WorkspaceDBRepository(BaseRepository):
             for row in cursor.fetchall()
         }
 
+    def get_contact_reports_to_map(self) -> dict[str, str]:
+        """Map contact_id → their manager's display_name via active ``reports_to``
+        edges.
+
+        Same entity_memberships source as ``get_contact_org_details_map`` but
+        filtered to ``role = 'reports_to'`` (a contact→contact edge: member is the
+        report, group is the manager), joined to entity_registry for the manager's
+        ``display_name``. Latest active edge wins (ASC + dict overwrite). Managers
+        with no registry row (or edges with no manager name) are omitted.
+        """
+        cursor = self._execute(
+            """SELECT m.entity_id, r.display_name AS manager_name
+               FROM entity_memberships m
+               JOIN entity_registry r
+                 ON r.entity_id = m.group_id AND r.entity_type = 'contact'
+               WHERE m.entity_type = 'contact' AND m.group_type = 'contact'
+                 AND m.role = 'reports_to' AND m.left_at IS NULL
+               ORDER BY m.joined_at ASC"""
+        )
+        return {row["entity_id"]: row["manager_name"] for row in cursor.fetchall() if row["manager_name"]}
+
     def _table_exists(self, name: str) -> bool:
         """True iff a table named ``name`` exists in the connected DB.
 

--- a/tests/test_workspace_crm_projection.py
+++ b/tests/test_workspace_crm_projection.py
@@ -86,6 +86,37 @@ def test_contact_org_details_excludes_closed_edges(repo):
     assert "c-closed" not in repo.get_contact_org_details_map()
 
 
+# ── reports_to (manager name) ─────────────────────────────────────────────────
+
+
+def test_reports_to_map_resolves_active_manager_name():
+    """get_contact_reports_to_map: contact_id → manager display_name via active
+    reports_to edges. Closed edges + non-reports_to roles excluded; a manager
+    with no registry row is omitted (JOIN, not LEFT JOIN)."""
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.executescript(
+        """
+        CREATE TABLE entity_registry (entity_type TEXT, entity_id TEXT, display_name TEXT);
+        CREATE TABLE entity_memberships (
+            entity_type TEXT, entity_id TEXT, group_type TEXT, group_id TEXT,
+            role TEXT, joined_at TEXT, left_at TEXT
+        );
+        INSERT INTO entity_registry VALUES
+            ('contact','c-report','Frederike Lehmann'),
+            ('contact','c-boss','Georg Fechter');
+        INSERT INTO entity_memberships VALUES
+            ('contact','c-report','contact','c-boss','reports_to','2026-01-01',NULL),
+            ('contact','c-closed','contact','c-boss','reports_to','2026-01-01','2026-03-01'),
+            ('contact','c-report','organization','o-x','member','2026-01-01',NULL),
+            ('contact','c-noreg','contact','c-ghost','reports_to','2026-01-01',NULL);
+        """
+    )
+    m = WorkspaceDBRepository(conn).get_contact_reports_to_map()
+    # active reports_to only; org 'member' edge, closed edge, unregistered manager all excluded
+    assert m == {"c-report": "Georg Fechter"}
+
+
 # ── engagement tasks ──────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## What

Completes **ASK-1** for the extension's NLE CRM Profile view — the two fields that were missing from #218 (flagged by extension after verifying against the running daemon).

| Field | Source | Notes |
|-------|--------|-------|
| **tier** | `entity_registry.metadata.tier` | Already parsed per-row into `meta` — no new query. Live: Georg=`lead`, Friederike=`1`, rest=`2`. |
| **reporting_to_name** | new `get_contact_reports_to_map()` | Joins `entity_memberships(role='reports_to', active)` → `entity_registry` for the manager's `display_name`. Same source as the org-affiliation map, filtered to the reports_to edge. |

The `reports_to` edge is contact→contact (member = the report, group = the manager). Managers with no registry row are omitted (JOIN, not LEFT JOIN). Closed edges (`left_at` set) and non-`reports_to` roles are excluded.

## JSON keys (answering extension's Q3)

The projection emits **`email`/`phone`** (not `email_primary`/`phone_primary`). Full contact key set now:
`email, phone, title, tags, notes, contact_type, lifecycle_stage, parent_org_id, parent_org_name, role, tier, reporting_to_name`.

## Verified end-to-end

Against the live `workspace.db`: 10 `reports_to` edges resolve (→ Georg Fechter / Luis Biscaldi); `tier` reads `lead`/`1`/`2`.

## Tests
`test_reports_to_map_resolves_active_manager_name` — excludes closed edges, non-`reports_to` roles, and unregistered managers. 33 pass locally; ruff + format + pyright clean.

## Follow-up (not in this PR)
The running daemon still needs a restart to serve #218 + this — tracked separately; I'll redeploy once this merges and confirm with extension.

🤖 Generated with [Claude Code](https://claude.com/claude-code)