### PR TITLE
feat(daemon-crm): build Gap B — GET /api/v1/entities/{id}/artifacts

### DIFF
--- a/empirica/api/routes/entities.py
+++ b/empirica/api/routes/entities.py
@@ -174,3 +174,27 @@ async def list_entities(
                 entry["reporting_to_name"] = contact_reports_to.get(eid)
             out.append(entry)
     return {"ok": True, "count": len(out), "entities": out}
+
+
+@router.get("/entities/{entity_id}/artifacts", dependencies=[Depends(verify_mint_bearer)])
+async def list_entity_artifacts(
+    entity_id: str,
+    type: str | None = Query(
+        None, description="Optional entity_type to disambiguate (contact, organization, engagement, ...)"
+    ),
+    limit: int = Query(100, ge=1, le=500),
+):
+    """Scoped artifacts for a single entity (canonical-model Gap B).
+
+    Returns the entity's DIRECT ``entity_artifacts`` pointers, newest first, each
+    carrying ``artifact_type`` + ``artifact_source`` (§5 — so the caller can
+    resolve + render the artifact). Unknown / empty entity → ``artifacts: []``
+    (honest-empty; the board renders 0 rather than the old 404). Membership-
+    transitive scoping (an entity's members' artifacts) is a deferred v2 pending
+    the §5 relation/direction.
+    """
+    from empirica.data.repositories.workspace_db import WorkspaceDBRepository
+
+    with WorkspaceDBRepository.open() as repo:
+        artifacts = repo.get_artifacts_for_entity(entity_id, entity_type=type, limit=limit)
+    return {"ok": True, "entity_id": entity_id, "count": len(artifacts), "artifacts": artifacts}

--- a/empirica/data/repositories/workspace_db.py
+++ b/empirica/data/repositories/workspace_db.py
@@ -682,6 +682,40 @@ class WorkspaceDBRepository(BaseRepository):
         )
         return [dict(row) for row in cursor.fetchall()]
 
+    def get_artifacts_for_entity(
+        self,
+        entity_id: str,
+        *,
+        entity_type: str | None = None,
+        limit: int = 100,
+    ) -> list[dict[str, Any]]:
+        """Scoped artifacts for an entity (canonical-model Gap B) — the DIRECT
+        entity_artifacts pointers WHERE entity_id=?, newest first. Each row carries
+        ``artifact_type`` + ``artifact_source`` (the §5 fields the extension needs
+        to resolve + render the artifact). ``entity_type`` is optional: entity_ids
+        are prefix-unique (eng-/c-/o-) so the id alone usually suffices — pass it to
+        disambiguate. Empty list when the entity has none.
+
+        Membership-transitive scoping (an entity's members' artifacts) is a
+        deferred v2 — its exact relation/direction lives in canonical-model §5,
+        which this method intentionally does not guess at.
+        """
+        where = ["entity_id = ?"]
+        params: list[Any] = [entity_id]
+        if entity_type:
+            where.append("entity_type = ?")
+            params.append(entity_type)
+        params.append(limit)
+        cursor = self._execute(
+            f"""SELECT artifact_type, artifact_id, artifact_source, relationship,
+                       relevance, engagement_id, discovered_via, created_at, created_by_ai
+                FROM entity_artifacts
+                WHERE {" AND ".join(where)}
+                ORDER BY created_at DESC LIMIT ?""",
+            tuple(params),
+        )
+        return [dict(row) for row in cursor.fetchall()]
+
     def count_entity_artifacts(self, entity_type: str, entity_id: str) -> int:
         """Count artifact links for an entity (list projection linked_artifact_count).
 

--- a/tests/test_workspace_crm_projection.py
+++ b/tests/test_workspace_crm_projection.py
@@ -157,3 +157,30 @@ def test_crm_projections_degrade_when_optional_tables_absent():
     assert repo.get_engagement_tasks("eng-1") == []
     # entity_memberships IS present → the org-details map still works (returns {}).
     assert repo.get_contact_org_details_map() == {}
+
+
+# ── scoped artifacts (canonical-model Gap B) ──────────────────────────────────
+
+
+def test_get_artifacts_for_entity_direct():
+    """get_artifacts_for_entity: the DIRECT entity_artifacts scoped to an entity,
+    each carrying artifact_type + artifact_source. entity_type disambiguates;
+    unknown entity → [] (honest-empty, not error — the endpoint 200s not 404s)."""
+    from empirica.data.repositories.workspace_db import _ensure_workspace_schema
+
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    _ensure_workspace_schema(conn)
+    repo = WorkspaceDBRepository(conn)
+    repo.add_entity_artifact("src-1", "source", "/p/.empirica", "engagement", "eng-x")
+    repo.add_entity_artifact("find-1", "finding", "/p/.empirica", "engagement", "eng-x")
+    repo.add_entity_artifact("src-2", "source", "/other/.empirica", "contact", "c-y")
+
+    out = repo.get_artifacts_for_entity("eng-x")
+    assert len(out) == 2
+    assert {a["artifact_type"] for a in out} == {"source", "finding"}
+    assert all(a.get("artifact_source") == "/p/.empirica" for a in out)  # §5 field present
+    # entity_type disambiguates; the contact's artifact is not returned for the engagement id
+    assert repo.get_artifacts_for_entity("eng-x", entity_type="contact") == []
+    # unknown entity → empty, never a raise (backs the endpoint's 200-not-404)
+    assert repo.get_artifacts_for_entity("no-such-entity") == []


### PR DESCRIPTION
## What

Builds **canonical-model Gap B** — the scoped-artifacts endpoint core hadn't built (it 404'd). That 404 is why engagements showed "no artifacts" even though the `entity_artifacts` edges were written.

`GET /api/v1/entities/{id}/artifacts` returns an entity's **direct** `entity_artifacts` pointers, newest first, each carrying `artifact_type` + `artifact_source` (§5 — enough to resolve + render). Unknown/empty entity → `{artifacts: [], count: 0}` (honest-empty, **200 not 404**). Optional `?type=` disambiguates; entity_ids are prefix-unique so the id alone usually suffices.

## Why / diagnosis

empirica-workspace verified against `workspace.db` + the live daemon: the edges are present (Francisco's 6 `source` edges), so it was never an edge or workspace problem — the endpoint just didn't exist.

## Verified live

`GET .../entities/eng-onboarding-francisco-suarez-ferrero/artifacts` surfaces the **6 source edges** (from empirica-mesh-support). New repo method `get_artifacts_for_entity(entity_id, entity_type=?, limit)`.

## Tests
Direct query returns the entity's artifacts with `artifact_type`/`artifact_source`, `?type=` disambiguates, unknown entity → `[]` (backs the 200-not-404). 34 pass; ruff + format + pyright clean.

## Deferred (v2)
**Membership-transitive** scoping (an entity's members' artifacts) — its exact relation/direction lives in canonical-model §5, which isn't in empirica's docs. Shipping the direct path now (unblocks the reported bug); I'll confirm the §5 transitive semantics with empirica-workspace before building (b).

🤖 Generated with [Claude Code](https://claude.com/claude-code)