### PR TITLE
fix(daemon): serve calibration config from the FastAPI daemon (was Flask-only → 404)

### DIFF
--- a/empirica/api/app.py
+++ b/empirica/api/app.py
@@ -71,13 +71,16 @@ def create_app() -> Flask:
 
     # Register blueprints
     from .auth import APIKeyMiddleware
-    from .routes import calibration, comparison, deltas, heatmaps, project, sessions, verification
+    from .routes import comparison, deltas, heatmaps, project, sessions, verification
 
     # Apply API key authentication middleware
     app.wsgi_app = APIKeyMiddleware(app.wsgi_app, prefix="/api/v1")  # type: ignore[method-assign]
 
     app.register_blueprint(sessions.bp, url_prefix="/api/v1")
-    app.register_blueprint(calibration.bp, url_prefix="/api/v1")
+    # NOTE: calibration is deliberately NOT registered here — it moved to a
+    # FastAPI router in serve_app.py (the app `empirica serve` actually runs).
+    # Registering it on this Flask app left it unserved by the daemon (404 on
+    # GET /api/v1/calibration/config — the extension's "Sentinel Config" tab).
     app.register_blueprint(deltas.bp, url_prefix="/api/v1")
     app.register_blueprint(verification.bp, url_prefix="/api/v1")
     app.register_blueprint(heatmaps.bp, url_prefix="/api/v1")

--- a/empirica/api/routes/calibration.py
+++ b/empirica/api/routes/calibration.py
@@ -9,24 +9,28 @@ the field schema, preset names, and the raw per-scope override blocks so the UI
 can show what's set where. PATCH validates a sparse body ({weights?, thresholds?,
 preset?}; a null value resets a key) and writes it to the requested scope's
 ``.empirica/calibration.yaml``.
+
+This is a **FastAPI router** mounted in ``serve_app.py`` — the app ``empirica
+serve`` actually runs — mirroring entities.py / engagements.py (APIRouter
+prefix=/api/v1, ``verify_mint_bearer`` dep). It previously lived as a Flask
+blueprint in the separate ``api/app.py``, which the daemon does NOT run, so
+``GET /api/v1/calibration/config`` 404'd on the running daemon (the extension's
+Sentinel Config tab showed "config API pending").
 """
 
+from __future__ import annotations
+
 import logging
-import os
 from pathlib import Path
+from typing import Any
 
-from flask import Blueprint, jsonify, request
+from fastapi import APIRouter, Body, Depends, HTTPException, Query
 
+from empirica.api.entity_mint_auth import verify_mint_bearer
 from empirica.core import calibration_config as cc
 
-bp = Blueprint("calibration", __name__)
+router = APIRouter(prefix="/api/v1", tags=["calibration"], dependencies=[Depends(verify_mint_bearer)])
 logger = logging.getLogger(__name__)
-
-_DEBUG_MODE = os.environ.get("FLASK_DEBUG", "false").lower() == "true"
-
-
-def _safe_error(error: Exception) -> str:
-    return str(error) if _DEBUG_MODE else "An internal error occurred"
 
 
 def _global_dir() -> Path:
@@ -53,11 +57,11 @@ def _resolve_practice_dir(practice_id: str) -> Path | None:
     return None
 
 
-def _effective(practice_id: str | None) -> dict:
+def _effective(practice_id: str | None) -> dict[str, Any]:
     """Resolve the effective config: global override always applies; practice
     override layers on top when the practice_id resolves."""
     global_ov = cc.read_override(_global_dir())
-    practice_ov: dict = {}
+    practice_ov: dict[str, Any] = {}
     if practice_id:
         d = _resolve_practice_dir(practice_id)
         if d is not None:
@@ -69,45 +73,43 @@ def _effective(practice_id: str | None) -> dict:
     return resolved
 
 
-@bp.route("/calibration/config", methods=["GET"])
-def get_config():
+@router.get("/calibration/config")
+async def get_config(practice_id: str | None = Query(None)):
     """Effective calibration config for a practice (or global-only if no id)."""
     try:
-        practice_id = request.args.get("practice_id")
-        return jsonify({"ok": True, **_effective(practice_id)})
+        return {"ok": True, **_effective(practice_id)}
     except Exception as e:
         logger.error(f"calibration GET failed: {e}", exc_info=True)
-        return jsonify({"ok": False, "error": _safe_error(e)}), 500
+        raise HTTPException(status_code=500, detail="calibration read failed") from e
 
 
-@bp.route("/calibration/config", methods=["PATCH"])
-def patch_config():
+@router.patch("/calibration/config")
+async def patch_config(
+    body: dict[str, Any] | None = Body(default=None),
+    scope: str = Query("practice"),
+    practice_id: str | None = Query(None),
+):
     """Write a sparse override to a scope's .empirica/calibration.yaml."""
+    if scope == "global":
+        scope_dir: Path | None = _global_dir()
+    elif scope == "practice":
+        if not practice_id:
+            raise HTTPException(status_code=400, detail="practice scope requires practice_id")
+        scope_dir = _resolve_practice_dir(practice_id)
+        if scope_dir is None:
+            raise HTTPException(status_code=404, detail=f"unknown practice_id: {practice_id}")
+    else:
+        raise HTTPException(status_code=400, detail=f"invalid scope: {scope!r} (global|practice)")
+
+    # FastAPI already coerces/validates the body to a dict (422 otherwise); a
+    # missing body is tolerated as an empty patch.
+    clean, errors = cc.validate_patch(body or {})
+    if errors:
+        raise HTTPException(status_code=422, detail={"error": "validation failed", "details": errors})
+
     try:
-        scope = request.args.get("scope", "practice")
-        practice_id = request.args.get("practice_id")
-
-        if scope == "global":
-            scope_dir: Path | None = _global_dir()
-        elif scope == "practice":
-            if not practice_id:
-                return jsonify({"ok": False, "error": "practice scope requires practice_id"}), 400
-            scope_dir = _resolve_practice_dir(practice_id)
-            if scope_dir is None:
-                return jsonify({"ok": False, "error": f"unknown practice_id: {practice_id}"}), 404
-        else:
-            return jsonify({"ok": False, "error": f"invalid scope: {scope!r} (global|practice)"}), 400
-
-        body = request.get_json(silent=True) or {}
-        if not isinstance(body, dict):
-            return jsonify({"ok": False, "error": "body must be a JSON object"}), 400
-
-        clean, errors = cc.validate_patch(body)
-        if errors:
-            return jsonify({"ok": False, "error": "validation failed", "details": errors}), 422
-
         cc.apply_patch(scope_dir, clean)
-        return jsonify({"ok": True, "scope": scope, **_effective(practice_id if scope == "practice" else None)})
     except Exception as e:
         logger.error(f"calibration PATCH failed: {e}", exc_info=True)
-        return jsonify({"ok": False, "error": _safe_error(e)}), 500
+        raise HTTPException(status_code=500, detail="calibration write failed") from e
+    return {"ok": True, "scope": scope, **_effective(practice_id if scope == "practice" else None)}

--- a/empirica/api/serve_app.py
+++ b/empirica/api/serve_app.py
@@ -229,6 +229,13 @@ def create_serve_app() -> FastAPI:
 
     app.include_router(engagements_router)
 
+    # Calibration config (settable epistemic weights + Sentinel thresholds) — the
+    # extension's "Sentinel Tuning" tab. FastAPI router (previously a Flask
+    # blueprint in api/app.py, which the daemon doesn't run → 404).
+    from empirica.api.routes.calibration import router as calibration_router
+
+    app.include_router(calibration_router)
+
     @app.get("/api/v1/health", response_model=HealthResponse)
     async def health():  # pyright: ignore[reportUnusedFunction]
         """Health check — reports integrations, active project info, and

--- a/tests/test_calibration_route.py
+++ b/tests/test_calibration_route.py
@@ -1,20 +1,24 @@
 """Route tests for GET/PATCH /api/v1/calibration/config.
 
-Registers just the calibration blueprint on a bare Flask app (bypassing the
-daemon's auth middleware + DB), and monkeypatches the scope dirs to tmp so no
-real ~/.empirica or project files are touched.
+Mounts just the calibration FastAPI router on a bare app (bypassing the daemon's
+other routes + DB), and monkeypatches the scope dirs to tmp so no real
+~/.empirica or project files are touched. The route moved from a Flask blueprint
+(api/app.py, which the daemon doesn't run → 404) to a FastAPI router in
+serve_app.py; these tests track that.
 """
 
 from __future__ import annotations
 
 import pytest
-from flask import Flask
 
 from empirica.api.routes import calibration
 
 
 @pytest.fixture()
 def client(tmp_path, monkeypatch):
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
     global_dir = tmp_path / "global"
     practice_dir = tmp_path / "practice-A"
     global_dir.mkdir()
@@ -27,15 +31,15 @@ def client(tmp_path, monkeypatch):
         lambda pid: practice_dir if pid == "practice-A" else None,
     )
 
-    app = Flask(__name__)
-    app.register_blueprint(calibration.bp, url_prefix="/api/v1")
-    return app.test_client()
+    app = FastAPI()
+    app.include_router(calibration.router)
+    return TestClient(app)
 
 
 def test_get_returns_schema_presets_and_defaults(client):
     resp = client.get("/api/v1/calibration/config")
     assert resp.status_code == 200
-    body = resp.get_json()
+    body = resp.json()
     assert body["ok"] is True
     assert body["weights"]["foundation"] == 0.35
     assert body["thresholds"]["engagement_gate"] == 0.60
@@ -47,11 +51,11 @@ def test_get_returns_schema_presets_and_defaults(client):
 def test_patch_global_persists_and_reflects(client):
     resp = client.patch("/api/v1/calibration/config?scope=global", json={"thresholds": {"engagement_gate": 0.7}})
     assert resp.status_code == 200
-    body = resp.get_json()
+    body = resp.json()
     assert body["ok"] is True
     assert body["thresholds"]["engagement_gate"] == 0.7
     # a fresh GET sees the persisted global override
-    body2 = client.get("/api/v1/calibration/config").get_json()
+    body2 = client.get("/api/v1/calibration/config").json()
     assert body2["thresholds"]["engagement_gate"] == 0.7
     assert "thresholds.engagement_gate" in body2["overridden"]
 
@@ -62,7 +66,7 @@ def test_patch_practice_layers_over_global(client):
         "/api/v1/calibration/config?scope=practice&practice_id=practice-A",
         json={"thresholds": {"engagement_gate": 0.9}},
     )
-    body = client.get("/api/v1/calibration/config?practice_id=practice-A").get_json()
+    body = client.get("/api/v1/calibration/config?practice_id=practice-A").json()
     assert body["thresholds"]["engagement_gate"] == 0.9  # practice wins
     assert body["sources"]["thresholds.engagement_gate"] == "practice"
 
@@ -70,7 +74,8 @@ def test_patch_practice_layers_over_global(client):
 def test_patch_invalid_key_is_422(client):
     resp = client.patch("/api/v1/calibration/config?scope=global", json={"thresholds": {"bogus": 0.5}})
     assert resp.status_code == 422
-    assert "details" in resp.get_json()
+    # FastAPI nests the HTTPException detail; the validation errors ride under it.
+    assert "details" in resp.json()["detail"]
 
 
 def test_patch_practice_without_id_is_400(client):
@@ -89,6 +94,6 @@ def test_patch_unknown_practice_is_404(client):
 def test_patch_reset_key_restores_default(client):
     client.patch("/api/v1/calibration/config?scope=global", json={"thresholds": {"engagement_gate": 0.7}})
     client.patch("/api/v1/calibration/config?scope=global", json={"thresholds": {"engagement_gate": None}})
-    body = client.get("/api/v1/calibration/config").get_json()
+    body = client.get("/api/v1/calibration/config").json()
     assert body["thresholds"]["engagement_gate"] == 0.60  # back to default
     assert body["overridden"] == []


### PR DESCRIPTION
## Bug (diagnosed by extension)

The Sentinel Config tab showed "config API pending" because `GET /api/v1/calibration/config` **404'd on the running daemon** — and a restart wouldn't fix it.

Root cause: the calibration route (#214) was a **Flask blueprint** registered in `api/app.py` — a separate app the daemon does **not** run. `empirica serve` runs the **FastAPI `serve_app.py`**, where the working CRM routes (entities/engagements/tasks) live. So the route was in the wrong app.

## Fix

Port calibration to a **FastAPI router** (`APIRouter(prefix=/api/v1)` + `verify_mint_bearer` dep, mirroring `entities.py`/`engagements.py`) mounted in `serve_app.py`, reading/writing the same `.empirica/calibration.yaml` + resolver — **GET/PATCH logic and success shape unchanged**. Dropped the now-dead Flask blueprint registration from `api/app.py`. Errors use FastAPI `HTTPException` (status codes preserved; body nests under `detail`).

## Verified
`GET /api/v1/calibration/config` → **200** on `create_serve_app()` (was 404); `schema` + `overrides` present. The Sentinel **enforcement** wiring (#216) is separate + untouched — this was purely the READ/WRITE API landing in the telemetry Flask app instead of the daemon FastAPI serve_app.

7 route tests ported Flask→FastAPI; ruff + format + pyright clean.

## Follow-up
Redeploy the daemon after merge → the extension's Sentinel Config tab lights up with zero extension change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)