### PR TITLE
docs: align SERVE_API engagements + KNOWN_ISSUES 11.31 (docs-align sweep)

### DIFF
--- a/docs/architecture/instance_isolation/KNOWN_ISSUES.md
+++ b/docs/architecture/instance_isolation/KNOWN_ISSUES.md
@@ -896,6 +896,31 @@ verification CWD fix — 1.9.6). Tests in
 `tests/test_postflight_pipeline_restructure.py` (19 cases) and
 `tests/test_project_resolver_raise.py` (8 cases).
 
+### 11.31 Stale Closed Exact-Suffix File Masks a Live Open Transaction (2026-07-03)
+
+**Symptom:** After a valid CHECK, a praxic edit is denied mid-transaction with
+"Epistemic loop closed (POSTFLIGHT completed)" — even though the transaction is
+open. Only a re-PREFLIGHT (which writes `open` to the current exact-suffix path)
+clears it.
+
+**Root cause:** `_find_transaction_file`'s primary exact-suffix match returned
+the file regardless of `status`. The ranked fallback scan below it (which prefers
+`(cc_match, is_open, updated_at)` — see 11.21's dual-key work) only ran when the
+exact file was *absent*. So when the instance suffix rotates (compaction /
+TMUX_PANE reuse) and a stale CLOSED `active_transaction_<suffix>.json` sits at the
+current suffix, the firewall read that closed marker and denied praxic — the live
+OPEN transaction (durable `claude_session_id`) under the old suffix was masked.
+
+**Fix:** fast-return the exact file only when it's OPEN or when no key is
+available; a CLOSED exact file with a key present falls through to the ranked scan
+(which prefers a key-matched OPEN, still returns the closed file when it's the
+only match, and returns None for a foreign file per the no-crosstalk rule).
+Applied to BOTH copies — `session_resolver.py` and the `sentinel-gate.py` mirror
+(`test_hook_resolver_mirrors_package` guards parity).
+
+**Commit:** PR #238. Tests in `tests/test_transaction_dual_key.py`
+(`test_find_exact_closed_does_not_mask_open_elsewhere` + 2 companions).
+
 ---
 
 ## By Design (Not Bugs)

--- a/docs/reference/api/SERVE_API.md
+++ b/docs/reference/api/SERVE_API.md
@@ -791,8 +791,8 @@ The `EngagementMin` feed for the X2 board.
 | `org` | — | Engagements `ticket_of` this organization id |
 | `contact` | — | Engagements this contact actively participates in (`engagement_contacts`); composes (AND) with `org` |
 | `domain` | — | By engagement domain (`support`, `sales`, …) |
-| `lifecycle` | — | By `lifecycle_state` (`open`/`in_progress`/`blocked`/`closed`) |
-| `include_closed` | `false` | Include terminal engagements (active-by-default; ignored when explicit `lifecycle` given) |
+| `lifecycle` | — | By `lifecycle_state` (`planned`/`open`/`in_progress`/`blocked`/`closed`), or `all` for the full set |
+| `include_closed` | `false` | Legacy sugar — adds terminal (`closed`) back. The feed is active-by-default `{open, in_progress, blocked}`; pre-active `planned` + terminal `closed` are excluded unless requested explicitly or via `lifecycle=all`. Ignored when explicit `lifecycle` given |
 | `limit` | `100` | 1–500 |
 
 Per row: `id`, `title`, `engagement_type`, `domain`, `stage`, `lifecycle_state`, `status`, `outcome`, `started_at`, `ended_at`, `updated_at`; counts `member_count`/`goal_count`/`linked_artifact_count`; and `metadata` = the whole registry bag + synthesized `org_display` (severity, assignee, `tickets[]`, identifier, tenant, machine_state, … all pass through).


### PR DESCRIPTION
## Docs-align remediation for 1.12.12

Two doc-accuracy fixes the pre-release docs-align sweep surfaced:

1. **`SERVE_API.md` — `GET /api/v1/engagements`** was stale for planned-lifecycle: the `lifecycle` param listed only `open/in_progress/blocked/closed` (missing `planned` + the `all` sentinel), and `include_closed` didn't reflect that `planned` is now *also* default-excluded / that it's terminal-only sugar. Updated both rows to match shipped behavior.
2. **`KNOWN_ISSUES.md` 11.31 (new)** — documents the `_find_transaction_file` stale-closed-mask fix (#238): the firewall reading a stale closed exact-suffix file over a live key-matched open transaction, and the prefer-open fix. Sits in the same instance-isolation lineage as 11.21's dual-key work.

Verified accurate (no change needed): the CHANGELOG `[Unreleased]` planned-lifecycle entry, the regenerated `CLI_COMMANDS_UNIFIED.md` engagement-list entry, and the cortex-mailbox harness-portability note.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)