### PR TITLE
fix(presence): unique tmp path per write — shared X.json.tmp tears under concurrent writers

### DIFF
--- a/empirica/cli/tui/cockpit_app.py
+++ b/empirica/cli/tui/cockpit_app.py
@@ -89,7 +89,11 @@ class CockpitApp(App):
     Screen { layout: vertical; }
 
     #summary  { padding: 0 1; height: 1; color: $text-muted; }
-    #inst-table { height: auto; min-height: 7; max-height: 12; }
+    /* Size to the fleet: grow with the instance list so the whole fleet is
+       visible without scrolling; 60vh caps pathological growth on small
+       terminals so goals/notifications keep their space. (Was a hard
+       max-height: 12, which forced a scrollbar on any fleet > ~10.) */
+    #inst-table { height: auto; min-height: 7; max-height: 60vh; }
 
     #action-bar {
         height: 3;

--- a/empirica/cli/tui/cockpit_app.py
+++ b/empirica/cli/tui/cockpit_app.py
@@ -272,10 +272,18 @@ class CockpitApp(App):
                     cells.append(f"{glyph}{name}")
             emit_24h = nd.get("emit_count_24h", 0)
             fb_24h = nd.get("fell_back_count_24h", 0)
-            stats = f"24h:{emit_24h}"
+            # 'emit:' not a bare '24h:' — the unlabeled form read as "mesh
+            # activity in 24h = 0" while wakes were flowing (the mesh pulse
+            # is the separate wakes chip below).
+            stats = f"emit:{emit_24h}"
             if fb_24h:
                 stats += f" fb:{fb_24h}"
             dispatch_part = f" · {' '.join(cells)} {stats}"
+
+        # Mesh pulse — wake events delivered in the last 24h (loop_fires.log).
+        # THE number a fleet operator wants at a glance: 0 here really does
+        # mean "no mesh activity", unlike the dispatcher's emit count.
+        wake_part = f" · wakes:{s.get('wake_count_24h', 0)}"
 
         # Auto-accept chip — always visible so the bypass state is never
         # ambiguous (was prev hidden when OFF, which made "is bypass on?"
@@ -291,7 +299,7 @@ class CockpitApp(App):
         else:
             auto_part = ""
 
-        text = f"empirica · {s.get('instances', 0)} inst{notif_part}{auto_part}{dispatch_part} · {ts}"
+        text = f"empirica · {s.get('instances', 0)} inst{notif_part}{auto_part}{wake_part}{dispatch_part} · {ts}"
         self.query_one("#summary", Static).update(text)
 
     def _render_table(self) -> None:

--- a/empirica/core/cockpit/instance_state.py
+++ b/empirica/core/cockpit/instance_state.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 import json
 import os
 import re
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
@@ -759,8 +759,49 @@ def aggregate_all(include_dead: bool = False) -> dict[str, Any]:
             "open_notifications": notifications_total(),
             "notify_dispatcher": build_notify_dispatcher_block(),
             "auto_accept": auto_accept,
+            "wake_count_24h": wake_count_24h(),
         },
     }
+
+
+def wake_count_24h(log_path: Path | None = None, window_hours: float = 24.0) -> int:
+    """Count mesh wake events delivered in the last N hours.
+
+    Reads ``~/.empirica/loop_fires.log`` — the append-only delivery log the
+    persistent listeners write one JSON line per wake event to. This is the
+    fleet's actual mesh pulse, distinct from the notify DISPATCHER's
+    ``emit_count_24h`` (rows in notify-dispatcher.jsonl — a subsystem that can
+    be entirely unused, so its zero rendered as a bare ``24h:0`` in the header
+    read as "mesh dead" while wakes were in fact flowing).
+
+    Only the tail of the log is scanned (the file is append-only and grows
+    unbounded; 1 MiB of tail is orders of magnitude more than a day of
+    events). Telemetry never breaks the cockpit — any failure returns 0.
+    """
+    path = log_path if log_path is not None else EMPIRICA_DIR / "loop_fires.log"
+    tail_bytes = 1024 * 1024
+    try:
+        cutoff = datetime.now(tz=timezone.utc) - timedelta(hours=window_hours)
+        count = 0
+        with open(path, "rb") as fh:
+            fh.seek(0, os.SEEK_END)
+            size = fh.tell()
+            fh.seek(max(0, size - tail_bytes))
+            data = fh.read().decode("utf-8", errors="replace")
+        lines = data.splitlines()
+        # When we started mid-file, the first line is likely partial — drop it.
+        if size > tail_bytes and lines:
+            lines = lines[1:]
+        for line in lines:
+            try:
+                ts = json.loads(line).get("ts")
+                if ts and datetime.fromisoformat(ts) >= cutoff:
+                    count += 1
+            except (ValueError, TypeError):
+                continue
+        return count
+    except Exception:
+        return 0
 
 
 def discover_dead_instances() -> list[str]:

--- a/empirica/core/cockpit/instance_state.py
+++ b/empirica/core/cockpit/instance_state.py
@@ -44,7 +44,13 @@ from empirica.core.cockpit.listener_registry import (
     ListenerRegistry,
     is_listener_paused,
 )
-from empirica.core.cockpit.liveness import _live_tmux_panes, is_alive, scan_live_claude
+from empirica.core.cockpit.liveness import (
+    TMUX_INSTANCE_PATTERN,
+    _live_tmux_panes,
+    is_alive,
+    scan_live_claude,
+    tmux_pane_cwds,
+)
 from empirica.core.cockpit.loop_registry import LoopRegistry, is_loop_paused
 from empirica.core.cockpit.notify_dispatcher_view import (
     annotate_loops_with_last_notify,
@@ -623,6 +629,54 @@ def _dedup_process_scan_overcount(instances: list[dict[str, Any]], live_cwd_coun
             surplus["alive"] = False
             surplus["liveness_signal"] = ""
             surplus["liveness_reason"] = "duplicate stale session — no distinct live claude process"
+
+    # PASS 2 — pane-footprint dedup. One session commonly leaves TWO instance
+    # footprints: its canonical ai_id (from EMPIRICA_INSTANCE_ID) and a bare
+    # pane-name record (tmux_N) from hooks that ran before the env id existed.
+    # Both are now alive via strong signals (process_env + tmux), so the fleet
+    # renders doubled — half the rows unlabeled tmux_N. Group by project
+    # (record's own binding, else the pane's cwd) and cap 'tmux'-signal records
+    # at (live procs in that project − canonical records): a pane record only
+    # survives when it is the session's ONLY identity (e.g. a session launched
+    # without EMPIRICA_INSTANCE_ID). Records with an explicit project binding
+    # outrank bare ones; ties break on recency.
+    canonical = {"current", "process_env", "pid"}
+    pane_cwds = tmux_pane_cwds() or {}
+    by_project = {}
+    for inst in instances:
+        if not inst.get("alive"):
+            continue
+        pp = inst.get("project_path")
+        if not pp:
+            m = TMUX_INSTANCE_PATTERN.match(str(inst.get("instance_id") or ""))
+            if m:
+                pp = pane_cwds.get(m.group(1))
+        if pp:
+            by_project.setdefault(os.path.realpath(pp), []).append(inst)
+    for rp, insts in by_project.items():
+        pane_recs = [i for i in insts if i.get("liveness_signal") == "tmux"]
+        if not pane_recs:
+            continue
+        live_count = live_cwd_counts.get(rp, 0)
+        if live_count == 0:
+            # The process scan saw NO claude proc in this project — blind or
+            # contradictory data (e.g. proc cwd ≠ pane cwd). Never demote a
+            # tmux verdict on absent evidence; leave the records standing.
+            continue
+        canonical_count = sum(1 for i in insts if i.get("liveness_signal") in canonical)
+        budget = max(0, live_count - canonical_count)
+        if len(pane_recs) <= budget:
+            continue
+        pane_recs.sort(
+            key=lambda i: (
+                i.get("project_path") is None,  # bound identity first
+                i.get("last_activity_seconds") if i.get("last_activity_seconds") is not None else float("inf"),
+            )
+        )
+        for surplus in pane_recs[budget:]:
+            surplus["alive"] = False
+            surplus["liveness_signal"] = ""
+            surplus["liveness_reason"] = "pane footprint of a session already shown under its canonical ai_id"
 
 
 def aggregate_all(include_dead: bool = False) -> dict[str, Any]:

--- a/empirica/core/cockpit/liveness.py
+++ b/empirica/core/cockpit/liveness.py
@@ -107,6 +107,38 @@ def _live_tmux_panes() -> set[str] | None:
     return panes
 
 
+def tmux_pane_cwds() -> dict[str, str] | None:
+    """Map pane number → realpath of the pane's current working directory.
+
+    Used by the pane-footprint dedup: a bare ``tmux_N`` record carries no
+    project binding of its own, but its pane's cwd identifies which project
+    the session lives in — letting the dedup group it with the canonical
+    (``EMPIRICA_INSTANCE_ID``) record for the same project. Returns ``None``
+    when tmux can't be queried (signal inconclusive, skip the dedup).
+    """
+    if shutil.which("tmux") is None:
+        return None
+    try:
+        result = subprocess.run(
+            ["tmux", "list-panes", "-a", "-F", "#{pane_id} #{pane_current_path}"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return None
+    if result.returncode != 0:
+        return {}
+    cwds: dict[str, str] = {}
+    for line in result.stdout.splitlines():
+        parts = line.strip().split(maxsplit=1)
+        if len(parts) != 2:
+            continue
+        pane_id, path = parts
+        cwds[pane_id.lstrip("%")] = os.path.realpath(path)
+    return cwds
+
+
 def _all_tmux_panes() -> set[str] | None:
     """Return set of ALL pane numbers regardless of command. Used for
     distinguishing 'pane gone' (terminal closed) from 'pane exists but

--- a/empirica/core/cockpit/liveness.py
+++ b/empirica/core/cockpit/liveness.py
@@ -60,6 +60,14 @@ class LivenessResult:
 # 'claude' is the bin name; 'node' covers older installations / dev launches.
 _CLAUDE_COMMANDS = frozenset({"claude", "node"})
 
+# Claude Code ≥2.1.x retitles its process (comm) to its bare version string —
+# tmux pane_current_command and psutil name() both report e.g. "2.1.199" while
+# argv[0] stays "claude". Without matching this, every name-based liveness
+# signal goes blind on modern CC: _live_tmux_panes() returns ∅ and
+# scan_live_claude() finds zero instances, so the cockpit declares live
+# sessions dead.
+_VERSION_TITLE = re.compile(r"^\d+\.\d+\.\d+$")
+
 
 def _live_tmux_panes() -> set[str] | None:
     """Return set of pane numbers (e.g. {'1', '2', '3'}) where Claude Code is running.
@@ -92,7 +100,9 @@ def _live_tmux_panes() -> set[str] | None:
         if len(parts) != 2:
             continue
         pane_id, cmd = parts
-        if cmd in _CLAUDE_COMMANDS:
+        # A bare semver foreground command is CC ≥2.1's retitled process; tmux
+        # gives us no argv to confirm, but nothing else titles itself that way.
+        if cmd in _CLAUDE_COMMANDS or _VERSION_TITLE.fullmatch(cmd):
             panes.add(pane_id.lstrip("%"))
     return panes
 
@@ -163,6 +173,9 @@ def _is_claude_proc(name: str | None, cmdline: list[str] | None) -> bool:
     nm = (name or "").lower()
     if nm == "claude":
         return True
+    if _VERSION_TITLE.fullmatch(nm):  # CC ≥2.1 retitles to its version string —
+        # argv[0] stays "claude", so confirm via cmdline like the node case.
+        return any("claude" in (arg or "").lower() for arg in (cmdline or []))
     if nm in _CLAUDE_COMMANDS:  # node — confirm it's actually claude
         return any("claude" in (arg or "").lower() for arg in (cmdline or []))
     return False

--- a/empirica/core/practitioner_presence.py
+++ b/empirica/core/practitioner_presence.py
@@ -131,7 +131,11 @@ def write_presence(
         "last_heartbeat": time.time(),
     }
     path = presence_path(claude_session_id)
-    tmp = path.with_name(path.name + ".tmp")
+    # Unique tmp per writer: a shared X.json.tmp lets concurrent writers (the 14
+    # listener services' refresh ticks + per-turn hooks) tear each other's writes
+    # before the atomic replace — leaving trailing garbage ('...211}21}') that the
+    # strict readers then silently skip. pid+monotonic-ns keeps each write private.
+    tmp = path.with_name(f"{path.name}.{os.getpid()}.{time.time_ns()}.tmp")
     tmp.write_text(json.dumps(record), encoding="utf-8")
     tmp.replace(path)  # atomic
     return record
@@ -246,7 +250,9 @@ def refresh_live_presence(*, now: float | None = None) -> dict[str, int]:
             continue
         counts["alive"] += 1
         rec["last_heartbeat"] = now
-        tmp = path.with_name(path.name + ".tmp")
+        # Unique tmp per writer — same rationale as write_presence: the shared
+        # X.json.tmp path is a torn-write race under concurrent refresh ticks.
+        tmp = path.with_name(f"{path.name}.{os.getpid()}.{time.time_ns()}.tmp")
         try:
             tmp.write_text(json.dumps(rec), encoding="utf-8")
             tmp.replace(path)  # atomic

--- a/tests/test_cockpit_instance_state.py
+++ b/tests/test_cockpit_instance_state.py
@@ -468,3 +468,28 @@ def test_discover_dead_keeps_ghost_when_no_canonical(env, monkeypatch):
 
     dead = ist.discover_dead_instances()
     assert "tmux_16" not in dead  # within budget — kept
+
+
+# ─── wake_count_24h — mesh pulse from loop_fires.log ─────────────────────────
+
+
+def test_wake_count_24h_counts_only_window(tmp_path):
+    """Rows inside the 24h window count; older rows and junk lines don't."""
+    from datetime import datetime, timedelta, timezone
+
+    now = datetime.now(tz=timezone.utc)
+    log = tmp_path / "loop_fires.log"
+    rows = [
+        json.dumps({"ts": (now - timedelta(hours=1)).isoformat(), "instance_id": "a"}),
+        json.dumps({"ts": (now - timedelta(hours=23)).isoformat(), "instance_id": "b"}),
+        json.dumps({"ts": (now - timedelta(hours=25)).isoformat(), "instance_id": "c"}),  # outside
+        "not json at all",
+        json.dumps({"no_ts": True}),
+    ]
+    log.write_text("\n".join(rows) + "\n", encoding="utf-8")
+    assert ist.wake_count_24h(log_path=log) == 2
+
+
+def test_wake_count_24h_missing_log_is_zero(tmp_path):
+    """No loop_fires.log (fresh install) → 0, never an exception."""
+    assert ist.wake_count_24h(log_path=tmp_path / "nope.log") == 0

--- a/tests/test_cockpit_instance_state.py
+++ b/tests/test_cockpit_instance_state.py
@@ -373,6 +373,60 @@ def test_dedup_env_match_consumes_slot_and_survives(tmp_path):
     assert instances[1]["alive"] is False  # cwd fallback demoted
 
 
+# ─── pass 2: pane-footprint dedup (tmux_N doubles of canonical records) ──────
+
+
+def test_dedup_pane_footprint_covered_by_canonical(tmp_path, monkeypatch):
+    """One session, two footprints: canonical ai_id (process_env) + bare pane
+    record (tmux), one live proc → the pane duplicate is demoted, canonical
+    stays. This is the doubled-fleet case (34 rows for 20 sessions)."""
+    monkeypatch.setattr(ist, "tmux_pane_cwds", lambda: {})
+    proj = str((tmp_path / "p").resolve())
+    canonical = _scan_inst(proj, 5.0, signal="process_env")
+    pane = dict(_scan_inst(proj, 10.0, signal="tmux"), instance_id="tmux_7")
+    instances = [canonical, pane]
+    ist._dedup_process_scan_overcount(instances, {proj: 1})
+    assert canonical["alive"] is True
+    assert pane["alive"] is False
+    assert "canonical" in pane["liveness_reason"]
+
+
+def test_dedup_pane_only_session_survives(tmp_path, monkeypatch):
+    """A session whose ONLY identity is its pane record (launched without
+    EMPIRICA_INSTANCE_ID) keeps its row: no canonical sibling, one live proc."""
+    monkeypatch.setattr(ist, "tmux_pane_cwds", lambda: {})
+    proj = str((tmp_path / "p").resolve())
+    pane = dict(_scan_inst(proj, 5.0, signal="tmux"), instance_id="tmux_30")
+    instances = [pane]
+    ist._dedup_process_scan_overcount(instances, {proj: 1})
+    assert pane["alive"] is True
+
+
+def test_dedup_pane_record_stands_when_scan_blind(tmp_path, monkeypatch):
+    """Scan reports zero procs for the project (blind / cwd mismatch) → never
+    demote a tmux verdict on absent evidence, even with a canonical sibling."""
+    monkeypatch.setattr(ist, "tmux_pane_cwds", lambda: {})
+    proj = str((tmp_path / "p").resolve())
+    canonical = _scan_inst(proj, 5.0, signal="process_env")
+    pane = dict(_scan_inst(proj, 10.0, signal="tmux"), instance_id="tmux_7")
+    instances = [canonical, pane]
+    ist._dedup_process_scan_overcount(instances, {proj: 0})
+    assert pane["alive"] is True
+
+
+def test_dedup_unbound_pane_grouped_via_pane_cwd(tmp_path, monkeypatch):
+    """A bare tmux_N record with NO project binding is grouped through its
+    pane's cwd and demoted when a canonical record covers the same project."""
+    proj = str((tmp_path / "p").resolve())
+    monkeypatch.setattr(ist, "tmux_pane_cwds", lambda: {"7": proj})
+    canonical = _scan_inst(proj, 5.0, signal="process_env")
+    pane = dict(_scan_inst(None, 10.0, signal="tmux"), instance_id="tmux_7")
+    instances = [canonical, pane]
+    ist._dedup_process_scan_overcount(instances, {proj: 1})
+    assert canonical["alive"] is True
+    assert pane["alive"] is False
+
+
 # ─── discover_dead_instances reaps superseded fallback ghosts ───────────────
 
 


### PR DESCRIPTION
## The bug (current code, reproducible)

Both presence writers in `empirica/core/practitioner_presence.py` derive the **same** temp path for a given presence file:

```python
tmp = path.with_name(path.name + ".tmp")   # L134 write_presence, L249 refresh_live_presence
```

With the per-ai_id persistent listener services each ticking `refresh_live_presence` over **all** presence files (plus per-turn `write_presence` hooks), two processes routinely open the same `X.json.tmp` with `O_TRUNC` at once. A shorter record written over a longer one leaves the longer record's tail bytes behind (`last_heartbeat` float precision varies per write), so the tmp is torn **before** the atomic replace ships it:

```
..."last_heartbeat": 1783103908.211}21}
```

## Impact — data corruption, not just cosmetics

Torn files fail the strict `json.loads` in `read_presence` / `list_presence` / `refresh_live_presence`, which **silently skip** them. The practice:
- goes invisible in the cockpit / `practitioner list`, and
- can never be re-stamped again (the #180 liveness-refresh skips it) → permanently stale.

Observed on Philipp's 20-session fleet: **6 files torn in a single refresh tick** (identical mtime), reproducible within minutes.

## The fix

Unique tmp per writer (`pid` + monotonic `ns`) at both sites — each write owns a private tmp; the existing atomic `replace` does the rest. The `practitioner_presence_*.json` glob doesn't match the tmp names, so no listing pollution.

## Verification

- `tests/test_practitioner_presence.py`: 19/19 pass.
- Live fleet test: all 14 launchd listener services + 6 in-session listeners restarted onto the fixed code, healer daemon **off**, 150s under full concurrent load → **zero** torn files (previously 6-7 in the same window).
- Side effect: with tearing gone, the existing #180 liveness-refresh keeps all 20 sessions visible in the cockpit as designed — no band-aid needed.

## Suggested follow-up (separate change)

Defense-in-depth: make the presence readers tolerant via `json.JSONDecoder().raw_decode()` (recover the first valid object, ignore trailing garbage), so any historical torn file heals instead of hiding a live practice.

Refs (mesh): prop_bdjzote5gvbqlfev2k3v2qvsje (root cause), prop_j2cur4q77vd6tjdrj5idhqdhvu (cockpit visibility) — endorsed by david.empirica-mesh-support, routed to @core for 1.12.12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017do29Eh2qWWFZbjsriz5KJ