### PR TITLE
feat(erm): B4 foundation — persist practitioner as a first-class ERM entity

### DIFF
--- a/empirica/cli/command_handlers/practitioner_commands.py
+++ b/empirica/cli/command_handlers/practitioner_commands.py
@@ -65,6 +65,18 @@ def handle_practitioner_write_command(args) -> int:
             )
         except ValueError as ve:
             return _emit_user_error(args, str(ve))
+        # B4: mirror the DURABLE half into the ERM — the practitioner entity +
+        # occupies→practice edge. Best-effort (never fail the live presence write
+        # on it); skipped when the practice ai_id is unknown. Idempotent upsert, so
+        # the per-turn write is self-healing.
+        if ai_id and ai_id != "unknown":
+            try:
+                from empirica.data.repositories.workspace_db import WorkspaceDBRepository
+
+                with WorkspaceDBRepository.open() as repo:
+                    repo.upsert_practitioner_entity(cc, ai_id)
+            except Exception:
+                pass
         if getattr(args, "output", "human") == "json":
             print(json.dumps({"ok": True, "presence": rec}, indent=2, default=str))
         else:

--- a/empirica/data/repositories/workspace_db.py
+++ b/empirica/data/repositories/workspace_db.py
@@ -1158,6 +1158,71 @@ class WorkspaceDBRepository(BaseRepository):
         )
         self.commit()
 
+    def upsert_practitioner_entity(
+        self,
+        claude_session_id: str,
+        practice_ai_id: str,
+        *,
+        display_name: str | None = None,
+        summary: str | None = None,
+        trajectory_pointer: str | None = None,
+    ) -> None:
+        """Persist a practitioner as a first-class ERM entity (B4 foundation).
+
+        A *practitioner* is a Claude conversation occupying a *practice*; its
+        DURABLE identity is the ``claude_session_id`` (survives compaction,
+        respawnable). This upserts the durable half into ``entity_registry``
+        (entity_type='practitioner', entity_id=claude_session_id) + the
+        ``occupies → practice`` membership edge (the practice keyed by its
+        canonical ``ai_id``). Idempotent.
+
+        The LIVE half — status / location / active transaction — is NOT stored
+        here: it stays in the presence file (ephemeral, high-churn) and is
+        synthesized on read. ``summary`` / ``trajectory_pointer`` are the durable
+        per-practitioner attrs (conversation tl;dr; a pointer to its trajectory
+        points), nullable at the foundation — B5 surfaces the reliability view.
+        """
+        meta: dict[str, Any] = {"practice_ai_id": practice_ai_id}
+        if summary is not None:
+            meta["summary"] = summary
+        if trajectory_pointer is not None:
+            meta["trajectory_pointer"] = trajectory_pointer
+        self.upsert_entity(
+            "practitioner",
+            claude_session_id,
+            display_name=display_name or f"{practice_ai_id} · {claude_session_id[:8]}",
+            source_db="workspace",
+            source_table="practitioner_presence",
+            metadata=json.dumps(meta),
+        )
+        self.upsert_entity_membership("practitioner", claude_session_id, "practice", practice_ai_id, role="occupies")
+
+    def list_practitioner_entities(self, practice_ai_id: str | None = None) -> list[dict[str, Any]]:
+        """The durable practitioner entities — "which practitioners, in which
+        practice" (B4 foundation query).
+
+        Returns the entity_registry practitioner rows, optionally scoped to a
+        practice via the active ``occupies`` edge. This is the DURABLE record — a
+        practitioner persists after its session ends (respawnable); merge with the
+        presence store for live status/location.
+        """
+        if practice_ai_id is None:
+            cursor = self._execute(
+                "SELECT * FROM entity_registry WHERE entity_type = 'practitioner' ORDER BY updated_at DESC"
+            )
+        else:
+            cursor = self._execute(
+                """SELECT r.* FROM entity_registry r
+                   JOIN entity_memberships m
+                     ON m.entity_type = 'practitioner' AND m.entity_id = r.entity_id
+                   WHERE r.entity_type = 'practitioner'
+                     AND m.group_type = 'practice' AND m.group_id = ?
+                     AND m.role = 'occupies' AND m.left_at IS NULL
+                   ORDER BY r.updated_at DESC""",
+                (practice_ai_id,),
+            )
+        return [dict(row) for row in cursor.fetchall()]
+
     def close_entity_membership(
         self,
         entity_type: str,

--- a/tests/test_workspace_crm_projection.py
+++ b/tests/test_workspace_crm_projection.py
@@ -184,3 +184,34 @@ def test_get_artifacts_for_entity_direct():
     assert repo.get_artifacts_for_entity("eng-x", entity_type="contact") == []
     # unknown entity → empty, never a raise (backs the endpoint's 200-not-404)
     assert repo.get_artifacts_for_entity("no-such-entity") == []
+
+
+# ── practitioner entity (B4 foundation) ───────────────────────────────────────
+
+
+def test_practitioner_entity_upsert_and_list_by_practice():
+    """upsert_practitioner_entity persists the durable practitioner entity +
+    occupies→practice edge (idempotent); list_practitioner_entities answers
+    'which practitioners, in which practice'."""
+    import json as _j
+
+    from empirica.data.repositories.workspace_db import _ensure_workspace_schema
+
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    _ensure_workspace_schema(conn)
+    repo = WorkspaceDBRepository(conn)
+
+    repo.upsert_practitioner_entity("cc-111", "empirica", summary="working on B4")
+    repo.upsert_practitioner_entity("cc-222", "empirica-cortex")
+    repo.upsert_practitioner_entity("cc-111", "empirica", summary="still B4")  # idempotent re-upsert
+
+    all_p = repo.list_practitioner_entities()
+    assert {p["entity_id"] for p in all_p} == {"cc-111", "cc-222"}  # no dupe on re-upsert
+    meta = _j.loads(next(p for p in all_p if p["entity_id"] == "cc-111")["metadata"])
+    assert meta["practice_ai_id"] == "empirica" and meta["summary"] == "still B4"
+
+    # scoped by practice via the active occupies edge
+    assert {p["entity_id"] for p in repo.list_practitioner_entities("empirica")} == {"cc-111"}
+    assert {p["entity_id"] for p in repo.list_practitioner_entities("empirica-cortex")} == {"cc-222"}
+    assert repo.list_practitioner_entities("no-such-practice") == []


### PR DESCRIPTION
## What (EPIC B / B4 — §5 build-sequence step 1, empirica-core lane)

Mirrors the **durable** half of a practitioner into the ERM, alongside contact/org/engagement — so *"which practitioners, in which practice"* is queryable and practitioners are first-class entities.

- **`upsert_practitioner_entity(claude_session_id, practice_ai_id, summary?, trajectory_pointer?)`** — upserts `entity_registry` (`entity_type='practitioner'`, `entity_id=claude_session_id`, `metadata={practice_ai_id, summary?, trajectory_pointer?}`) + the **`occupies → practice`** edge (practice keyed by its canonical `ai_id`). Idempotent.
- **`list_practitioner_entities(practice_ai_id?)`** — scoped via the active `occupies` edge.
- Wired **best-effort** into `practitioner write` (skipped when practice ai_id is unknown; never fails the live presence write). The per-turn idempotent upsert is self-healing.

## The durable/live split

The **live** half (status / location / active-transaction) stays in the presence file and is synthesized on read — *not* stored here. `summary` / `trajectory_pointer` are nullable durable attrs. The generic `GET /api/v1/entities?type=practitioner` already lists these; a presence-merge for live status is the next thin layer.

## Scope discipline

This is only the **foundation** (`*(my lane)*` in `PRACTITIONER_DELIBERATION_MODEL.md` §5.1). The contested legs — **B5** reliability shrinkage, **B6** deliberation record, **B7** Sentinel arbitration — are autonomy/cortex lanes and explicitly deferred (the "ratify before building" cautions apply to those, not this persistence slice).

## Tests
Idempotent upsert (no dupe on re-write), metadata carries practice + summary, `list` scopes by practice via the occupies edge, unknown practice → `[]`. Live smoke confirms the write→entity→list path. 20 pass; ruff + format + pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)