### PR TITLE
docs(skills): make cortex-mailbox skills harness-aware (flat vs namespace tools)

### DIFF
--- a/empirica/plugins/claude-code-integration/skills/cortex-mailbox-poll/SKILL.md
+++ b/empirica/plugins/claude-code-integration/skills/cortex-mailbox-poll/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cortex-mailbox-poll
 description: "Use when wiring the canonical cortex inbox+outbox polling loop into Claude Code's /loop. This is the orchestration spine — every empirica claude polls Cortex on a fast adaptive cadence (30s base, 5m max) for proposals addressed to itself + status changes on its own outgoing proposals. Self-throttles when an empirica transaction is open (the AI is already busy; no need to interrupt). The canonical loop catalog (empirica/core/cockpit/canonical_loops.py) auto-installs this when the TUI cockpit toggles L on an instance that has no loops registered. This skill is the body the AI runs each fire."
-version: 1.0.0
+version: 1.1.0
 ---
 
 # Cortex mailbox-poll cron loop wiring
@@ -13,6 +13,26 @@ status changes route in seconds, not on the next user prompt.
 This skill is a thin wrapper over `/loop-cron` — same self-scheduling
 template, with `cortex_inbox_poll` + `cortex_outbox_poll` MCP calls
 plugged in as the body.
+
+---
+
+## Harness portability — flat tool names are the Claude Code form
+
+Every `mcp__cortex__cortex_*` name in this skill is the **Claude Code**
+calling convention, where each MCP tool is exposed as its own flat tool.
+**Namespace-aggregating harnesses** (codex / ecodex, the OpenAI
+Responses-API) instead collapse a whole MCP server's toolset into ONE
+namespace tool — `mcp__cortex` — driven by an operation + params interface.
+There you invoke the cortex **operation** *through* that namespace tool
+(operation=`cortex_inbox_poll`, params=`{…}`); a flat
+`mcp__cortex__cortex_inbox_poll` call parses to a non-namespaced tool name,
+matches nothing, and returns `unsupported call`.
+
+**Rule of thumb:** read every `mcp__cortex__<op>` below as **"the cortex
+operation `<op>`"** and call it however your harness surfaces cortex tools —
+a flat tool in Claude Code, the `mcp__cortex` namespace tool + `operation`
+param in codex/ecodex. The operations and their params are identical across
+harnesses; only the invocation shape differs.
 
 ---
 

--- a/empirica/plugins/claude-code-integration/skills/cortex-mailbox-send/SKILL.md
+++ b/empirica/plugins/claude-code-integration/skills/cortex-mailbox-send/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cortex-mailbox-send
 description: "Use when sending a message to a PEER AI in the mesh — discussion, FYI, question, request to do work, or completion-ack for a request a peer made of YOU. Pairs with /cortex-mailbox-poll (the receive side). Covers: when-to-send vs when-to-just-log-locally, choosing between collab flavor (auto-accept, conversational) vs ECO-gated flavor (typed action request that waits for a human decision), addressing peers by ai_id, completing inbound proposals so the source AI gets the ack, and recovery if a previous send mis-targeted. NOT for cortex_bus_* (system instance work queue, different concern) or cortex_collab_post (collab-doc events, web workflow only)."
-version: 1.1.0
+version: 1.2.0
 ---
 
 # Sending in the AI Mesh
@@ -33,6 +33,27 @@ It's not a fourth send-tool — you create SERs via `cortex_propose` with
 sustained multi-practitioner work. When a thread accumulates ≥3 rounds across
 the same practitioners, or when work has named participants with role tiers,
 SER is the right primitive. See **Flavor 3** below for full operational depth.
+
+---
+
+## Harness portability — flat tool names are the Claude Code form
+
+Every `mcp__cortex__cortex_*` name in this skill (`cortex_collab`,
+`cortex_propose`, `cortex_publish`, …) is the **Claude Code** calling
+convention, where each MCP tool is exposed as its own flat tool.
+**Namespace-aggregating harnesses** (codex / ecodex, the OpenAI
+Responses-API) instead collapse a whole MCP server's toolset into ONE
+namespace tool — `mcp__cortex` — driven by an operation + params interface.
+There you invoke the cortex **operation** *through* that namespace tool
+(operation=`cortex_collab`, params=`{…}`); a flat `mcp__cortex__cortex_collab`
+call parses to a non-namespaced tool name, matches nothing, and returns
+`unsupported call`.
+
+**Rule of thumb:** read every `mcp__cortex__<op>` below as **"the cortex
+operation `<op>`"** and call it however your harness surfaces cortex tools —
+a flat tool in Claude Code, the `mcp__cortex` namespace tool + `operation`
+param in codex/ecodex. The operations and their params are identical across
+harnesses; only the invocation shape differs.
 
 ---
 


### PR DESCRIPTION
## Harness-portability fix for the cortex-mailbox skills

Reported by **ecodex** (`prop_j223smb`), verified end-to-end this session.

**The bug:** codex / ecodex aggregate an MCP server's *entire* toolset into ONE namespace tool (`mcp__cortex`) driven by an operation + params interface. The `cortex-mailbox-poll` / `cortex-mailbox-send` skills hardcode flat `mcp__cortex__cortex_inbox_poll`-style names — correct for Claude Code (flat tools), but under namespace aggregation a flat name parses to a non-namespaced tool → **`unsupported call`**. That blocks every non-Claude ecodex practitioner on its *first* inbox poll — the whole doorbell→poll→execute delivery path.

Ecodex confirmed the capability itself works: routing `cortex_inbox_poll` *through* the `mcp__cortex` namespace tool returned `{ok:true, inbox:[], status:accepted}`. Only the **calling convention** in the skills was CC-specific.

**The fix:** add a `## Harness portability` section to both skills:
- The flat `mcp__server__tool` names are the **Claude Code** form.
- Namespace-aggregating harnesses (codex/ecodex, OpenAI Responses-API) invoke the same **operation** through the server's namespace tool + `operation` param.
- Rule of thumb: read every `mcp__cortex__<op>` as *"the cortex operation `<op>`"* and call it however your harness surfaces cortex tools. Operations + params are identical across harnesses; only the invocation shape differs.

Skill versions bumped (poll `1.0.0→1.1.0`, send `1.1.0→1.2.0`). Docs-only; no code paths touched.

Follow-up (not in this PR): the constitution + `empirica-system-prompt-lean.md` template also reference flat names — same note could ride there later. Scoped this to the two skills ecodex named (the ones a practitioner loads for the mailbox loop) to keep it focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)