### PR TITLE
feat(engagements): planned (pre-active) lifecycle state + ?lifecycle=all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to Empirica will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Engagement `planned` (pre-active) lifecycle state + `?lifecycle=all`
+  fetch-everything.** Engagements gain a `planned` state ahead of `open`, for
+  queued-but-not-started work. The active-by-default feed
+  (`GET /api/v1/engagements`, the `engagement-list` CLI, and the org/contact
+  drill) now excludes **both** pre-active (`planned`) and terminal (`closed`) —
+  the "who are we working with now" view is the complement
+  `{open, in_progress, blocked}`. Reach the full set with an explicit
+  `?lifecycle=<state>` (`planned` / `closed` each individually targetable) or
+  the new `?lifecycle=all` sentinel (`--lifecycle all` on the CLI). `include_closed`
+  remains as legacy sugar — it adds `closed` back to the feed but leaves
+  `planned` out unless it's requested explicitly. Enum + filter live app-side in
+  `WorkspaceDBRepository` (`ENGAGEMENT_PREACTIVE_STATES` /
+  `ENGAGEMENT_DEFAULT_EXCLUDED_STATES`); invalid states surface as a 422, never a 500.
+
 ## [1.12.11] — 2026-07-03
 
 ### Added

--- a/docs/human/developers/CLI_COMMANDS_UNIFIED.md
+++ b/docs/human/developers/CLI_COMMANDS_UNIFIED.md
@@ -23,7 +23,7 @@
 > dictionary, then running this script.
 
 **Framework version:** 1.12.11
-**Generated:** 2026-07-03 07:27:44 UTC
+**Generated:** 2026-07-03 13:14:08 UTC
 **Total commands:** 256 (across 26 categories)
 
 For the most up-to-date detail on any single command, prefer
@@ -1964,11 +1964,11 @@ List engagements (active-by-default) filtered by --domain / --lifecycle / --org;
 - `--domain` — optional
   Filter by domain
 - `--lifecycle` — optional
-  Filter by lifecycle_state (open|in_progress|blocked|closed)
+  Filter by lifecycle_state (planned|open|in_progress|blocked|closed), or 'all' for the full set
 - `--org` — optional
   Scope to an organization's tickets (role='ticket_of')
 - `--include-closed` — optional · flag
-  Include terminal (closed) engagements. Default: active-only (open|in_progress|blocked). Ignored when --lifecycle is given.
+  Legacy sugar — add terminal (closed) engagements back. Default: active-only (open|in_progress|blocked); pre-active 'planned' stays out unless requested or --lifecycle all. Ignored when --lifecycle is given.
 - `--limit` — optional · type=`int` · default=`100`
   Max rows (default: 100)
 - `--output` — optional · type=`choice` · choices={human, json} · default=`human`

--- a/empirica/api/routes/engagements.py
+++ b/empirica/api/routes/engagements.py
@@ -45,11 +45,17 @@ async def list_engagements(
         "(engagement_contacts edge). Composes with `org` (AND) when both are given.",
     ),
     domain: str | None = Query(None, description="Filter by engagement domain (support, sales, ...)"),
-    lifecycle: str | None = Query(None, description="Filter by lifecycle_state (open, in_progress, blocked, closed)"),
+    lifecycle: str | None = Query(
+        None,
+        description="Filter by lifecycle_state (planned, open, in_progress, blocked, closed), "
+        "or `all` for the full set (Engagements-area fetch-everything).",
+    ),
     include_closed: bool = Query(
         False,
-        description="Include terminal (closed) engagements. Default false — the feed is "
-        "active-by-default (SER#183 part-2). Ignored when an explicit `lifecycle` is given.",
+        description="Legacy sugar — adds terminal (closed) engagements back to the feed. Default "
+        "false — the feed is active-by-default {open, in_progress, blocked} (SER#183 part-2); "
+        "pre-active `planned` stays out unless requested explicitly or via `lifecycle=all`. "
+        "Ignored when an explicit `lifecycle` is given.",
     ),
     limit: int = Query(100, ge=1, le=500),
 ):
@@ -119,7 +125,9 @@ class EngagementCreateRequest(BaseModel):
     domain: str = Field(description="Engagement domain — one of the 6 (support, sales, …)")
     title: str | None = Field(default=None, description="Ticket title; synthesized if omitted (NOT NULL in schema)")
     stage: str | None = Field(default=None, description="Full stage_id; validated against the domain")
-    lifecycle_state: str | None = Field(default=None, description="open|in_progress|blocked|closed (default open)")
+    lifecycle_state: str | None = Field(
+        default=None, description="planned|open|in_progress|blocked|closed (default open)"
+    )
     engagement_type: str = Field(default="support")
     description: str | None = None
     org: str | None = Field(default=None, description="Organization id — sets the ticket_of edge atomically")

--- a/empirica/cli/command_handlers/engagement_commands.py
+++ b/empirica/cli/command_handlers/engagement_commands.py
@@ -116,6 +116,7 @@ def handle_engagement_list_command(args):
                 )
         except ValueError as ve:
             _emit_user_error(output, str(ve))
+            return  # invalid --lifecycle → error already surfaced; don't fall through to unbound rows
         if output == "json":
             print(json.dumps({"ok": True, "count": len(rows), "engagements": rows}, indent=2, default=str))
             return

--- a/empirica/cli/parsers/checkpoint_parsers.py
+++ b/empirica/cli/parsers/checkpoint_parsers.py
@@ -671,14 +671,16 @@ def add_checkpoint_parsers(subparsers):
     )
     engagement_list_parser.add_argument("--domain", help="Filter by domain")
     engagement_list_parser.add_argument(
-        "--lifecycle", help="Filter by lifecycle_state (open|in_progress|blocked|closed)"
+        "--lifecycle",
+        help="Filter by lifecycle_state (planned|open|in_progress|blocked|closed), or 'all' for the full set",
     )
     engagement_list_parser.add_argument("--org", help="Scope to an organization's tickets (role='ticket_of')")
     engagement_list_parser.add_argument(
         "--include-closed",
         action="store_true",
-        help="Include terminal (closed) engagements. Default: active-only "
-        "(open|in_progress|blocked). Ignored when --lifecycle is given.",
+        help="Legacy sugar — add terminal (closed) engagements back. Default: active-only "
+        "(open|in_progress|blocked); pre-active 'planned' stays out unless requested or --lifecycle all. "
+        "Ignored when --lifecycle is given.",
     )
     engagement_list_parser.add_argument("--limit", type=int, default=100, help="Max rows (default: 100)")
     engagement_list_parser.add_argument("--output", choices=["human", "json"], default="human", help="Output format")

--- a/empirica/data/repositories/workspace_db.py
+++ b/empirica/data/repositories/workspace_db.py
@@ -243,13 +243,15 @@ _DEFAULT_ENGAGEMENT_STAGES = [
 # Engagement enums — enforced app-side. The engagement is an OPERATIONAL row
 # (sqlite ALTER can't add CHECK), so lifecycle/outcome validity lives at the repo
 # layer; domain/stage validity is checked against the definition tables.
-ENGAGEMENT_LIFECYCLE_STATES = frozenset({"open", "in_progress", "blocked", "closed"})
-# Terminal states — excluded by default from org/contact engagement scoping
-# (SER#183 part-2: the drill is a "who are we working with now" view; terminal
-# engagements belong in the dedicated Engagements area). Add new terminal states
-# here so the default-active filter picks them up; the complement (open,
-# in_progress, blocked) is "active".
+ENGAGEMENT_LIFECYCLE_STATES = frozenset({"planned", "open", "in_progress", "blocked", "closed"})
+# States off the default-active feed, for two distinct reasons (SER#183 part-2:
+# the org/contact drill is a "who are we working with now" view). PRE-ACTIVE:
+# planned — queued but not started. TERMINAL: closed — done. The active feed is
+# the complement, {open, in_progress, blocked}; the full set (incl. planned +
+# closed) is reached via an explicit lifecycle_state or the ``all`` sentinel.
+ENGAGEMENT_PREACTIVE_STATES = frozenset({"planned"})
 ENGAGEMENT_TERMINAL_STATES = frozenset({"closed"})
+ENGAGEMENT_DEFAULT_EXCLUDED_STATES = ENGAGEMENT_PREACTIVE_STATES | ENGAGEMENT_TERMINAL_STATES
 ENGAGEMENT_OUTCOMES = frozenset({"won", "lost", "resolved", "wont_fix", "defer", "superseded"})
 
 
@@ -1550,16 +1552,23 @@ class WorkspaceDBRepository(BaseRepository):
         ``lifecycle_state`` must be a valid state.
 
         Active-by-default (SER#183 part-2): when no explicit ``lifecycle_state``
-        is given, terminal engagements (``ENGAGEMENT_TERMINAL_STATES``, i.e.
-        closed) are excluded — the org/contact drill is a "who are we working
-        with now" view. Opt into the full set with ``include_closed=True`` or by
-        requesting a specific ``lifecycle_state`` (an explicit state always wins,
-        so ``lifecycle_state='closed'`` still returns closed). The Engagements
-        area surfaces terminal history via these opt-ins.
+        is given, the feed is the active set {open, in_progress, blocked} —
+        pre-active (``planned``) and terminal (``closed``) are excluded, since
+        the org/contact drill is a "who are we working with now" view. Opt back
+        in by requesting a specific ``lifecycle_state`` (an explicit state always
+        wins — ``'planned'`` / ``'closed'`` return those), by
+        ``lifecycle_state='all'`` (the Engagements-area fetch-everything), or —
+        legacy sugar — ``include_closed=True`` (adds closed back; planned still
+        needs an explicit request).
         """
-        if lifecycle_state is not None and lifecycle_state not in ENGAGEMENT_LIFECYCLE_STATES:
+        # ``all`` is the explicit fetch-everything sentinel (Engagements area) —
+        # not a stored state, so it bypasses both membership validation and the
+        # default-active exclusion below.
+        fetch_all = lifecycle_state == "all"
+        if lifecycle_state is not None and not fetch_all and lifecycle_state not in ENGAGEMENT_LIFECYCLE_STATES:
             raise ValueError(
-                f"invalid lifecycle_state '{lifecycle_state}' — must be one of {sorted(ENGAGEMENT_LIFECYCLE_STATES)}"
+                f"invalid lifecycle_state '{lifecycle_state}' — must be one of "
+                f"{sorted(ENGAGEMENT_LIFECYCLE_STATES)} or 'all'"
             )
         params: list[Any] = []
         where: list[str] = []
@@ -1584,15 +1593,22 @@ class WorkspaceDBRepository(BaseRepository):
         if domain is not None:
             where.append("e.domain = ?")
             params.append(domain)
-        if lifecycle_state is not None:
-            # Explicit state wins — including an explicit request for closed.
+        if fetch_all:
+            pass  # ``all`` — no lifecycle filter; the Engagements-area full set.
+        elif lifecycle_state is not None:
+            # Explicit state wins — including an explicit request for planned/closed.
             where.append("e.lifecycle_state = ?")
             params.append(lifecycle_state)
-        elif not include_closed and ENGAGEMENT_TERMINAL_STATES:
-            # Default-active: exclude terminal states unless opted in.
-            placeholders = ", ".join("?" for _ in ENGAGEMENT_TERMINAL_STATES)
-            where.append(f"e.lifecycle_state NOT IN ({placeholders})")
-            params.extend(sorted(ENGAGEMENT_TERMINAL_STATES))
+        else:
+            # Default-active feed: exclude pre-active + terminal. ``include_closed``
+            # is legacy sugar that opts the TERMINAL (closed) states back in;
+            # pre-active (planned) stays out of a plain feed request either way
+            # (use ?lifecycle=planned / all to see it).
+            excluded = ENGAGEMENT_PREACTIVE_STATES if include_closed else ENGAGEMENT_DEFAULT_EXCLUDED_STATES
+            if excluded:
+                placeholders = ", ".join("?" for _ in excluded)
+                where.append(f"e.lifecycle_state NOT IN ({placeholders})")
+                params.extend(sorted(excluded))
         where_clause = ("WHERE " + " AND ".join(where)) if where else ""
         params.append(limit)
         cursor = self._execute(

--- a/tests/test_engagement_repository.py
+++ b/tests/test_engagement_repository.py
@@ -13,8 +13,10 @@ import time
 import pytest
 
 from empirica.data.repositories.workspace_db import (
+    ENGAGEMENT_DEFAULT_EXCLUDED_STATES,
     ENGAGEMENT_LIFECYCLE_STATES,
     ENGAGEMENT_OUTCOMES,
+    ENGAGEMENT_PREACTIVE_STATES,
     WorkspaceDBRepository,
     _ensure_workspace_schema,
 )
@@ -32,8 +34,11 @@ def repo() -> WorkspaceDBRepository:
 
 
 def test_enum_sets():
-    assert {"open", "in_progress", "blocked", "closed"} == ENGAGEMENT_LIFECYCLE_STATES
+    assert {"planned", "open", "in_progress", "blocked", "closed"} == ENGAGEMENT_LIFECYCLE_STATES
     assert {"won", "lost", "resolved", "wont_fix", "defer", "superseded"} == ENGAGEMENT_OUTCOMES
+    # planned (pre-active) + closed (terminal) are the two states off the active feed.
+    assert {"planned"} == ENGAGEMENT_PREACTIVE_STATES
+    assert {"planned", "closed"} == ENGAGEMENT_DEFAULT_EXCLUDED_STATES
 
 
 # ── create / get ─────────────────────────────────────────────────────────────
@@ -136,6 +141,52 @@ def test_list_org_scoped_is_active_by_default(repo):
     repo.conn.commit()
     assert {e["engagement_id"] for e in repo.list_engagements(org_id="acme")} == {"t1"}
     assert {e["engagement_id"] for e in repo.list_engagements(org_id="acme", include_closed=True)} == {"t1", "t2"}
+
+
+# ── planned (pre-active) + ?lifecycle=all fetch-everything ─────────────────────
+
+
+def test_list_excludes_planned_by_default(repo):
+    """Pre-active 'planned' is off the active feed (brackets it from the front)."""
+    repo.create_engagement("a1", "active", domain="support")
+    repo.create_engagement("p1", "queued", domain="support")
+    repo.update_engagement("p1", lifecycle_state="planned")
+    assert {e["engagement_id"] for e in repo.list_engagements()} == {"a1"}
+
+
+def test_list_include_closed_still_excludes_planned(repo):
+    """include_closed is terminal-only sugar — pre-active 'planned' stays out."""
+    repo.create_engagement("a1", "active", domain="support")
+    repo.create_engagement("p1", "queued", domain="support")
+    repo.create_engagement("c1", "done", domain="support")
+    repo.update_engagement("p1", lifecycle_state="planned")
+    repo.update_engagement("c1", lifecycle_state="closed", outcome="won")
+    assert {e["engagement_id"] for e in repo.list_engagements(include_closed=True)} == {"a1", "c1"}
+
+
+def test_list_explicit_planned_returns_planned(repo):
+    """An explicit lifecycle_state='planned' wins over the default exclusion."""
+    repo.create_engagement("a1", "active", domain="support")
+    repo.create_engagement("p1", "queued", domain="support")
+    repo.update_engagement("p1", lifecycle_state="planned")
+    assert {e["engagement_id"] for e in repo.list_engagements(lifecycle_state="planned")} == {"p1"}
+
+
+def test_list_all_returns_everything(repo):
+    """lifecycle_state='all' — the Engagements-area fetch-everything (planned + closed included)."""
+    repo.create_engagement("a1", "active", domain="support")
+    repo.create_engagement("p1", "queued", domain="support")
+    repo.create_engagement("c1", "done", domain="support")
+    repo.update_engagement("p1", lifecycle_state="planned")
+    repo.update_engagement("c1", lifecycle_state="closed", outcome="won")
+    assert {e["engagement_id"] for e in repo.list_engagements(lifecycle_state="all")} == {"a1", "p1", "c1"}
+
+
+def test_update_accepts_planned(repo):
+    """'planned' is a valid lifecycle_state for a transition into pre-active."""
+    repo.create_engagement("e1", "x", domain="support")
+    updated = repo.update_engagement("e1", lifecycle_state="planned")
+    assert updated["lifecycle_state"] == "planned"
 
 
 # ── contact scoping (engagement_contacts edge) ────────────────────────────────

--- a/tests/test_engagements_endpoint.py
+++ b/tests/test_engagements_endpoint.py
@@ -243,6 +243,29 @@ def test_route_active_by_default_excludes_closed(client):
     assert closed_ids == {cid}  # explicit lifecycle targets the terminal one
 
 
+def test_route_planned_excluded_and_all_fetches_everything(client):
+    """Pre-active 'planned' is off the default feed; ?lifecycle=all fetches it back.
+
+    include_closed is terminal-only sugar — planned stays out of it; only an
+    explicit ?lifecycle=planned / ?lifecycle=all surfaces a pre-active row.
+    """
+    pid = client.post("/api/v1/engagements", json={"domain": "support", "title": "queued work"}).json()["engagement_id"]
+    assert client.patch(f"/api/v1/engagements/{pid}", json={"lifecycle_state": "planned"}).status_code == 200
+
+    default_ids = {e["id"] for e in client.get("/api/v1/engagements").json()["engagements"]}
+    assert pid not in default_ids and "e1" in default_ids  # planned excluded by default
+
+    # include_closed is terminal-only — it does NOT restore planned.
+    sugar_ids = {e["id"] for e in client.get("/api/v1/engagements?include_closed=true").json()["engagements"]}
+    assert pid not in sugar_ids
+
+    all_ids = {e["id"] for e in client.get("/api/v1/engagements?lifecycle=all").json()["engagements"]}
+    assert pid in all_ids and "e1" in all_ids  # fetch-everything includes planned
+
+    planned_ids = {e["id"] for e in client.get("/api/v1/engagements?lifecycle=planned").json()["engagements"]}
+    assert planned_ids == {pid}  # explicit planned targets it
+
+
 # ---- POST /api/v1/engagements (C3 create) ----------------------------------
 
 


### PR DESCRIPTION
## Engagement `planned` lifecycle state + `?lifecycle=all`

Closes the fully-specced design (goal `cd76cdff`). Adds a **`planned`** state ahead of `open` for queued-but-not-started engagements, and makes the active-by-default feed exclude **both** pre-active and terminal states.

### Behavior

| Request | Returns |
|---|---|
| `GET /api/v1/engagements` (no filter) | active feed: `{open, in_progress, blocked}` — `planned` **and** `closed` excluded |
| `?lifecycle=planned` / `?lifecycle=closed` | that specific state (explicit always wins) |
| `?lifecycle=all` | **everything** (new fetch-everything sentinel) |
| `?include_closed=true` | legacy sugar — adds `closed` back; `planned` stays out unless requested |
| `?lifecycle=not_a_state` | 422 (never 500) |

Same semantics on the CLI: `engagement-list --lifecycle {planned\|…\|all}` / `--include-closed`.

### Implementation

- `ENGAGEMENT_LIFECYCLE_STATES` gains `planned`. The single terminal set splits into `ENGAGEMENT_PREACTIVE_STATES {planned}` + `ENGAGEMENT_TERMINAL_STATES {closed}`, unioned into `ENGAGEMENT_DEFAULT_EXCLUDED_STATES` for the default `NOT IN` filter.
- `list_engagements`: `lifecycle_state="all"` is a sentinel that bypasses validation + exclusion; `include_closed` opts terminal back in but leaves `planned` out.
- API + CLI param descriptions updated; **CLI docs regenerated** (`generate_cli_docs.py`).
- Bonus: `engagement-list` handler now `return`s after an invalid-`--lifecycle` error (was falling through to an unbound `rows`).

### Deliberately deferred (checkpoint)

The live-data **`active → in_progress` reconcile migration is NOT in this PR.** Existing rows default to `lifecycle_state='open'` (already in the active feed), so the feature is fully functional without it. The migration touches the live `workspace.db` and is a separate, checkpoint-gated step.

### Tests

`test_engagement_repository.py` (+5) and `test_engagements_endpoint.py` (+1): planned-excluded-by-default, `include_closed`-still-excludes-planned, explicit `planned`/`all`, `update` accepts `planned`, enum-set assertion updated. **51 pass**, ruff + format + pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)