### PR TITLE
test(module-provision): de-flake interval-automation assertion

### DIFF
--- a/tests/test_module_provision.py
+++ b/tests/test_module_provision.py
@@ -186,7 +186,10 @@ def test_interval_automation_passes_interval(tmp_path, monkeypatch):
     )
     m = _manifest(tmp_path, automations=[{"name": "poller", "kind": "interval", "interval": "5m"}])
     provision_module(m, dry_run=False, plugin_root=tmp_path / "p", staging_root=tmp_path / "s")
-    assert "--interval" in calls[0] and "5m" in calls[0]
+    # Assert the interval-registration call is AMONG the captured calls — provision
+    # makes several subprocess calls (a git-notes message-store `for-each-ref` can
+    # interleave), so it is not deterministically calls[0] under pytest-randomly.
+    assert any("--interval" in c and "5m" in c for c in calls), f"no interval-registration call in {calls}"
 
 
 def test_dry_run_registers_nothing(tmp_path, monkeypatch):


### PR DESCRIPTION
## What

Fixes the flaky `tests/test_module_provision.py::test_interval_automation_passes_interval` — the root of the recurring **"CI always fails on Python 3.11"** friction.

## Diagnosis

The test asserted the `--interval` subprocess call was `calls[0]`. But `provision_module` makes several `subprocess.run` calls, and a git-notes message-store `git for-each-ref refs/notes/…` can interleave ahead of the interval-registration call — so `calls[0]` was **non-deterministic under `pytest-randomly`**.

It passed on the Gap B *PR* run (good seed) and failed on the *develop* run (bad seed) at `146472520` — same code, different seed — and happened to land on the 3.11 job, reading as a version problem. It's **neither version- nor package-specific** (3.11 is just our declared floor).

## Fix

Assert the interval-registration call is **among** the captured calls (`any(...)`) rather than positionally first. Order-independent by construction — **22 pass across 5 random seeds** (1/42/100/777/2026).

This greens develop (currently red from this flake) and removes the recurring "3.11" noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)