### PR TITLE
fix(sentinel): stale closed exact-suffix file no longer masks a live open transaction

### DIFF
--- a/empirica/plugins/claude-code-integration/hooks/sentinel-gate.py
+++ b/empirica/plugins/claude-code-integration/hooks/sentinel-gate.py
@@ -1010,10 +1010,24 @@ def _find_transaction_file(
     sync with empirica/utils/session_resolver.py:_find_transaction_file.
     See: docs/architecture/instance_isolation/KNOWN_ISSUES.md (11.21)
     """
-    # Primary: exact suffix match
+    # Primary: exact suffix match. An OPEN exact file wins immediately, and the
+    # keyless case returns it as-is. But a CLOSED exact file must NOT short-circuit
+    # when we hold a key: a stale closed transaction at the current suffix would
+    # otherwise mask a newer key-matched OPEN transaction under a rotated suffix,
+    # making this firewall deny praxic with "Epistemic loop closed" after a valid
+    # CHECK. When closed + keyed, fall through to the ranked scan below. Kept in
+    # sync with empirica/utils/session_resolver.py:_find_transaction_file.
     exact = empirica_dir / f"active_transaction{suffix}.json"
     if exact.exists():
-        return exact
+        if not (claude_session_id or session_id):
+            return exact
+        try:
+            with open(exact) as exact_f:
+                if json.load(exact_f).get("status") == "open":
+                    return exact
+        except Exception:
+            return exact  # unreadable → treat as authoritative, don't scan
+        # exact is CLOSED and a key is available → fall through to the scan.
 
     # Fallback: scan suffix-mismatched files. Rank candidates and return the best
     # rather than the first sorted match — claude_session_id is stable across the

--- a/empirica/utils/session_resolver.py
+++ b/empirica/utils/session_resolver.py
@@ -1255,10 +1255,26 @@ def _find_transaction_file(
     Returns:
         Path to the transaction file, or None
     """
-    # Primary: exact suffix match
+    # Primary: exact suffix match. An OPEN exact file wins immediately (the
+    # common, no-rotation case), and the keyless case returns it as-is. But a
+    # CLOSED exact file must NOT short-circuit when we hold a key: a stale closed
+    # transaction at the current suffix would otherwise mask a newer key-matched
+    # OPEN transaction under a rotated suffix, making the firewall deny praxic
+    # with "Epistemic loop closed" after a valid CHECK. When closed + keyed, fall
+    # through to the ranked scan below (it prefers a key-matched OPEN, still
+    # returns this closed file when it's our only match, and returns None for a
+    # foreign file per the no-crosstalk rule).
     exact = empirica_dir / f"active_transaction{suffix}.json"
     if exact.exists():
-        return exact
+        if not (claude_session_id or session_id):
+            return exact
+        try:
+            with open(exact) as exact_f:
+                if json.load(exact_f).get("status") == "open":
+                    return exact
+        except Exception:
+            return exact  # unreadable → treat as authoritative, don't scan
+        # exact is CLOSED and a key is available → fall through to the scan.
 
     # Fallback: scan for suffix-mismatched files. Rank candidates and return the
     # best rather than the first sorted match — claude_session_id is stable

--- a/tests/test_transaction_dual_key.py
+++ b/tests/test_transaction_dual_key.py
@@ -145,6 +145,40 @@ def test_find_prefers_most_recent_open(tmp_path):
     assert _find_transaction_file(ed, "_tmux_9", None, "cc-1") == new_p
 
 
+def test_find_exact_closed_does_not_mask_open_elsewhere(tmp_path):
+    """The spurious-close bug: a STALE CLOSED file sits at the CURRENT exact
+    suffix, while the live OPEN transaction (same durable cc) is under a rotated
+    suffix. The primary exact-match must NOT short-circuit on the closed file —
+    otherwise the firewall reads status=closed and denies praxic with 'Epistemic
+    loop closed' despite a valid open transaction (re-PREFLIGHT was the only fix)."""
+    ed = tmp_path / ".empirica"
+    # Stale closed file AT the current exact suffix (_tmux_9).
+    _write_tx(
+        ed, "_tmux_9", transaction_id="T-STALE-CLOSED", claude_session_id="cc-1", status="closed", updated_at=100.0
+    )
+    # Live open transaction under a rotated suffix, same durable cc.
+    open_p = _write_tx(
+        ed, "_tmux_1", transaction_id="T-OPEN", claude_session_id="cc-1", status="open", updated_at=200.0
+    )
+    assert _find_transaction_file(ed, "_tmux_9", None, "cc-1") == open_p
+
+
+def test_find_exact_closed_alone_still_resolves(tmp_path):
+    """No regression to the closed-read path: when the CLOSED exact-suffix file
+    is the only cc-match (nothing open), it must still resolve — the firewall
+    needs it to say 'loop closed, re-PREFLIGHT'."""
+    ed = tmp_path / ".empirica"
+    closed_p = _write_tx(ed, "_tmux_9", transaction_id="T-CLOSED", claude_session_id="cc-1", status="closed")
+    assert _find_transaction_file(ed, "_tmux_9", None, "cc-1") == closed_p
+
+
+def test_find_exact_open_fast_path_unchanged(tmp_path):
+    """The common case: an OPEN exact-suffix file still fast-returns immediately."""
+    ed = tmp_path / ".empirica"
+    open_p = _write_tx(ed, "_tmux_9", transaction_id="T-OPEN", claude_session_id="cc-1", status="open")
+    assert _find_transaction_file(ed, "_tmux_9", None, "cc-1") == open_p
+
+
 # ---- firewall hook copy mirrors the package -----------------------------
 
 


### PR DESCRIPTION
## The spurious-close bug (David-flagged, seen on `bae3e72d`)

A transaction showed `status=closed` **mid-praxic after a valid CHECK**, blocking edits with *"Epistemic loop closed"* — and only a re-PREFLIGHT cleared it.

### Root cause

`_find_transaction_file`'s **primary exact-suffix match returned the file regardless of status**:

```python
exact = empirica_dir / f"active_transaction{suffix}.json"
if exact.exists():
    return exact          # ← no status check
```

The ranked fallback scan below it *correctly* prefers `(cc_match, is_open, updated_at)` — but it only runs when the exact file is **absent**. So when the instance suffix rotates (compaction / TMUX_PANE reuse) and a **stale closed** `active_transaction_<suffix>.json` sits at the current suffix, the firewall reads *that* (closed) and denies praxic — even though the live **open** transaction (durable `claude_session_id`) exists under the old suffix. Re-PREFLIGHT writes `open` to the current exact path, which is why it "fixed" it.

### Fix

Fast-return the exact file only when it's **OPEN** or when **no key** is available. A **closed** exact file with a key present falls through to the ranked scan, which:
- prefers a key-matched **OPEN** transaction (the bug fix),
- still returns the closed file when it's the only match (**closed-read path preserved** — the firewall still says "loop closed, re-PREFLIGHT" when you genuinely POSTFLIGHTed),
- returns `None` for a foreign file (**no-crosstalk** rule, already an established invariant).

Applied to **both** copies — the package `session_resolver.py` and the hook's standalone mirror in `sentinel-gate.py` (kept in sync; `test_hook_resolver_mirrors_package` guards the parity).

### Tests

`tests/test_transaction_dual_key.py` (+3): the reproduction (closed exact must not mask an open elsewhere — **fails on the old code, passes now**), closed-exact-alone still resolves, open-exact fast-path unchanged. Full dual-key suite green (**18**), ruff + pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)