### PR TITLE
feat(erm): B6 — deliberation record (contributes_to edge)

### DIFF
--- a/empirica/data/repositories/workspace_db.py
+++ b/empirica/data/repositories/workspace_db.py
@@ -1290,6 +1290,99 @@ class WorkspaceDBRepository(BaseRepository):
             )
         return [dict(row) for row in cursor.fetchall()]
 
+    def record_deliberation_read(
+        self,
+        claude_session_id: str,
+        engagement_id: str,
+        *,
+        read_summary: str | None = None,
+        role: str = "contributes_to",
+    ) -> None:
+        """Record a practitioner's attributed read on an engagement (B6).
+
+        A *deliberation* is the set of practitioner reads on one engagement
+        (PRACTITIONER_DELIBERATION_MODEL §4). Each read is a ``contributes_to``
+        edge (practitioner → engagement) in ``entity_memberships`` — exactly
+        parallel to B4's ``occupies`` (practitioner → practice), so it inherits
+        the same idempotency + soft-close semantics: re-recording the same
+        practitioner's read on the same engagement UPDATES the summary (latest
+        position wins) rather than duplicating, and the edge is soft-closed
+        (``left_at``) not deleted, keeping the deliberation history auditable.
+
+        ``read_summary`` is the practitioner's contribution/position, stored in
+        the edge ``notes``. The read's RELIABILITY vector is NOT stored here — it
+        is computed at query/arbitration time from the practitioner's
+        session-keyed calibration track (B5 ``compute_practitioner_divergence``),
+        which lives in the project DB, not the workspace ERM. Core records WHO
+        contributed WHAT; the reliability-weighting is layered on where both DBs
+        are reachable (autonomy's arbitration lane, B7).
+        """
+        self.upsert_entity_membership(
+            "practitioner",
+            claude_session_id,
+            "engagement",
+            engagement_id,
+            role=role,
+            notes=read_summary,
+        )
+
+    def get_deliberation(self, engagement_id: str) -> list[dict[str, Any]]:
+        """The deliberation record for an engagement — its attributed
+        practitioner reads (B6).
+
+        Returns one row per live ``contributes_to`` edge on the engagement, each
+        a read attributed to its contributing practitioner: the
+        ``practitioner_session_id``, the ``practice_ai_id`` + conversation
+        ``summary`` from the practitioner's durable registry row (B4), the
+        ``read_summary`` (position), and ``joined_at``. Ordered oldest-first
+        (deliberation chronology).
+
+        LEFT JOIN to the registry — an attributed read is real even if the
+        practitioner's durable entity hasn't been persisted yet; attribution
+        fields are ``None`` in that case (honest-empty) rather than silently
+        dropping the read.
+
+        This is the RAW record. The per-read reliability vector (B5) and the
+        arbitrated direction (B7) are layered on by the consumer — core surfaces
+        the reads, autonomy weights + arbitrates.
+        """
+        cursor = self._execute(
+            """SELECT m.entity_id AS practitioner_session_id,
+                      m.role, m.notes AS read_summary, m.joined_at,
+                      r.display_name, r.metadata
+               FROM entity_memberships m
+               LEFT JOIN entity_registry r
+                 ON r.entity_type = 'practitioner' AND r.entity_id = m.entity_id
+               WHERE m.entity_type = 'practitioner'
+                 AND m.group_type = 'engagement' AND m.group_id = ?
+                 AND m.role = 'contributes_to' AND m.left_at IS NULL
+               ORDER BY m.joined_at""",
+            (engagement_id,),
+        )
+        out: list[dict[str, Any]] = []
+        for row in cursor.fetchall():
+            d = dict(row)
+            meta: dict[str, Any] = {}
+            raw = d.get("metadata")
+            if raw:
+                try:
+                    parsed = json.loads(raw)
+                    if isinstance(parsed, dict):
+                        meta = parsed
+                except (ValueError, TypeError):
+                    meta = {}
+            out.append(
+                {
+                    "practitioner_session_id": d["practitioner_session_id"],
+                    "practice_ai_id": meta.get("practice_ai_id"),
+                    "summary": meta.get("summary"),
+                    "read_summary": d["read_summary"],
+                    "joined_at": d["joined_at"],
+                    "display_name": d["display_name"],
+                }
+            )
+        return out
+
     def close_entity_membership(
         self,
         entity_type: str,

--- a/tests/unit/test_entity_repo.py
+++ b/tests/unit/test_entity_repo.py
@@ -282,3 +282,74 @@ class TestCloseEntityMembership:
         repo.upsert_entity_membership("engagement", "e-1", "organization", "o-1", role="ticket_of")
         active = repo.get_entity_memberships("engagement", "e-1")["member_of"]
         assert len(active) == 1 and active[0]["left_at"] is None
+
+
+class TestDeliberationRecord:
+    """B6 — deliberation record: contributes_to edge (practitioner ↔ engagement)
+    + attributed reads. Parallel to B4's occupies edge, so it inherits
+    idempotency + soft-close from entity_memberships."""
+
+    def test_empty_engagement_has_no_reads(self, tmp_workspace_repo):
+        assert tmp_workspace_repo.get_deliberation("eng-1") == []
+
+    def test_record_and_read_attributed(self, tmp_workspace_repo):
+        repo = tmp_workspace_repo
+        # Two practitioners occupying a practice, each contributing a read.
+        repo.upsert_practitioner_entity("sess-A", "empirica", summary="A's tl;dr")
+        repo.upsert_practitioner_entity("sess-B", "empirica", summary="B's tl;dr")
+        repo.record_deliberation_read("sess-A", "eng-1", read_summary="lean ship")
+        repo.record_deliberation_read("sess-B", "eng-1", read_summary="hold, risk")
+
+        reads = repo.get_deliberation("eng-1")
+        assert len(reads) == 2
+        by_sess = {r["practitioner_session_id"]: r for r in reads}
+        assert by_sess["sess-A"]["read_summary"] == "lean ship"
+        # attribution is enriched from the practitioner's durable registry row (B4)
+        assert by_sess["sess-A"]["practice_ai_id"] == "empirica"
+        assert by_sess["sess-A"]["summary"] == "A's tl;dr"
+        assert by_sess["sess-B"]["read_summary"] == "hold, risk"
+
+    def test_read_scoped_to_engagement(self, tmp_workspace_repo):
+        repo = tmp_workspace_repo
+        repo.upsert_practitioner_entity("sess-A", "empirica")
+        repo.record_deliberation_read("sess-A", "eng-1", read_summary="on eng-1")
+        repo.record_deliberation_read("sess-A", "eng-2", read_summary="on eng-2")
+        assert len(repo.get_deliberation("eng-1")) == 1
+        assert repo.get_deliberation("eng-1")[0]["read_summary"] == "on eng-1"
+        assert repo.get_deliberation("eng-2")[0]["read_summary"] == "on eng-2"
+
+    def test_re_record_updates_position_not_duplicates(self, tmp_workspace_repo):
+        repo = tmp_workspace_repo
+        repo.upsert_practitioner_entity("sess-A", "empirica")
+        repo.record_deliberation_read("sess-A", "eng-1", read_summary="first position")
+        repo.record_deliberation_read("sess-A", "eng-1", read_summary="revised position")
+        reads = repo.get_deliberation("eng-1")
+        assert len(reads) == 1  # latest position wins, no duplicate edge
+        assert reads[0]["read_summary"] == "revised position"
+
+    def test_read_surfaces_without_registry_row(self, tmp_workspace_repo):
+        # An attributed read is real even if the practitioner entity wasn't
+        # persisted; attribution fields are None (LEFT JOIN, honest-empty).
+        repo = tmp_workspace_repo
+        repo.record_deliberation_read("sess-ghost", "eng-1", read_summary="unattributed read")
+        reads = repo.get_deliberation("eng-1")
+        assert len(reads) == 1
+        assert reads[0]["practitioner_session_id"] == "sess-ghost"
+        assert reads[0]["read_summary"] == "unattributed read"
+        assert reads[0]["practice_ai_id"] is None
+        assert reads[0]["summary"] is None
+
+    def test_closed_read_excluded_but_auditable(self, tmp_workspace_repo):
+        repo = tmp_workspace_repo
+        repo.upsert_practitioner_entity("sess-A", "empirica")
+        repo.record_deliberation_read("sess-A", "eng-1", read_summary="withdrawn")
+        # Practitioner withdraws from the deliberation → soft-close the edge.
+        assert repo.close_entity_membership("practitioner", "sess-A", "engagement", "eng-1") is True
+        assert repo.get_deliberation("eng-1") == []
+        # ...but the row persists (auditable history), consistent with B4 semantics.
+        cur = repo._execute(
+            "SELECT left_at FROM entity_memberships "
+            "WHERE entity_type='practitioner' AND entity_id='sess-A' AND group_type='engagement'"
+        )
+        rows = cur.fetchall()
+        assert len(rows) == 1 and rows[0]["left_at"] is not None


### PR DESCRIPTION
## EPIC B / B6 — deliberation record

The fourth leg of practitioner presence (B4 practitioner entity, B5 reliability surface → **B6 deliberation record**). A **deliberation** is the set of practitioner reads on one engagement ([`PRACTITIONER_DELIBERATION_MODEL` §4](../blob/develop/docs/architecture/PRACTITIONER_DELIBERATION_MODEL.md)). Each read is a **`contributes_to` edge** (practitioner → engagement) — exactly parallel to B4's `occupies` (practitioner → practice), so it reuses `entity_memberships` and inherits its idempotency + soft-close semantics. **No schema change.**

### What changed (`empirica/data/repositories/workspace_db.py`)

- **`record_deliberation_read(session_id, engagement_id, *, read_summary=None)`** — writes/updates the `contributes_to` edge. Latest position wins (no duplicate edge); withdrawing is a soft-close (`left_at`), keeping deliberation history auditable.
- **`get_deliberation(engagement_id)`** — the attributed reads on an engagement. Each `contributes_to` edge is **LEFT**-JOINed to the practitioner's durable registry row (B4) for `practice_ai_id` + conversation `summary`. LEFT so an edge whose practitioner entity isn't persisted yet still surfaces (honest-empty attribution) rather than being silently dropped. Ordered oldest-first (deliberation chronology).

### The seam (deliberate, consistent with B5)

Reliability weighting is **not** here. The per-read reliability vector (B5 `compute_practitioner_divergence`) and the arbitrated direction (B7) are layered on **by the consumer** — the reliability track lives in the *project* DB, not the workspace ERM, so the reliability-attach happens at the assembly layer where both DBs are reachable (autonomy's arbitration lane, B7). Core records **who contributed what**; autonomy **weights + arbitrates**.

### Tests (`tests/unit/test_entity_repo.py` — `TestDeliberationRecord`)

6 tests: empty engagement, attributed multi-practitioner read, engagement-scoping, re-record-updates-position (no dup), LEFT-JOIN honest-empty (read without registry row), soft-close exclusion + auditability.

Gate: 34/34 pass (6 new + 28 existing) · `ruff check` clean · `ruff format` clean · `pyright` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)