### PR TITLE
feat(post_test): B5 — expose per-phase brier_variance for true-SE shrink

### DIFF
--- a/empirica/core/post_test/dynamic_thresholds.py
+++ b/empirica/core/post_test/dynamic_thresholds.py
@@ -442,6 +442,17 @@ def get_brier_profile(
             predictions = [(row[0], row[1]) for row in rows]
             decomp = compute_brier_decomposition(predictions)
 
+            # Per-sample Brier components (the same (p−o)² the score averages) —
+            # expose their SAMPLE variance (ddof=1) so a consumer can form the
+            # true SE = sqrt(brier_variance / n) rather than the conservative
+            # bound SE ≤ 1/(2·√n) that assumes max dispersion (var=0.25 for a
+            # [0,1] component). Raw dispersion stat, not a weighting — the
+            # shrinkage fold stays autonomy's lane (PRACTITIONER_DELIBERATION_MODEL
+            # §3, B7). n ≥ 3 here (guarded above), so the ddof=1 denominator ≥ 2.
+            components = [(p - o) ** 2 for p, o in predictions]
+            mean_component = sum(components) / len(components)
+            brier_variance = sum((c - mean_component) ** 2 for c in components) / (len(components) - 1)
+
             # Compute recent vs historical for trend
             recent = predictions[: len(predictions) // 2] if len(predictions) >= 6 else predictions
             historical = predictions[len(predictions) // 2 :] if len(predictions) >= 6 else []
@@ -458,6 +469,7 @@ def get_brier_profile(
 
             profile[phase] = {
                 "brier_score": decomp.brier_score,
+                "brier_variance": round(brier_variance, 6),
                 "reliability": decomp.reliability,
                 "resolution": decomp.resolution,
                 "uncertainty": decomp.uncertainty,
@@ -503,7 +515,13 @@ def compute_practitioner_divergence(
     track and the practice aggregate::
 
         {phase: {brier_delta, reliability_delta, practitioner_brier,
-                 practice_brier, practitioner_n, practice_n}}
+                 practice_brier, practitioner_n, practice_n,
+                 practitioner_brier_variance, practice_brier_variance}}
+
+    The per-side ``brier_variance`` (sample variance, ddof=1, of the per-sample
+    Brier components) lets a consumer form the true standard error
+    ``SE = sqrt(brier_variance / n)`` — used by the asymmetric shrink instead of
+    the conservative max-dispersion bound ``SE ≤ 1/(2·√n)``.
 
     ``brier_delta`` = practitioner − practice (NEGATIVE = better-calibrated than
     the practice; POSITIVE = worse). A phase with too few grounded points on
@@ -536,6 +554,11 @@ def compute_practitioner_divergence(
             "practice_brier": a["brier_score"],
             "practitioner_n": p["n_predictions"],
             "practice_n": a["n_predictions"],
+            # Per-side Brier variance (B5) → the consumer forms the true SE
+            # = sqrt(brier_variance / n) for the asymmetric shrink, instead of
+            # the max-dispersion bound. Weighting stays autonomy's lane (B7).
+            "practitioner_brier_variance": p.get("brier_variance"),
+            "practice_brier_variance": a.get("brier_variance"),
         }
     return out
 

--- a/tests/core/post_test/test_practitioner_brier.py
+++ b/tests/core/post_test/test_practitioner_brier.py
@@ -78,3 +78,29 @@ def test_divergence_insufficient_data():
     d = compute_practitioner_divergence("sess-thin", "empirica", db)["combined"]
     assert d["status"] == "insufficient_data"
     assert d["practitioner_n"] == 1
+
+
+def test_brier_variance_matches_sample_variance():
+    # Per-sample Brier components (self−grounded)²: 0.0, 0.16, 0.04 — hand-check
+    # the ddof=1 sample variance the profile exposes for the true-SE fold (B7).
+    rows = [
+        ("sess-x", "empirica", "combined", 0.9, 0.9, 0),  # (0.9-0.9)² = 0.0
+        ("sess-x", "empirica", "combined", 0.5, 0.9, 1),  # (0.5-0.9)² = 0.16
+        ("sess-x", "empirica", "combined", 0.7, 0.9, 2),  # (0.7-0.9)² = 0.04
+    ]
+    prof = get_practitioner_brier_profile("sess-x", "empirica", _db_with_trajectory(rows))["combined"]
+    comps = [0.0, 0.16, 0.04]
+    mean = sum(comps) / len(comps)
+    expected_var = sum((c - mean) ** 2 for c in comps) / (len(comps) - 1)  # ddof=1
+    assert abs(prof["brier_variance"] - round(expected_var, 6)) < 1e-6
+    # SE = sqrt(brier_variance / n) is well-defined and non-negative.
+    assert (prof["brier_variance"] / prof["n_predictions"]) ** 0.5 >= 0.0
+
+
+def test_divergence_exposes_both_variances():
+    db = _db_with_trajectory(_rows())
+    d = compute_practitioner_divergence("sess-A", "empirica", db)["combined"]
+    # both sides' variance ride alongside the means + n's so the consumer can
+    # form a per-side SE for the asymmetric shrink.
+    assert d["practitioner_brier_variance"] >= 0.0
+    assert d["practice_brier_variance"] >= 0.0


### PR DESCRIPTION
## B5 follow-up — expose Brier variance for the asymmetric shrink

Answers autonomy's B7 signature question. Their asymmetric shrink (harder-shrink on *better-than-practice* claims) keys off the Brier **standard error**, but `compute_practitioner_divergence` exposed means + n's only — forcing the conservative bound `SE ≤ 1/(2·√n)`.

That bound is the **max-dispersion** assumption (`var=0.25` for a `[0,1]` component). It systematically **over-shrinks low-dispersion practitioners** — the consistent, well-calibrated ones, which is exactly the better-than-practice population the asymmetric rule most needs to credit accurately. Real SE fixes that, and it's cheap while B5 is fresh.

### Change (`empirica/core/post_test/dynamic_thresholds.py`)

- `get_brier_profile` gains **`brier_variance`** per phase: sample variance (ddof=1) of the per-sample Brier components `(self_assessed − grounded)²` — the same `(p−o)²` the score already averages. `n ≥ 3` is guarded, so ddof=1 is defined.
- `compute_practitioner_divergence` surfaces **`practitioner_brier_variance`** + **`practice_brier_variance`** alongside the means/n's → the consumer forms the true `SE = sqrt(brier_variance / n)` per side.

### Seam preserved

Still **raw dispersion, not a weighting** — the shrinkage fold stays autonomy's lane (`PRACTITIONER_DELIBERATION_MODEL` §3 / B7). Purely additive; existing callers of `get_brier_profile` / `compute_practitioner_divergence` are unaffected (new keys only).

Note: the ddof=1 sample variance *can* exceed the 0.25 population bound for small-n / high-dispersion samples — i.e. the real SE isn't strictly ≤ `1/(2√n)`; it's the *actual* dispersion, which is the point. Autonomy's `n < n_min` floor handles genuinely thin samples.

### Tests

`tests/core/post_test/test_practitioner_brier.py` (+2): hand-verified sample variance, divergence exposes both sides'. **5 pass**, ruff + format + pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)