### PR TITLE
feat(daemon-crm): project metadata.ticket onto the engagement response

### DIFF
--- a/empirica/api/routes/engagements.py
+++ b/empirica/api/routes/engagements.py
@@ -102,6 +102,9 @@ async def list_engagements(
                         "severity": proj["severity"],
                         "assignee_id": proj["assignee_id"],
                         "assignee_display": proj["assignee_display"],
+                        # routing/blocker block for the board's engagement detail
+                        # (kind, feedback_required_from, decision_owner, unblock_channel, fork)
+                        "ticket": proj["ticket"],
                     },
                 }
             )

--- a/empirica/data/repositories/workspace_db.py
+++ b/empirica/data/repositories/workspace_db.py
@@ -1406,6 +1406,11 @@ class WorkspaceDBRepository(BaseRepository):
             "severity": meta.get("severity"),
             "assignee_id": meta.get("assignee_id"),
             "assignee_display": meta.get("assignee_display"),
+            # ticket: the routing/blocker block (kind, text, feedback_required_from,
+            # decision_owner, unblock_channel, fork) passed through from the registry
+            # metadata for the board's engagement detail. Render-only v1 — None when
+            # absent; promote to a spine column only if it needs to be queryable.
+            "ticket": meta.get("ticket"),
         }
 
     def update_engagement(

--- a/tests/test_engagements_endpoint.py
+++ b/tests/test_engagements_endpoint.py
@@ -117,6 +117,27 @@ def test_projection_severity_assignee_passthrough(repo):
     assert p["assignee_display"] == "Sam"
 
 
+def test_projection_ticket_passthrough(repo):
+    """The routing/blocker `ticket` block projects through from registry metadata
+    (render-only v1 for the board's engagement detail)."""
+    ticket = {
+        "kind": "blocker",
+        "feedback_required_from": "client",
+        "decision_owner": "Georg Fechter",
+        "unblock_channel": "nle-leadership",
+        "fork": "fork 2",
+    }
+    repo.create_engagement("e1", "Ticket", domain="support", stage="support.new")
+    _registry(repo, "engagement", "e1", "Ticket", metadata={"ticket": ticket})
+    assert repo.get_engagement_projection("e1")["ticket"] == ticket
+
+
+def test_projection_ticket_none_when_absent(repo):
+    repo.create_engagement("e1", "Ticket", domain="support", stage="support.new")
+    _registry(repo, "engagement", "e1", "Ticket", metadata={"severity": "high"})
+    assert repo.get_engagement_projection("e1")["ticket"] is None
+
+
 def test_projection_tolerates_garbage_metadata(repo):
     repo.create_engagement("e1", "Ticket", domain="support", stage="support.new")
     repo._execute(


### PR DESCRIPTION
## What

`GET /api/v1/engagements` now includes a **`ticket`** block in each engagement's `metadata` — the routing/blocker record (`kind`, `text`, `feedback_required_from`, `decision_owner`, `unblock_channel`, `fork`) passed through from `entity_registry.metadata.ticket`.

Same passthrough pattern as `severity`/`assignee` (and the contact `tier` projection in #221) — **render-only v1, no schema change**, `None` when absent.

## Why

The extension's ticket-render was blocked: `entity_registry.metadata.ticket` held the 5 tickets, but the daemon serializer didn't project them onto the engagement response (metadata was `{org_display, severity, assignee_id, assignee_display}` only). Now the board can render the blocker badge, "⚠ awaiting `<owner>`" chip, and unblock-channel route hint in the engagement detail.

## Verified
Live workspace.db has 5 engagements carrying tickets. Tests: `ticket` passthrough + `None`-when-absent (mirroring the severity/assignee tests).

22 pass; ruff + format + pyright clean.

## Follow-up
Redeploy the daemon after merge so the extension can render it (render-only via metadata; promote to a spine column only if mesh-support needs it queryable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)