### PR TITLE
feat(daemon-crm): Gap B (b) — membership-transitive scoped artifacts (§5b)

### DIFF
--- a/empirica/api/routes/entities.py
+++ b/empirica/api/routes/entities.py
@@ -184,17 +184,29 @@ async def list_entity_artifacts(
     ),
     limit: int = Query(100, ge=1, le=500),
 ):
-    """Scoped artifacts for a single entity (canonical-model Gap B).
+    """Scoped artifacts for a single entity (canonical-model Gap B, §5b).
 
-    Returns the entity's DIRECT ``entity_artifacts`` pointers, newest first, each
-    carrying ``artifact_type`` + ``artifact_source`` (§5 — so the caller can
-    resolve + render the artifact). Unknown / empty entity → ``artifacts: []``
-    (honest-empty; the board renders 0 rather than the old 404). Membership-
-    transitive scoping (an entity's members' artifacts) is a deferred v2 pending
-    the §5 relation/direction.
+    Returns the entity's DIRECT ``entity_artifacts`` UNION its one-hop MEMBERS'
+    direct artifacts (container→members, fan DOWN, one hop) — each row carrying
+    ``artifact_type`` + ``artifact_source`` and a ``via`` field (``None`` for
+    direct; the member entity_id for transitive). Deduped by
+    (artifact_type, artifact_id), direct winning. The member junction differs by
+    the entity's type: engagement→contacts via engagement_contacts,
+    organization→contacts+engagements via entity_memberships, contact=leaf.
+
+    ``type`` is resolved from the registry when omitted (needed to pick the
+    junction). Unknown / empty entity → ``artifacts: []`` (honest-empty; the
+    board renders 0 rather than the old 404).
     """
     from empirica.data.repositories.workspace_db import WorkspaceDBRepository
 
     with WorkspaceDBRepository.open() as repo:
-        artifacts = repo.get_artifacts_for_entity(entity_id, entity_type=type, limit=limit)
-    return {"ok": True, "entity_id": entity_id, "count": len(artifacts), "artifacts": artifacts}
+        entity_type = type or repo.get_entity_type(entity_id)
+        artifacts = repo.get_scoped_artifacts(entity_id, entity_type, limit=limit)
+    return {
+        "ok": True,
+        "entity_id": entity_id,
+        "entity_type": entity_type,
+        "count": len(artifacts),
+        "artifacts": artifacts,
+    }

--- a/empirica/data/repositories/workspace_db.py
+++ b/empirica/data/repositories/workspace_db.py
@@ -716,6 +716,73 @@ class WorkspaceDBRepository(BaseRepository):
         )
         return [dict(row) for row in cursor.fetchall()]
 
+    def get_entity_type(self, entity_id: str) -> str | None:
+        """Resolve an entity's type from the registry (first match); None if absent.
+        Used to pick the §5b membership-transitive junction for scoped artifacts."""
+        row = self._execute(
+            "SELECT entity_type FROM entity_registry WHERE entity_id = ? LIMIT 1", (entity_id,)
+        ).fetchone()
+        return row["entity_type"] if row else None
+
+    def get_scoped_artifacts(
+        self,
+        entity_id: str,
+        entity_type: str | None,
+        *,
+        limit: int = 100,
+    ) -> list[dict[str, Any]]:
+        """Scoped artifacts for an entity (Gap B, §5b) = its DIRECT entity_artifacts
+        UNION its one-hop MEMBERS' direct artifacts — container→members, fan DOWN
+        only, exactly one hop.
+
+        The member junction differs by the container's type (§5b):
+          - ``engagement`` → its contacts, via ``engagement_contacts`` (left_at IS NULL)
+          - ``organization`` → its contacts + engagements, via ``entity_memberships``
+            (group_type='organization', left_at IS NULL)
+          - ``contact`` / other / unknown → leaf: direct only, no transitive
+
+        Deduped by (artifact_type, artifact_id), DIRECT winning; each transitive row
+        carries ``via`` = the member entity_id it came from (``None`` for direct).
+        Deeper walks (a member's other containers) belong to the workspace
+        graph-walker, not this endpoint.
+        """
+        out: list[dict[str, Any]] = []
+        seen: set[tuple[Any, Any]] = set()
+
+        def _add(rows: list[dict[str, Any]], via: str | None) -> None:
+            for a in rows:
+                key = (a.get("artifact_type"), a.get("artifact_id"))
+                if key in seen:
+                    continue
+                seen.add(key)
+                row = dict(a)
+                row["via"] = via
+                out.append(row)
+
+        # Direct first — wins on dedupe.
+        _add(self.get_artifacts_for_entity(entity_id, entity_type=entity_type, limit=limit), None)
+
+        # One-hop members (fan DOWN by the container's type).
+        members: list[tuple[str, str]] = []
+        if entity_type == "engagement" and self._table_exists("engagement_contacts"):
+            cur = self._execute(
+                "SELECT contact_id FROM engagement_contacts WHERE engagement_id = ? AND left_at IS NULL",
+                (entity_id,),
+            )
+            members = [("contact", r["contact_id"]) for r in cur.fetchall()]
+        elif entity_type == "organization":
+            cur = self._execute(
+                "SELECT entity_type, entity_id FROM entity_memberships "
+                "WHERE group_type = 'organization' AND group_id = ? AND left_at IS NULL",
+                (entity_id,),
+            )
+            members = [(r["entity_type"], r["entity_id"]) for r in cur.fetchall()]
+
+        for m_type, m_id in members:
+            _add(self.get_artifacts_for_entity(m_id, entity_type=m_type, limit=limit), m_id)
+
+        return out
+
     def count_entity_artifacts(self, entity_type: str, entity_id: str) -> int:
         """Count artifact links for an entity (list projection linked_artifact_count).
 

--- a/tests/test_module_provision.py
+++ b/tests/test_module_provision.py
@@ -186,7 +186,10 @@ def test_interval_automation_passes_interval(tmp_path, monkeypatch):
     )
     m = _manifest(tmp_path, automations=[{"name": "poller", "kind": "interval", "interval": "5m"}])
     provision_module(m, dry_run=False, plugin_root=tmp_path / "p", staging_root=tmp_path / "s")
-    assert "--interval" in calls[0] and "5m" in calls[0]
+    # Assert the interval-registration call is AMONG the captured calls — provision
+    # makes several subprocess calls (a git-notes message-store `for-each-ref` can
+    # interleave), so it is not deterministically calls[0] under pytest-randomly.
+    assert any("--interval" in c and "5m" in c for c in calls), f"no interval-registration call in {calls}"
 
 
 def test_dry_run_registers_nothing(tmp_path, monkeypatch):

--- a/tests/test_workspace_crm_projection.py
+++ b/tests/test_workspace_crm_projection.py
@@ -186,6 +186,41 @@ def test_get_artifacts_for_entity_direct():
     assert repo.get_artifacts_for_entity("no-such-entity") == []
 
 
+def test_get_scoped_artifacts_transitive_fan_down():
+    """§5b: scoped artifacts = direct ∪ one-hop members' direct, fan DOWN.
+    engagement→contacts via engagement_contacts (left_at IS NULL); dedupe by
+    (type,id) with direct winning; transitive rows tagged via <member>; contact
+    is a leaf."""
+    from empirica.data.repositories.workspace_db import _ensure_workspace_schema
+
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    _ensure_workspace_schema(conn)
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS engagement_contacts (
+               engagement_id TEXT, contact_id TEXT, role TEXT, joined_at REAL, left_at REAL,
+               contribution_notes TEXT, PRIMARY KEY (engagement_id, contact_id))"""
+    )
+    repo = WorkspaceDBRepository(conn)
+    repo.add_entity_artifact("src-eng", "source", "/p", "engagement", "eng-1")  # direct on engagement
+    conn.execute("INSERT INTO engagement_contacts VALUES ('eng-1','c-a','participant',1,NULL,NULL)")
+    conn.execute("INSERT INTO engagement_contacts VALUES ('eng-1','c-left','participant',1,2,NULL)")  # left
+    repo.add_entity_artifact("src-a", "source", "/p", "contact", "c-a")  # active member's artifact
+    repo.add_entity_artifact("src-left", "finding", "/p", "contact", "c-left")  # left member's artifact
+    conn.commit()
+
+    scoped = repo.get_scoped_artifacts("eng-1", "engagement")
+    tagged = {a["artifact_id"]: a["via"] for a in scoped}
+    assert tagged["src-eng"] is None  # direct
+    assert tagged["src-a"] == "c-a"  # transitive, via the active member
+    assert "src-left" not in tagged  # left contact (left_at set) excluded
+
+    # contact is a leaf — no transitive fan-down
+    assert all(a["via"] is None for a in repo.get_scoped_artifacts("c-a", "contact"))
+    # unknown type → leaf (direct only), never raises
+    assert repo.get_scoped_artifacts("nope", None) == []
+
+
 # ── practitioner entity (B4 foundation) ───────────────────────────────────────
 
 


### PR DESCRIPTION
## What

Extends `GET /api/v1/entities/{id}/artifacts` from **direct-only** to **direct ∪ one-hop members' direct** (container→members, fan DOWN, exactly one hop) — completing Gap B per empirica-workspace's **§5b** spec.

The member junction differs by the container's type:
| Container | Members via | Notes |
|-----------|-------------|-------|
| **engagement** | `engagement_contacts` (`left_at IS NULL`) | contact↔engagement lives here, **not** `entity_memberships` — the ambiguity §5b resolved |
| **organization** | `entity_memberships` (`group_type='organization'`, `left_at IS NULL`) | member's `entity_type` distinguishes contact vs engagement |
| **contact** / other / unknown | — | leaf, direct only |

- **Dedupe** by `(artifact_type, artifact_id)`, direct winning.
- Each row carries **`via`** = the member entity_id it came from (`None` for direct).
- Route resolves `entity_type` from the registry when `?type=` is omitted (needed to pick the junction) and returns it.
- Fan **down only**, exactly **one hop** (deeper walks belong to the workspace graph-walker); `engagement_contacts` guarded by `_table_exists`.

## Verified
Live: Francisco's engagement resolves to `engagement` + fans to its contacts (0 transitive artifacts today — no contact-level edges yet, which is correct). Test covers the case where members *do* carry artifacts (via-tagged), left-member exclusion, contact-leaf, and unknown-type.

11 pass; ruff + format + pyright clean.

Closes the Gap B ask (direct shipped in #226; this is (b)). Specced by empirica-workspace §5b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)