### PR TITLE
fix(daemon-crm): pass the whole metadata bag through projections (was a per-key allowlist)

### DIFF
--- a/empirica/api/routes/engagements.py
+++ b/empirica/api/routes/engagements.py
@@ -97,15 +97,12 @@ async def list_engagements(
                     "member_count": proj["member_count"],
                     "goal_count": proj["goal_count"],
                     "linked_artifact_count": proj["linked_artifact_count"],
-                    "metadata": {
-                        "org_display": proj["org_display"],
-                        "severity": proj["severity"],
-                        "assignee_id": proj["assignee_id"],
-                        "assignee_display": proj["assignee_display"],
-                        # routing/blocker block for the board's engagement detail
-                        # (kind, feedback_required_from, decision_owner, unblock_channel, fork)
-                        "ticket": proj["ticket"],
-                    },
+                    # Pass the WHOLE entity_registry.metadata bag through (severity,
+                    # assignee, tickets[], identifier, tenant, machine_state, …) — no
+                    # per-key allowlist — with the synthesized org_display layered on
+                    # top (derived from the ticket_of edge, not stored in metadata;
+                    # wins on any key collision).
+                    "metadata": {**proj["metadata"], "org_display": proj["org_display"]},
                 }
             )
     return {"ok": True, "count": len(out), "engagements": out}

--- a/empirica/api/routes/entities.py
+++ b/empirica/api/routes/entities.py
@@ -172,6 +172,11 @@ async def list_entities(
                 # reporting_to_name resolves the reports_to edge → manager's name.
                 entry["tier"] = meta.get("tier")
                 entry["reporting_to_name"] = contact_reports_to.get(eid)
+                # Pass the WHOLE registry metadata bag through too (parallel to the
+                # engagement projection) so every key workspace writes reaches the
+                # extension — no per-key allowlist. The curated flat fields above
+                # stay for existing bindings; new keys ride under `metadata`.
+                entry["metadata"] = meta
             out.append(entry)
     return {"ok": True, "count": len(out), "entities": out}
 

--- a/empirica/data/repositories/workspace_db.py
+++ b/empirica/data/repositories/workspace_db.py
@@ -1569,14 +1569,14 @@ class WorkspaceDBRepository(BaseRepository):
             "goal_count": goal_count,
             "linked_artifact_count": linked_artifact_count,
             "org_display": org_display,
-            "severity": meta.get("severity"),
-            "assignee_id": meta.get("assignee_id"),
-            "assignee_display": meta.get("assignee_display"),
-            # ticket: the routing/blocker block (kind, text, feedback_required_from,
-            # decision_owner, unblock_channel, fork) passed through from the registry
-            # metadata for the board's engagement detail. Render-only v1 — None when
-            # absent; promote to a spine column only if it needs to be queryable.
-            "ticket": meta.get("ticket"),
+            # The WHOLE entity_registry.metadata bag — severity / assignee /
+            # tickets[] / identifier / tenant / machine_state / … — NOT a per-key
+            # allowlist, so every key workspace writes reaches the extension with
+            # zero per-key core changes. (The old allowlist regressed on the
+            # ticket→tickets[] migration: it projected the dropped singular
+            # `ticket` as null.) `org_display` is synthesized from the ticket_of
+            # edge (not stored in metadata) and layered on at the route.
+            "metadata": meta,
         }
 
     def update_engagement(

--- a/tests/test_engagements_endpoint.py
+++ b/tests/test_engagements_endpoint.py
@@ -67,8 +67,7 @@ def test_projection_zero_when_bare(repo):
     assert p["goal_count"] == 0
     assert p["linked_artifact_count"] == 0
     assert p["org_display"] is None
-    assert p["severity"] is None
-    assert p["assignee_id"] is None
+    assert p["metadata"] == {}  # no registry row → empty metadata bag
 
 
 def test_projection_counts(repo):
@@ -112,14 +111,14 @@ def test_projection_severity_assignee_passthrough(repo):
         metadata={"severity": "high", "assignee_id": "u-7", "assignee_display": "Sam"},
     )
     p = repo.get_engagement_projection("e1")
-    assert p["severity"] == "high"
-    assert p["assignee_id"] == "u-7"
-    assert p["assignee_display"] == "Sam"
+    assert p["metadata"]["severity"] == "high"
+    assert p["metadata"]["assignee_id"] == "u-7"
+    assert p["metadata"]["assignee_display"] == "Sam"
 
 
 def test_projection_ticket_passthrough(repo):
-    """The routing/blocker `ticket` block projects through from registry metadata
-    (render-only v1 for the board's engagement detail)."""
+    """The routing/blocker `ticket` block projects through inside the metadata bag
+    (render-only for the board's engagement detail)."""
     ticket = {
         "kind": "blocker",
         "feedback_required_from": "client",
@@ -129,13 +128,24 @@ def test_projection_ticket_passthrough(repo):
     }
     repo.create_engagement("e1", "Ticket", domain="support", stage="support.new")
     _registry(repo, "engagement", "e1", "Ticket", metadata={"ticket": ticket})
-    assert repo.get_engagement_projection("e1")["ticket"] == ticket
+    assert repo.get_engagement_projection("e1")["metadata"]["ticket"] == ticket
 
 
-def test_projection_ticket_none_when_absent(repo):
+def test_projection_passes_whole_metadata_bag(repo):
+    """The projection passes the WHOLE registry metadata bag — not a per-key
+    allowlist — so new keys (identifier / tenant / tickets[] / machine_state)
+    reach the caller with zero core change (the ticket→tickets[] migration is
+    what the old allowlist regressed on)."""
     repo.create_engagement("e1", "Ticket", domain="support", stage="support.new")
-    _registry(repo, "engagement", "e1", "Ticket", metadata={"severity": "high"})
-    assert repo.get_engagement_projection("e1")["ticket"] is None
+    meta = {
+        "severity": "high",
+        "identifier": "nle-onboarding-05",
+        "tenant": "nle",
+        "tickets": [{"kind": "blocker", "decision_owner": "Georg"}],
+        "machine_state": "green",
+    }
+    _registry(repo, "engagement", "e1", "Ticket", metadata=meta)
+    assert repo.get_engagement_projection("e1")["metadata"] == meta  # every key passes through
 
 
 def test_projection_tolerates_garbage_metadata(repo):
@@ -146,9 +156,8 @@ def test_projection_tolerates_garbage_metadata(repo):
            VALUES ('engagement', 'e1', 'Ticket', 'test', 'test', ?, '{not json')""",
         (time.time(),),
     )
-    # must not raise — severity/assignee just resolve to None
-    p = repo.get_engagement_projection("e1")
-    assert p["severity"] is None
+    # must not raise — garbage metadata resolves to an empty bag
+    assert repo.get_engagement_projection("e1")["metadata"] == {}
 
 
 # ── route smoke (TestClient + temp workspace.db) ─────────────────────────────
@@ -266,8 +275,8 @@ def test_create_sets_ticket_of_and_metadata(client):
     assert e["metadata"]["org_display"] == "Acme Corp"  # ticket_of resolved
     assert e["metadata"]["severity"] == "critical"
     assert e["metadata"]["assignee_display"] == "Sam"
-    # org_display must NOT be stored in the raw metadata bag (read-synthesized only)
-    assert e["metadata"]["assignee_id"] is None
+    # assignee_id was not set → simply absent from the passed-through bag
+    assert e["metadata"].get("assignee_id") is None
 
 
 def test_create_invalid_domain_422(client):


### PR DESCRIPTION
## What / why (extension-verified, mesh-endorsed)

The engagement metadata projection was a **hardcoded allowlist** `{severity, assignee_id, assignee_display, ticket}` + synthesized `org_display`. So the newer keys workspace writes — `identifier`, `tenant`, `tickets[]`, `machine_state` — **never reached the extension**. And workspace migrated `ticket`→`tickets[]`, so the old singular `ticket` key now projects **null** — a **regression** that emptied the board's blocker chips. This was the real bottleneck behind the active view.

## Fix

Pass the **whole `entity_registry.metadata` bag** through — no per-key allowlist:
- `get_engagement_projection` returns the full `meta` bag; the route spreads it and layers the synthesized `org_display` on top (derived from the `ticket_of` edge, not stored in metadata; wins on collision).
- The **contact** projection gets the same — a `metadata` sub-object with the whole registry bag alongside the existing flat curated fields (email/phone/tier/…), so existing bindings are unbroken and new keys ride under `metadata`.

Every key workspace writes now reaches the extension with **zero per-key core changes forever** — mesh-endorsed as the canonical metadata-extension model.

## Tests
Whole-bag pass-through (incl. `tickets[]`/`identifier`/`tenant`/`machine_state`), garbage metadata → `{}`, route metadata carries `org_display` + the bag, bare engagement → empty bag. 47 pass; ruff + format + pyright clean.

## Follow-up
Redeploy the daemon after merge → the extension's blocker chips + identifier/tenant/machine_state light up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)