### PR TITLE
fix(presence): unique per-writer tmp + tolerant readers (torn-write corruption)

### DIFF
--- a/empirica/core/practitioner_presence.py
+++ b/empirica/core/practitioner_presence.py
@@ -82,6 +82,71 @@ def presence_path(claude_session_id: str) -> Path:
     return EMPIRICA_DIR / f"{_PREFIX}{_safe(claude_session_id)}.json"
 
 
+def _atomic_write_presence(path: Path, record: dict[str, Any]) -> None:
+    """Atomically publish a presence record via a UNIQUE per-writer tmp.
+
+    Many listener services sweep the SAME presence dir via
+    :func:`refresh_live_presence`, so a shared ``<name>.tmp`` was O_TRUNCed by
+    several writers at once — a shorter write landing over a longer one left a
+    torn tail, and the strict readers then skipped the file, hiding a live
+    practice PERMANENTLY (it also couldn't be re-stamped). Each writer now owns
+    its tmp (``<name>.<pid>.<ns>.tmp``); the atomic replace publishes a whole
+    record (last writer wins, always valid JSON). The tmp is cleaned up on
+    failure so a crashed write can't leak it.
+    """
+    tmp = path.with_name(f"{path.name}.{os.getpid()}.{time.time_ns()}.tmp")
+    try:
+        tmp.write_text(json.dumps(record), encoding="utf-8")
+        tmp.replace(path)  # atomic
+    except BaseException:
+        try:
+            tmp.unlink()
+        except OSError:
+            pass
+        raise
+
+
+def _load_presence(path: Path) -> dict[str, Any] | None:
+    """Read a presence record, tolerant of a torn tail (defense in depth).
+
+    A stray concurrent writer under the old shared-tmp bug — or a torn file still
+    on disk from before this fix — leaves invalid JSON that strict ``json.loads``
+    rejects, silently hiding a live practice. ``raw_decode`` recovers the leading
+    valid object so a garbage tail can't. Returns None only when the file is
+    unreadable or its leading bytes aren't a JSON object.
+    """
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    try:
+        obj: Any = json.loads(text)
+    except json.JSONDecodeError:
+        try:
+            obj, _ = json.JSONDecoder().raw_decode(text)
+        except (json.JSONDecodeError, ValueError):
+            return None
+    return obj if isinstance(obj, dict) else None
+
+
+def _sweep_stale_tmps(older_than: float = 60.0) -> int:
+    """Unlink abandoned per-writer tmps (crashed mid-write). Conservative: only
+    tmps older than ``older_than`` seconds — a live writer's tmp exists for <1s,
+    so this never races an in-flight write. Returns the count removed."""
+    if not EMPIRICA_DIR.exists():
+        return 0
+    cutoff = time.time() - older_than
+    removed = 0
+    for tmp in EMPIRICA_DIR.glob(f"{_PREFIX}*.tmp"):
+        try:
+            if tmp.stat().st_mtime < cutoff:
+                tmp.unlink()
+                removed += 1
+        except OSError:
+            continue
+    return removed
+
+
 def write_presence(
     claude_session_id: str,
     *,
@@ -130,10 +195,7 @@ def write_presence(
         "session_pid": session_pid,
         "last_heartbeat": time.time(),
     }
-    path = presence_path(claude_session_id)
-    tmp = path.with_name(path.name + ".tmp")
-    tmp.write_text(json.dumps(record), encoding="utf-8")
-    tmp.replace(path)  # atomic
+    _atomic_write_presence(presence_path(claude_session_id), record)
     return record
 
 
@@ -141,10 +203,7 @@ def read_presence(claude_session_id: str) -> dict[str, Any] | None:
     path = presence_path(claude_session_id)
     if not path.exists():
         return None
-    try:
-        return json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        return None
+    return _load_presence(path)
 
 
 def clear_presence(claude_session_id: str) -> bool:
@@ -183,9 +242,8 @@ def list_presence(
     now = time.time()
     out: list[dict[str, Any]] = []
     for path in _all_presence_files():
-        try:
-            rec = json.loads(path.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError):
+        rec = _load_presence(path)
+        if rec is None:
             continue
         if practice_ai_id is not None and rec.get("practice_ai_id") != practice_ai_id:
             continue
@@ -231,11 +289,11 @@ def refresh_live_presence(*, now: float | None = None) -> dict[str, int]:
     ``{"refreshed", "alive", "dead", "no_pid"}``.
     """
     now = time.time() if now is None else now
+    _sweep_stale_tmps()  # hygiene: clear per-writer tmps abandoned by crashed writers
     counts = {"refreshed": 0, "alive": 0, "dead": 0, "no_pid": 0}
     for path in _all_presence_files():
-        try:
-            rec = json.loads(path.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError):
+        rec = _load_presence(path)
+        if rec is None:
             continue
         pid = rec.get("session_pid")
         if not isinstance(pid, int):
@@ -246,10 +304,8 @@ def refresh_live_presence(*, now: float | None = None) -> dict[str, int]:
             continue
         counts["alive"] += 1
         rec["last_heartbeat"] = now
-        tmp = path.with_name(path.name + ".tmp")
         try:
-            tmp.write_text(json.dumps(rec), encoding="utf-8")
-            tmp.replace(path)  # atomic
+            _atomic_write_presence(path, rec)
             counts["refreshed"] += 1
         except OSError:
             pass

--- a/tests/test_practitioner_presence.py
+++ b/tests/test_practitioner_presence.py
@@ -228,3 +228,59 @@ def test_pid_alive_probe(fake_home):
     proc = subprocess.Popen(["true"])
     proc.wait()
     assert pp._pid_alive(proc.pid) is False
+
+
+# ---- torn-write data-corruption fix (shared-tmp race) --------------------------
+
+
+def test_torn_tail_tolerated_by_readers(fake_home):
+    """A torn write (leading valid record + leftover tail from a longer prior
+    write) must NOT hide a live practice — raw_decode recovers the record."""
+    rec = {
+        "claude_session_id": "cc-torn",
+        "practice_ai_id": "empirica",
+        "status": "active",
+        "session_pid": 1,
+        "last_heartbeat": time.time(),
+    }
+    p = pp.presence_path("cc-torn")
+    # Complete record + garbage tail (what a shorter write over a longer one leaves).
+    p.write_text(json.dumps(rec) + '{"leftover": "tail from a longer previous write')
+
+    assert pp.read_presence("cc-torn")["claude_session_id"] == "cc-torn"
+    listed = pp.list_presence("empirica", include_stale=True)
+    assert any(r["claude_session_id"] == "cc-torn" for r in listed)
+
+
+def test_load_presence_none_on_pure_garbage(fake_home):
+    p = pp.presence_path("cc-junk")
+    p.write_text("not json at all")
+    assert pp._load_presence(p) is None
+
+
+def test_write_uses_unique_tmp_no_shared_collision(fake_home):
+    """Each writer owns a unique `<name>.<pid>.<ns>.tmp`; the old shared
+    `<name>.tmp` is never created, so concurrent writers can't O_TRUNC each
+    other. The atomic replace leaves no tmp behind and a complete record."""
+    pp.write_presence("cc-u", practice_ai_id="empirica")
+    path = pp.presence_path("cc-u")
+    assert not path.with_name(path.name + ".tmp").exists()  # no shared tmp
+    assert not list(pp.EMPIRICA_DIR.glob(f"{pp._PREFIX}*.tmp"))  # no tmp leaked at all
+    assert pp.read_presence("cc-u")["claude_session_id"] == "cc-u"
+    # a second write to the same path succeeds cleanly (last writer wins)
+    pp.write_presence("cc-u", practice_ai_id="empirica", status="idle")
+    assert pp.read_presence("cc-u")["status"] == "idle"
+
+
+def test_sweep_stale_tmps_removes_only_abandoned(fake_home):
+    import os
+
+    pp.EMPIRICA_DIR.mkdir(parents=True, exist_ok=True)
+    old = pp.EMPIRICA_DIR / f"{pp._PREFIX}cc-old.json.999.111.tmp"
+    fresh = pp.EMPIRICA_DIR / f"{pp._PREFIX}cc-new.json.999.222.tmp"
+    old.write_text("{}")
+    fresh.write_text("{}")
+    stamp = time.time() - 120
+    os.utime(old, (stamp, stamp))  # abandoned 2 min ago
+    assert pp._sweep_stale_tmps(older_than=60.0) == 1
+    assert not old.exists() and fresh.exists()


### PR DESCRIPTION
## Presence torn-write data corruption (mesh-support-diagnosed, verified in source)

Routed to `@core` by mesh-support (`prop_v7huhgly`), reproduced/grounded by Philipp's fleet across two fleets. **Verified against the source before fixing.**

### Root cause

`write_presence` (L134) and `refresh_live_presence` (L249) both published via a **shared per-target tmp** — `<name>.tmp`. Many `com.empirica.listener.<ai_id>` services sweep the *same* presence dir via `refresh_live_presence`, so several writers `O_TRUNC`'d the same tmp concurrently → a shorter write over a longer one left a **torn tail** → `tmp.replace` published it → the strict `json.loads` readers (3 sites) then **skipped** the file, hiding a live practice **permanently** (it couldn't even be re-stamped, since refresh also skips it).

Evidence (Philipp): torn-tail bytes, 6 files sharing one refresh mtime, single-writer CLI probe always clean ⇒ concurrency, not the serializer. This is the classic *race / shared-mutable-state* pattern (>1 writer, one key, last-write-wins clobber).

### Fix

- **PRIMARY** — `_atomic_write_presence`: unique tmp per writer (`<name>.<pid>.<ns>.tmp`) at both write sites. Each writer owns its tmp; the atomic replace publishes a whole record (last writer wins, always valid JSON). Cleans up its tmp on failure.
- **DEFENSE-IN-DEPTH** — `_load_presence`: `json.loads`, then `raw_decode` to recover the leading valid record from a torn tail. Applied at all 3 read sites — **heals files already torn on disk** so they resurface.
- **HYGIENE** — `_sweep_stale_tmps`: unlink per-writer tmps abandoned by crashed writers (mtime > 60s, never races a live <1s write); called each daemon tick.

### Tests (`tests/test_practitioner_presence.py`, +4)

torn-tail recovered by readers · pure-garbage → `None` · unique-tmp leaves no shared/leaked tmp + last-writer-wins · sweep removes only abandoned tmps. **23 pass**, ruff + pyright clean.

**Release note:** candidate for **1.12.12** pull-in (data corruption on live fleets, not just visibility) — David's call. Parts 2-3 of the broader presence-liveness goal (periodic listener heartbeat, SessionStart ai_id/pid) remain 1.12.13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)