### PR TITLE
feat(post_test): B5 — per-practitioner Brier reliability surface

### DIFF
--- a/empirica/core/post_test/dynamic_thresholds.py
+++ b/empirica/core/post_test/dynamic_thresholds.py
@@ -399,11 +399,18 @@ def get_brier_profile(
     ai_id: str,
     db,
     lookback: int = 50,
+    session_id: str | None = None,
 ) -> dict:
     """Get Brier score profile for an AI across phases.
 
     Useful for calibration-report and epistemic profiles.
     Returns decomposition per phase with trend information.
+
+    ``session_id`` scopes to a single PRACTITIONER (claude session) rather than
+    the practice aggregate (B5): every trajectory point already carries
+    ``session_id``, so passing it filters the same decomposition to one
+    practitioner's own calibration track. Default ``None`` = the practice
+    aggregate (``WHERE ai_id = ?``), unchanged for existing callers.
     """
     try:
         cursor = db.conn.cursor()
@@ -411,13 +418,16 @@ def get_brier_profile(
 
         for phase in ["noetic", "praxic", "combined"]:
             phase_filter = "AND phase = ?" if phase != "combined" else ""
-            params = [ai_id] + ([phase] if phase != "combined" else []) + [lookback]
+            session_filter = "AND session_id = ?" if session_id else ""
+            params = (
+                [ai_id] + ([phase] if phase != "combined" else []) + ([session_id] if session_id else []) + [lookback]
+            )
 
             cursor.execute(
                 f"""
                 SELECT self_assessed, grounded
                 FROM calibration_trajectory
-                WHERE ai_id = ? {phase_filter} AND grounded IS NOT NULL
+                WHERE ai_id = ? {phase_filter} {session_filter} AND grounded IS NOT NULL
                 ORDER BY timestamp DESC
                 LIMIT ?
             """,
@@ -460,6 +470,74 @@ def get_brier_profile(
     except Exception as e:
         logger.debug(f"Brier profile computation failed: {e}")
         return {}
+
+
+def get_practitioner_brier_profile(
+    session_id: str,
+    ai_id: str,
+    db,
+    lookback: int = 50,
+) -> dict:
+    """Per-PRACTITIONER Brier profile (EPIC B / B5) — the session-keyed
+    reliability track that's already latent in ``calibration_trajectory``.
+
+    Same phase decomposition as :func:`get_brier_profile`, scoped to one
+    practitioner (claude session) via the ``session_id`` every trajectory point
+    already carries — so a practitioner's OWN calibration surfaces rather than
+    being rolled up to the practice aggregate. This is the RAW surface; the
+    credibility-weighted fold (Bühlmann shrinkage on thin ``n``) is autonomy's
+    lane, applied at arbitration time (PRACTITIONER_DELIBERATION_MODEL §3).
+    """
+    return get_brier_profile(ai_id, db, lookback=lookback, session_id=session_id)
+
+
+def compute_practitioner_divergence(
+    session_id: str,
+    ai_id: str,
+    db,
+    lookback: int = 50,
+) -> dict:
+    """Per-phase practitioner-vs-practice reliability divergence (EPIC B / B5).
+
+    Returns, per phase, the RAW divergence between a practitioner's own Brier
+    track and the practice aggregate::
+
+        {phase: {brier_delta, reliability_delta, practitioner_brier,
+                 practice_brier, practitioner_n, practice_n}}
+
+    ``brier_delta`` = practitioner − practice (NEGATIVE = better-calibrated than
+    the practice; POSITIVE = worse). A phase with too few grounded points on
+    either side returns ``{"status": "insufficient_data", ...}``.
+
+    This is the raw signal only. The credibility-weighted fold — shrink a
+    thin-``n`` practitioner's divergence toward the practice prior (Bühlmann
+    ``w = n/(n+k)``, hard floor at ``n < n_min``, asymmetric on
+    better-than-practice claims) — is autonomy's lane, applied when the
+    divergence feeds arbitration (PRACTITIONER_DELIBERATION_MODEL §3/§6). The
+    seam is deliberate: empirica-core surfaces, autonomy weights.
+    """
+    practitioner = get_practitioner_brier_profile(session_id, ai_id, db, lookback=lookback)
+    practice = get_brier_profile(ai_id, db, lookback=lookback)
+    out: dict = {}
+    for phase in ("noetic", "praxic", "combined"):
+        p = practitioner.get(phase, {})
+        a = practice.get(phase, {})
+        if "brier_score" not in p or "brier_score" not in a:
+            out[phase] = {
+                "status": "insufficient_data",
+                "practitioner_n": p.get("n_predictions", p.get("n", 0)),
+                "practice_n": a.get("n_predictions", a.get("n", 0)),
+            }
+            continue
+        out[phase] = {
+            "brier_delta": round(p["brier_score"] - a["brier_score"], 4),
+            "reliability_delta": round(p["reliability"] - a["reliability"], 4),
+            "practitioner_brier": p["brier_score"],
+            "practice_brier": a["brier_score"],
+            "practitioner_n": p["n_predictions"],
+            "practice_n": a["n_predictions"],
+        }
+    return out
 
 
 def _find_brier_section(lines: list[str]) -> tuple[int, int]:

--- a/tests/core/post_test/test_practitioner_brier.py
+++ b/tests/core/post_test/test_practitioner_brier.py
@@ -1,0 +1,80 @@
+"""EPIC B / B5 — per-practitioner Brier profile + practice-vs-practitioner divergence.
+
+The raw per-practitioner reliability surface (session-keyed Brier), latent in the
+already-instrumented ``calibration_trajectory`` table. Seeds the table directly
+(``record_trajectory_point`` needs a full GroundedAssessment + sessions row) so
+the query/aggregation is pinned. Credibility shrinkage stays autonomy's lane.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from types import SimpleNamespace
+
+from empirica.core.post_test.dynamic_thresholds import (
+    compute_practitioner_divergence,
+    get_brier_profile,
+    get_practitioner_brier_profile,
+)
+
+
+def _db_with_trajectory(rows):
+    """rows: (session_id, ai_id, phase, self_assessed, grounded, ts)."""
+    conn = sqlite3.connect(":memory:")
+    conn.execute(
+        """CREATE TABLE calibration_trajectory (
+               session_id TEXT, ai_id TEXT, vector_name TEXT, phase TEXT,
+               self_assessed REAL, grounded REAL, gap REAL, timestamp REAL)"""
+    )
+    for sid, ai, phase, sa, gr, ts in rows:
+        conn.execute(
+            "INSERT INTO calibration_trajectory "
+            "(session_id, ai_id, vector_name, phase, self_assessed, grounded, timestamp) "
+            "VALUES (?, ?, 'know', ?, ?, ?, ?)",
+            (sid, ai, phase, sa, gr, ts),
+        )
+    conn.commit()
+    return SimpleNamespace(conn=conn)
+
+
+# A well-calibrated practitioner (self ≈ grounded) vs an overconfident one (self ≫ grounded).
+_A = [(0.7, 0.7), (0.8, 0.8), (0.9, 0.85), (0.6, 0.65), (0.75, 0.75), (0.85, 0.8)]
+_B = [(0.9, 0.4), (0.85, 0.3), (0.95, 0.5), (0.8, 0.35), (0.9, 0.45), (0.88, 0.4)]
+
+
+def _rows():
+    rows = [("sess-A", "empirica", "combined", sa, gr, i) for i, (sa, gr) in enumerate(_A)]
+    rows += [("sess-B", "empirica", "combined", sa, gr, 100 + i) for i, (sa, gr) in enumerate(_B)]
+    return rows
+
+
+def test_practitioner_brier_scoped_to_session():
+    db = _db_with_trajectory(_rows())
+    pa = get_practitioner_brier_profile("sess-A", "empirica", db)
+    pb = get_practitioner_brier_profile("sess-B", "empirica", db)
+    practice = get_brier_profile("empirica", db)  # all 12 rows, both sessions
+
+    # the well-calibrated practitioner has a lower (better) Brier than the overconfident one
+    assert pa["combined"]["brier_score"] < pb["combined"]["brier_score"]
+    # each practitioner profile is scoped to its own session; the practice sees both
+    assert pa["combined"]["n_predictions"] == len(_A)
+    assert pb["combined"]["n_predictions"] == len(_B)
+    assert practice["combined"]["n_predictions"] == len(_A) + len(_B)
+
+
+def test_practitioner_divergence_signals_direction():
+    db = _db_with_trajectory(_rows())
+    # A (well-calibrated) vs the mixed practice aggregate → better-than-practice (negative delta)
+    da = compute_practitioner_divergence("sess-A", "empirica", db)["combined"]
+    assert da["practitioner_n"] == len(_A) and da["practice_n"] == len(_A) + len(_B)
+    assert da["brier_delta"] <= 0  # A is better-calibrated than the practice
+    # B (overconfident) vs the practice → worse-than-practice (positive delta)
+    db_ = compute_practitioner_divergence("sess-B", "empirica", db)["combined"]
+    assert db_["brier_delta"] >= 0
+
+
+def test_divergence_insufficient_data():
+    db = _db_with_trajectory([("sess-thin", "empirica", "combined", 0.8, 0.8, 0)])  # 1 point
+    d = compute_practitioner_divergence("sess-thin", "empirica", db)["combined"]
+    assert d["status"] == "insufficient_data"
+    assert d["practitioner_n"] == 1


### PR DESCRIPTION
## EPIC B / B5 — practitioner reliability surfacing

The third leg of practitioner presence (B2 identity, B3 identity/location split, B4 practitioner entity → **B5 reliability**). Surfaces the **session-keyed reliability track** that's already latent in `calibration_trajectory` — every point carries `session_id`, but the Brier decomposition was only ever computed at the practice aggregate (`WHERE ai_id = ?`). B5 lets the *same* decomposition scope to one practitioner.

### What changed (`empirica/core/post_test/dynamic_thresholds.py`)

- **`get_brier_profile`** gains an optional `session_id` param. Default `None` = practice aggregate — **unchanged for every existing caller**. When set, adds `AND session_id = ?` to the trajectory query.
- **`get_practitioner_brier_profile(session_id, ai_id, db)`** — thin wrapper for the per-practitioner raw surface.
- **`compute_practitioner_divergence(session_id, ai_id, db)`** — per-phase practitioner-vs-practice divergence: `brier_delta = practitioner − practice` (negative = the practitioner is better-calibrated than its practice), `reliability_delta`, and both `n`s. Returns `status: insufficient_data` when either side is thin.

### The seam (deliberate)

This surfaces the **raw** signal only. The credibility-weighted fold — shrink a thin-`n` practitioner's divergence toward the practice prior (Bühlmann `w = n/(n+k)`, hard floor at `n < n_min`, asymmetric on better-than-practice claims) — is **autonomy's lane**, applied when the divergence feeds arbitration. empirica-core surfaces; autonomy weights. No schema change; query-only.

### Tests

`tests/core/post_test/test_practitioner_brier.py` — 3 tests seeding `calibration_trajectory` directly:
- session-scoped `n` + well-calibrated < overconfident Brier ordering
- divergence direction (well-calibrated → negative delta, overconfident → positive)
- insufficient-data guard

Gate: 3/3 pass · `ruff check` clean · `ruff format` clean · `pyright` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)