### PR TITLE
feat(presence): B3 — detect_current_location, a location controller split from identity

### DIFF
--- a/empirica/cli/command_handlers/practitioner_commands.py
+++ b/empirica/cli/command_handlers/practitioner_commands.py
@@ -39,11 +39,16 @@ def handle_practitioner_write_command(args) -> int:
     try:
         from empirica.core.practitioner_presence import write_presence
         from empirica.utils.session_resolver import InstanceResolver as R
-        from empirica.utils.session_resolver import get_instance_id
+        from empirica.utils.session_resolver import detect_current_location
 
         cc = args.session
         ai_id = getattr(args, "ai_id", None) or R.ai_id() or "unknown"
-        location = getattr(args, "location", None) or get_instance_id()
+        # LOCATION, not identity: the physical terminal/pane, re-resolved live each
+        # per-turn write (context-shift-tracker). Uses detect_current_location (not
+        # get_instance_id) so a practitioner whose EMPIRICA_INSTANCE_ID carries a
+        # durable identity — e.g. an ecodex thread_id — records its real tmux/TTY
+        # location, not its identity. The durable key stays claude_session_id (cc).
+        location = getattr(args, "location", None) or detect_current_location()
         empirica_sid = getattr(args, "empirica_session", None) or R.session_id(claude_session_id=cc)
         tx = getattr(args, "active_transaction", None) or R.transaction_id(claude_session_id=cc)
         status = getattr(args, "status", "active")

--- a/empirica/utils/session_resolver.py
+++ b/empirica/utils/session_resolver.py
@@ -885,40 +885,66 @@ def get_instance_id() -> str | None:
         logger.debug(f"Using explicit instance_id: {explicit_id}")
         return explicit_id
 
-    # Priority 2: tmux pane (most common for multi-instance work)
-    # IMPORTANT: Use tmux_{N} format (not tmux:%N) to match file naming convention
-    # Files are named: instance_projects/tmux_4.json, active_transaction_tmux_4.json
+    # Priorities 2-6: physical location (tmux / Terminal / X11 / TTY / none).
+    # Shared with detect_current_location() so the two never drift — the only
+    # difference is that get_instance_id honors the Priority-1 identity override
+    # above, whereas detect_current_location resolves the LOCATION alone.
+    return _resolve_physical_location()
+
+
+def _resolve_physical_location() -> str | None:
+    """Resolve the EPHEMERAL physical location of the current process — the
+    terminal/pane it runs in — independent of any practitioner IDENTITY override.
+
+    Priority: tmux pane → macOS Terminal session → X11 window → TTY device →
+    None. This is the location half of instance resolution; the identity half
+    (the ``EMPIRICA_INSTANCE_ID`` / ``CLAUDE_INSTANCE_ID`` override) is handled
+    by :func:`get_instance_id`'s Priority 1. Kept as one shared helper so the
+    two callers can't drift.
+    """
+    import os
+
+    # tmux pane — tmux_{N} format (not tmux:%N) to match the file naming
+    # convention (instance_projects/tmux_4.json, active_transaction_tmux_4.json).
     tmux_pane = os.environ.get("TMUX_PANE")
     if tmux_pane:
-        instance_id = f"tmux_{tmux_pane.lstrip('%')}"
-        logger.debug(f"Using tmux pane as instance_id: {instance_id}")
-        return instance_id
-
-    # Priority 3: macOS Terminal.app session
+        return f"tmux_{tmux_pane.lstrip('%')}"
+    # macOS Terminal.app session (truncate — the full id is very long).
     term_session = os.environ.get("TERM_SESSION_ID")
     if term_session:
-        # Truncate to reasonable length (full ID is very long)
-        instance_id = f"term:{term_session[:16]}"
-        logger.debug(f"Using Terminal.app session as instance_id: {instance_id}")
-        return instance_id
-
-    # Priority 4: X11 window ID
+        return f"term:{term_session[:16]}"
+    # X11 window id.
     window_id = os.environ.get("WINDOWID")
     if window_id:
-        instance_id = f"x11:{window_id}"
-        logger.debug(f"Using X11 window ID as instance_id: {instance_id}")
-        return instance_id
-
-    # Priority 5: TTY device (persists across CLI invocations in same terminal)
+        return f"x11:{window_id}"
+    # TTY device (persists across CLI invocations in the same terminal).
     tty_key = get_tty_key()
     if tty_key:
-        instance_id = f"term_{tty_key}"
-        logger.debug(f"Using TTY as instance_id: {instance_id}")
-        return instance_id
-
-    # Priority 6: No isolation (legacy behavior)
-    logger.debug("No instance_id available - using legacy behavior")
+        return f"term_{tty_key}"
     return None
+
+
+def detect_current_location() -> str | None:
+    """The practitioner's CURRENT physical location (tmux pane / TTY / …),
+    re-resolved LIVE — a controller SEPARATE from durable identity.
+
+    A practitioner's identity is its ``claude_session_id`` (durable — it survives
+    compaction AND pane moves); its LOCATION is ephemeral and can change
+    mid-session (moved tmux pane, new TTY). Presence tracking wants the live
+    location, so callers re-resolve this on each per-turn presence write rather
+    than caching it once at session-init.
+
+    Unlike :func:`get_instance_id`, this deliberately IGNORES the
+    ``EMPIRICA_INSTANCE_ID`` override: that env var carries a durable
+    practitioner IDENTITY (e.g. a codex/ecodex thread_id wired in to key
+    per-practitioner calibration), NOT a physical location. Using it as a
+    location would pin a moved practitioner to a stale 'location' that is really
+    its identity — the exact identity/location conflation this split resolves.
+    Returns ``None`` when no physical location is detectable (e.g. a
+    non-terminal harness) — honest, rather than leaking the identity into the
+    location field.
+    """
+    return _resolve_physical_location()
 
 
 def _get_instance_suffix() -> str:

--- a/tests/test_session_resolver.py
+++ b/tests/test_session_resolver.py
@@ -14,6 +14,7 @@ import uuid
 import pytest
 
 from empirica.utils.session_resolver import (
+    detect_current_location,
     get_instance_id,
     get_latest_session_id,
     is_session_alias,
@@ -303,6 +304,39 @@ class TestGetInstanceIdOverrideWarning:
         with caplog.at_level(logging.DEBUG, logger="empirica.utils.session_resolver"):
             assert get_instance_id() == "GLOBAL:%bad"
         assert len(self._warnings(caplog)) == 1
+
+
+class TestDetectCurrentLocation:
+    """detect_current_location resolves the ephemeral PHYSICAL location
+    (tmux pane / TTY / …) — a controller SEPARATE from durable identity (B3).
+
+    Unlike get_instance_id it ignores the EMPIRICA_INSTANCE_ID override, which
+    carries a durable practitioner IDENTITY (e.g. an ecodex thread_id), not a
+    physical location. So a practitioner whose identity is wired into that env
+    var still records its real tmux/TTY as its presence location.
+    """
+
+    def test_ignores_identity_override_resolves_physical(self, monkeypatch):
+        # ecodex-style: EMPIRICA_INSTANCE_ID = a durable thread_id identity.
+        monkeypatch.setenv("EMPIRICA_INSTANCE_ID", "019f23cf-2b49-7f21-96bf-b7280bbafbc4")
+        monkeypatch.setenv("TMUX_PANE", "%11")
+        # identity resolver honors the override; location resolver returns physical tmux
+        assert get_instance_id() == "019f23cf-2b49-7f21-96bf-b7280bbafbc4"
+        assert detect_current_location() == "tmux_11"
+
+    def test_agrees_with_instance_id_without_override(self, monkeypatch):
+        monkeypatch.delenv("EMPIRICA_INSTANCE_ID", raising=False)
+        monkeypatch.delenv("CLAUDE_INSTANCE_ID", raising=False)
+        monkeypatch.setenv("TMUX_PANE", "%7")
+        # no identity override → the two resolvers agree (both = physical tmux)
+        assert detect_current_location() == "tmux_7" == get_instance_id()
+
+    def test_none_when_no_physical_location(self, monkeypatch):
+        for var in ("EMPIRICA_INSTANCE_ID", "CLAUDE_INSTANCE_ID", "TMUX_PANE", "TERM_SESSION_ID", "WINDOWID"):
+            monkeypatch.delenv(var, raising=False)
+        # No terminal at all (non-terminal harness) → honest None, not a leaked identity.
+        monkeypatch.setattr("empirica.utils.session_resolver.get_tty_key", lambda: None)
+        assert detect_current_location() is None
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What (EPIC B / B3)

Splits the two concerns `get_instance_id()` conflated — per your 2026-06-24 note that *instance-detection is a separate controller from practitioner identity*:

- **Identity** — durable `claude_session_id` (survives compaction *and* pane moves). The `EMPIRICA_INSTANCE_ID` override an ecodex-style fork wires its `thread_id` into is identity too.
- **Location** — ephemeral tmux pane / TTY, re-resolved live.

## Changes

- **`_resolve_physical_location()`** — extracted shared resolver (tmux → Terminal → X11 → TTY → None), so the two callers can't drift. `get_instance_id` keeps its Priority-1 identity override, then delegates here (behavior unchanged for it).
- **`detect_current_location()`** — physical-location-only; **deliberately ignores `EMPIRICA_INSTANCE_ID`** (that's identity). Returns `None` on a non-terminal harness rather than leaking the identity into `location`.
- **`practitioner write`** now stamps `location` from `detect_current_location()` instead of `get_instance_id()`. So an ecodex-style practitioner (whose `EMPIRICA_INSTANCE_ID` = a durable thread_id) records its **real tmux/TTY** as location; the durable presence key stays `claude_session_id`.

The *live per-turn re-resolve* half was already wired (`context-shift-tracker` fires `practitioner write` each turn) — this PR is the identity/location **separation** that was missing.

## Tests
`detect_current_location`: ignores the identity override (returns physical `tmux_11` while `get_instance_id` returns the id), agrees without an override, `None` when no terminal is detectable. **192** practitioner/presence/instance/session-resolver tests green; ruff + format + pyright clean.

## Scope note
This is the empirica-side B3 leg. The cortex mailbox re-key (inbox/outbox → canonical ai_id) and B4 (practitioner entity_type) remain — B4 is designed in `PRACTITIONER_DELIBERATION_MODEL.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)