### PR TITLE
feat(daemon-crm): add ?contact= filter to GET /api/v1/engagements

### DIFF
--- a/empirica/api/routes/engagements.py
+++ b/empirica/api/routes/engagements.py
@@ -39,6 +39,11 @@ def _require_severity(severity: str | None) -> None:
 @router.get("/engagements", dependencies=[Depends(verify_mint_bearer)])
 async def list_engagements(
     org: str | None = Query(None, description="Filter to engagements ticket_of this organization id"),
+    contact: str | None = Query(
+        None,
+        description="Filter to engagements this contact id actively participates in "
+        "(engagement_contacts edge). Composes with `org` (AND) when both are given.",
+    ),
     domain: str | None = Query(None, description="Filter by engagement domain (support, sales, ...)"),
     lifecycle: str | None = Query(None, description="Filter by lifecycle_state (open, in_progress, blocked, closed)"),
     include_closed: bool = Query(
@@ -64,6 +69,7 @@ async def list_engagements(
         try:
             rows = repo.list_engagements(
                 org_id=org,
+                contact_id=contact,
                 domain=domain,
                 lifecycle_state=lifecycle,
                 include_closed=include_closed,

--- a/empirica/data/repositories/workspace_db.py
+++ b/empirica/data/repositories/workspace_db.py
@@ -1277,6 +1277,7 @@ class WorkspaceDBRepository(BaseRepository):
         domain: str | None = None,
         lifecycle_state: str | None = None,
         org_id: str | None = None,
+        contact_id: str | None = None,
         include_closed: bool = False,
         limit: int = 100,
     ) -> list[dict[str, Any]]:
@@ -1284,7 +1285,10 @@ class WorkspaceDBRepository(BaseRepository):
 
         ``org_id`` scopes to engagements that are members of that organization
         with role='ticket_of' (the canonical org→ticket linkage), joining
-        entity_memberships. ``lifecycle_state`` must be a valid state.
+        entity_memberships. ``contact_id`` scopes to engagements the contact is
+        an active participant in (``engagement_contacts`` edge, ``left_at IS
+        NULL``); the two org/contact filters compose (AND) when both are given.
+        ``lifecycle_state`` must be a valid state.
 
         Active-by-default (SER#183 part-2): when no explicit ``lifecycle_state``
         is given, terminal engagements (``ENGAGEMENT_TERMINAL_STATES``, i.e.
@@ -1307,6 +1311,17 @@ class WorkspaceDBRepository(BaseRepository):
                 "m.group_type = 'organization' AND m.group_id = ? AND m.role = 'ticket_of' AND m.left_at IS NULL"
             )
             params.append(org_id)
+        if contact_id is not None:
+            # engagement_contacts is workspace-managed and NOT vendored into the
+            # core substrate — absent on a core-only install. No linkage table →
+            # no contact-scoped engagements (honest-empty), never a 500.
+            if not self._table_exists("engagement_contacts"):
+                return []
+            # Active participation edge — engagement_contacts.PK(engagement_id,
+            # contact_id) guarantees ≤1 match per engagement, so no row dupes.
+            join += " JOIN engagement_contacts ec ON ec.engagement_id = e.engagement_id"
+            where.append("ec.contact_id = ? AND ec.left_at IS NULL")
+            params.append(contact_id)
         if domain is not None:
             where.append("e.domain = ?")
             params.append(domain)

--- a/tests/test_engagement_repository.py
+++ b/tests/test_engagement_repository.py
@@ -138,6 +138,68 @@ def test_list_org_scoped_is_active_by_default(repo):
     assert {e["engagement_id"] for e in repo.list_engagements(org_id="acme", include_closed=True)} == {"t1", "t2"}
 
 
+# ── contact scoping (engagement_contacts edge) ────────────────────────────────
+
+
+def _seed_engagement_contacts(repo, edges):
+    """engagement_contacts is workspace-managed (not core-vendored) — create it +
+    seed edges. Each edge: (engagement_id, contact_id, left_at)."""
+    repo.conn.execute(
+        """CREATE TABLE IF NOT EXISTS engagement_contacts (
+               engagement_id TEXT NOT NULL, contact_id TEXT NOT NULL,
+               role TEXT DEFAULT 'participant', joined_at REAL NOT NULL, left_at REAL,
+               contribution_notes TEXT, PRIMARY KEY (engagement_id, contact_id))"""
+    )
+    now = time.time()
+    for eid, cid, left_at in edges:
+        repo.conn.execute(
+            "INSERT INTO engagement_contacts (engagement_id, contact_id, joined_at, left_at) VALUES (?, ?, ?, ?)",
+            (eid, cid, now, left_at),
+        )
+    repo.conn.commit()
+
+
+def test_list_contact_scoped_via_engagement_contacts(repo):
+    repo.create_engagement("t1", "carly ticket", domain="support")
+    repo.create_engagement("t2", "carly ticket 2", domain="support")
+    repo.create_engagement("t3", "unrelated", domain="support")
+    _seed_engagement_contacts(
+        repo,
+        [("t1", "c-carly", None), ("t2", "c-carly", None), ("t3", "c-other", None)],
+    )
+    assert {e["engagement_id"] for e in repo.list_engagements(contact_id="c-carly")} == {"t1", "t2"}
+
+
+def test_list_contact_scope_excludes_left_edges(repo):
+    repo.create_engagement("t1", "active edge", domain="support")
+    repo.create_engagement("t2", "left edge", domain="support")
+    _seed_engagement_contacts(repo, [("t1", "c-carly", None), ("t2", "c-carly", time.time())])
+    assert {e["engagement_id"] for e in repo.list_engagements(contact_id="c-carly")} == {"t1"}
+
+
+def test_list_contact_and_org_compose(repo):
+    repo.create_engagement("t1", "acme + carly", domain="support")
+    repo.create_engagement("t2", "acme only", domain="support")
+    now = time.time()
+    for eid in ("t1", "t2"):
+        repo.conn.execute(
+            "INSERT INTO entity_memberships (entity_type, entity_id, group_type, group_id, role, joined_at, created_at) "
+            "VALUES ('engagement', ?, 'organization', 'acme', 'ticket_of', ?, ?)",
+            (eid, now, now),
+        )
+    repo.conn.commit()
+    _seed_engagement_contacts(repo, [("t1", "c-carly", None)])
+    # org AND contact both apply → only t1 (acme ticket carly participates in)
+    assert {e["engagement_id"] for e in repo.list_engagements(org_id="acme", contact_id="c-carly")} == {"t1"}
+
+
+def test_list_contact_scope_empty_when_linkage_table_absent(repo):
+    """Core-only DB (no engagement_contacts table) → contact filter honest-empty,
+    never a `no such table` 500."""
+    repo.create_engagement("t1", "some ticket", domain="support")
+    assert repo.list_engagements(contact_id="c-carly") == []
+
+
 # ── update + enum enforcement ────────────────────────────────────────────────
 
 

--- a/tests/test_engagements_endpoint.py
+++ b/tests/test_engagements_endpoint.py
@@ -178,6 +178,15 @@ def test_route_domain_filter(client):
     assert client.get("/api/v1/engagements?domain=sales").json()["count"] == 0
 
 
+def test_route_contact_filter_wires_and_degrades(client):
+    # ?contact= binds as a query param; the temp workspace.db has no
+    # engagement_contacts table (core-only), so the filter is honest-empty
+    # (200, count 0) rather than a `no such table` 500.
+    r = client.get("/api/v1/engagements?contact=c-nobody")
+    assert r.status_code == 200
+    assert r.json()["count"] == 0
+
+
 def test_route_invalid_lifecycle_422(client):
     r = client.get("/api/v1/engagements?lifecycle=not_a_state")
     assert r.status_code == 422


### PR DESCRIPTION
## What

Adds a **`?contact=`** query param to `GET /api/v1/engagements` — scopes the feed to engagements a contact **actively participates in** (`engagement_contacts` edge, `left_at IS NULL`). The contact-side mirror of the existing `?org=` (`ticket_of`) filter; the two **compose (AND)** when both are given. Backs the extension's per-contact engagement drill (d7a87292).

## Resilience

`engagement_contacts` is **workspace-managed** and not vendored into the core substrate — absent on a core-only install. The filter degrades to **honest-empty** (`[]` / count 0) via a `_table_exists("engagement_contacts")` guard rather than a `no such table` 500 (same pattern as the contact projection resilience fix).

## Verified

Live workspace.db has 20 `engagement_contacts` edges. Repo-level tests:
- positive filter (contact → their engagements)
- excludes `left_at`-set (inactive) edges
- `org` + `contact` compose to the intersection
- table-absent → `[]` (no 500)

Route-level: `?contact=` binds + degrades gracefully (200, count 0) on a core-only temp DB.

43 tests pass; ruff + format + pyright clean.

## Follow-up
I'll redeploy the running daemon after merge so the new filter is live for the extension.

🤖 Generated with [Claude Code](https://claude.com/claude-code)