### PR TITLE
fix(presence): pid-liveness override — live process stays visible past stale heartbeat

### DIFF
--- a/empirica/core/practitioner_presence.py
+++ b/empirica/core/practitioner_presence.py
@@ -251,6 +251,19 @@ def list_presence(
         last = rec.get("last_heartbeat")
         age = (now - last) if isinstance(last, (int, float)) else None
         rec["stale"] = age is None or age > threshold
+        # pid-liveness override: an alive process is PRESENT even with a stale
+        # heartbeat. Idle-at-prompt panes fire no UserPromptSubmit, so
+        # heartbeat-recency alone under-shows the live fleet — the daemon's
+        # refresh_live_presence re-stamp helps, but readers must not depend on
+        # its cadence. A `kill -0`-alive session_pid is authoritative liveness,
+        # so it keeps the record visible regardless of the heartbeat age. Local
+        # pids only (presence files are per-box), consistent with the daemon's
+        # own `_pid_alive` usage. `pid_alive` is surfaced so callers can tell a
+        # heartbeat-fresh record from one kept alive purely by its process.
+        pid = rec.get("session_pid")
+        rec["pid_alive"] = isinstance(pid, int) and _pid_alive(pid)
+        if rec["stale"] and rec["pid_alive"]:
+            rec["stale"] = False
         if rec["stale"] and not include_stale:
             continue
         out.append(rec)

--- a/tests/test_practitioner_presence.py
+++ b/tests/test_practitioner_presence.py
@@ -284,3 +284,46 @@ def test_sweep_stale_tmps_removes_only_abandoned(fake_home):
     os.utime(old, (stamp, stamp))  # abandoned 2 min ago
     assert pp._sweep_stale_tmps(older_than=60.0) == 1
     assert not old.exists() and fresh.exists()
+
+
+# ---- pid-liveness visibility override (invisible-idle-fleet fix) ---------------
+
+
+def _make_stale(claude_session_id: str):
+    """Backdate a presence file's heartbeat well past the default stale window."""
+    p = pp.presence_path(claude_session_id)
+    d = json.loads(p.read_text())
+    d["last_heartbeat"] = time.time() - (pp.DEFAULT_STALE_AFTER_S + 60)
+    p.write_text(json.dumps(d))
+
+
+def test_stale_heartbeat_but_live_pid_stays_visible(fake_home):
+    """An idle-at-prompt session (stale heartbeat) whose process is alive must
+    still show — the daemon-refresh cadence must not be the only thing keeping it
+    visible. kill -0 on session_pid is authoritative."""
+    import os
+
+    pp.write_presence("cc-live", practice_ai_id="empirica", session_pid=os.getpid())
+    _make_stale("cc-live")
+    rows = pp.list_presence("empirica")  # default excludes stale
+    assert len(rows) == 1
+    assert rows[0]["claude_session_id"] == "cc-live"
+    assert rows[0]["stale"] is False and rows[0]["pid_alive"] is True
+
+
+def test_stale_heartbeat_dead_pid_excluded(fake_home):
+    import subprocess
+
+    proc = subprocess.Popen(["true"])
+    proc.wait()  # pid now dead
+    pp.write_presence("cc-dead", practice_ai_id="empirica", session_pid=proc.pid)
+    _make_stale("cc-dead")
+    assert pp.list_presence("empirica") == []  # stale + dead → excluded
+    everyone = pp.list_presence("empirica", include_stale=True)
+    assert len(everyone) == 1 and everyone[0]["stale"] is True and everyone[0]["pid_alive"] is False
+
+
+def test_stale_heartbeat_no_pid_excluded(fake_home):
+    pp.write_presence("cc-nopid", practice_ai_id="empirica")  # no session_pid
+    _make_stale("cc-nopid")
+    assert pp.list_presence("empirica") == []  # legacy/no-pid record ages out normally


### PR DESCRIPTION
## Presence liveness — part 1/3 (pid-based visibility)

The **PRIMARY** fix of the mesh-support-routed presence-liveness work (the *invisible-idle-fleet* class: `kill -0` verified 20/20 alive, 17 hidden).

`practitioner-list`, `empirica status`, the cortex heartbeat emitter, `resolve_practitioners` (→ sentinel control verbs + autonomy's watch-sweep) all read presence through **`list_presence`**, which filters by `last_heartbeat` recency. An idle-at-prompt session fires no `UserPromptSubmit`, so its heartbeat goes stale and it **ages out of the fleet view** — though the process is alive and waiting. The daemon's `refresh_live_presence` re-stamp helps, but readers must not *depend* on its cadence.

### Fix

`list_presence` now applies a **pid-liveness override**: a `kill -0`-alive `session_pid` keeps the record non-stale regardless of heartbeat age (authoritative liveness), and a `pid_alive` flag is surfaced so callers can tell a heartbeat-fresh record from one kept alive purely by its process. Local pids only (presence is per-box), consistent with `refresh_live_presence`'s own `_pid_alive` usage. One change at the chokepoint → propagates to every reader.

### Tests (+3)

stale + live-pid stays visible (`stale=False`, `pid_alive=True`) · stale + dead-pid excluded · stale + no-pid ages out normally. 26 pass, ruff + pyright clean.

Part 2 (periodic listener-emitted heartbeat) and part 3 (SessionStart ai_id resolve + pid re-stamp on resume) follow as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)