### PR TITLE
fix(loops): guard ghost canonical-loop units — placeholder refusal + cron→calendar

### DIFF
--- a/empirica/cli/command_handlers/cockpit_commands.py
+++ b/empirica/cli/command_handlers/cockpit_commands.py
@@ -966,8 +966,32 @@ def handle_loop_tick_command(args) -> int:
     """systemd-user service ExecStart target. Appends one JSON event to the
     fires log; the Monitor bridge tails this and relays into the running
     Claude session. Must succeed even on systems without systemd (the log
-    write is the contract; the timer mechanism is separate)."""
+    write is the contract; the timer mechanism is separate).
+
+    Ghost-fire guard: a stale/ghost unit — an old
+    ``com.empirica.loop.<placeholder>.*`` or a loop whose registry entry was
+    removed without its timer — must not keep appending wake events. Refuse a
+    placeholder instance id or a loop not in the instance's registry (clean
+    skip, exit 0 — the scheduler unit itself should be removed, but a ghost
+    tick must not pollute the fires log meanwhile)."""
     from empirica.core.loop_scheduler import SystemdLoopScheduler
+    from empirica.core.loop_scheduler.launchd import is_placeholder_instance
+
+    if is_placeholder_instance(args.instance_id):
+        return _emit(
+            args,
+            {"ok": True, "skipped": "placeholder_instance", "instance_id": args.instance_id, "name": args.name},
+            f"tick skipped: placeholder instance {args.instance_id!r} (ghost unit — remove it)",
+        )
+    try:
+        if LoopRegistry(args.instance_id).get(args.name) is None:
+            return _emit(
+                args,
+                {"ok": True, "skipped": "not_registered", "instance_id": args.instance_id, "name": args.name},
+                f"tick skipped: {args.instance_id}/{args.name} not in registry (ghost unit — remove it)",
+            )
+    except Exception:
+        pass  # registry read is best-effort — never block a legit tick on a read hiccup
 
     try:
         path = SystemdLoopScheduler.tick(args.instance_id, args.name)

--- a/empirica/core/loop_scheduler/launchd.py
+++ b/empirica/core/loop_scheduler/launchd.py
@@ -113,6 +113,50 @@ def parse_interval_seconds(interval: str | int) -> int:
     return secs
 
 
+# Placeholder / unresolved instance ids — a loop unit must NEVER be installed
+# under one; it produces ghost com.empirica.loop.<placeholder>.* units that map
+# to no real practitioner and can never be reconciled. Callers must resolve the
+# real ai_id before enable(). Shared by both schedulers (systemd imports these).
+PLACEHOLDER_INSTANCE_IDS = frozenset({"project", "unknown", "none", ""})
+
+
+def is_placeholder_instance(instance_id: str | None) -> bool:
+    """True if `instance_id` is unset or a known unresolved placeholder."""
+    return instance_id is None or str(instance_id).strip().lower() in PLACEHOLDER_INSTANCE_IDS
+
+
+def looks_like_cron(spec: str | int) -> bool:
+    """True if `spec` is a 5-field cron expression (vs an interval like '30s')."""
+    return isinstance(spec, str) and len(spec.split()) == 5
+
+
+_CRON_FIELD_KEYS = ("Minute", "Hour", "Day", "Month", "Weekday")
+
+
+def cron_to_launchd_calendar(cron: str) -> dict[str, int]:
+    """Parse a 5-field cron (``M H D Mo W``) into a launchd StartCalendarInterval
+    dict. Only fixed integers + ``*`` (wildcard → omitted) are supported; ranges,
+    steps and lists raise ValueError — a daily cron must never silently degrade
+    to a 30-second timer, so we refuse what we can't map exactly. launchd's
+    ``Weekday`` is 0-7 (0/7 = Sunday), matching cron, so it passes through."""
+    fields = cron.split()
+    if len(fields) != 5:
+        raise ValueError(f"expected a 5-field cron expression, got {cron!r}")
+    out: dict[str, int] = {}
+    for key, field in zip(_CRON_FIELD_KEYS, fields):
+        if field == "*":
+            continue
+        if not field.isdigit():
+            raise ValueError(
+                f"cron field {key}={field!r} unsupported (only fixed integers or '*' — "
+                f"ranges/steps/lists can't map to a launchd calendar entry)"
+            )
+        out[key] = int(field)
+    if not out:
+        raise ValueError(f"cron {cron!r} is all-wildcard; use an interval loop, not a calendar schedule")
+    return out
+
+
 def _launchctl(*args: str, check: bool = False) -> subprocess.CompletedProcess:
     return subprocess.run(
         ["launchctl", *args],
@@ -175,10 +219,21 @@ class LaunchdLoopScheduler:
 
     def enable(self, instance_id: str, name: str, interval: str | int) -> LoopUnitFiles:
         """Write the agent plist + launchctl load -w it (persistent until
-        explicit unload). Returns the on-disk path."""
+        explicit unload). Returns the on-disk path.
+
+        Refuses a placeholder/unresolved ``instance_id`` (no ghost
+        ``com.empirica.loop.<placeholder>.*`` units). A cron-shaped ``interval``
+        (5 fields) installs a ``StartCalendarInterval`` — a daily cron must never
+        become a 30-second ``StartInterval`` timer; anything else is an interval
+        timer in seconds.
+        """
+        if is_placeholder_instance(instance_id):
+            raise ValueError(
+                f"refusing to install a loop under placeholder instance id {instance_id!r} — "
+                "resolve the real ai_id first (guards ghost com.empirica.loop.<placeholder>.* units)"
+            )
         paths = self.unit_paths(instance_id, name)
         label = _label(instance_id, name)
-        seconds = parse_interval_seconds(interval)
 
         plist_dict = {
             "Label": label,
@@ -189,7 +244,6 @@ class LaunchdLoopScheduler:
                 instance_id,
                 name,
             ],
-            "StartInterval": seconds,
             "RunAtLoad": False,
             # Agent stdout/stderr → /tmp for debugging (macOS launchd
             # convention). S108 noqa: launchd agents expect /tmp paths
@@ -199,13 +253,20 @@ class LaunchdLoopScheduler:
             # Don't restart on exit — `tick` is a one-shot, completion is success.
             "KeepAlive": False,
         }
+        if looks_like_cron(interval):
+            plist_dict["StartCalendarInterval"] = cron_to_launchd_calendar(str(interval))
+            sched_desc = f"cron {interval!r}"
+        else:
+            seconds = parse_interval_seconds(interval)
+            plist_dict["StartInterval"] = seconds
+            sched_desc = f"every {seconds}s"
         with open(paths.plist, "wb") as f:
             plistlib.dump(plist_dict, f)
 
         # `launchctl load -w <path>` loads the agent and marks it enabled
         # in the user database so it persists across logout/login.
         _launchctl("load", "-w", str(paths.plist), check=True)
-        logger.info(f"launchd loop enabled: {label} (every {seconds}s)")
+        logger.info(f"launchd loop enabled: {label} ({sched_desc})")
         return paths
 
     def disable(self, instance_id: str, name: str) -> bool:

--- a/empirica/core/loop_scheduler/systemd.py
+++ b/empirica/core/loop_scheduler/systemd.py
@@ -41,7 +41,36 @@ import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 
+# Shared placeholder-instance + cron-detection helpers live in launchd (the
+# other backend); import them so both schedulers reject the same ghost inputs
+# from a single source of truth. launchd does not import systemd → no cycle.
+from empirica.core.loop_scheduler.launchd import is_placeholder_instance, looks_like_cron
+
 logger = logging.getLogger(__name__)
+
+
+def cron_to_systemd_oncalendar(cron: str) -> str:
+    """Map a simple 5-field cron (``M H D Mo W``) to a systemd OnCalendar string.
+
+    Supports a fixed minute + hour with wildcard day/month/weekday — the
+    canonical daily-at-a-time loops (e.g. ``17 3 * * *`` → ``*-*-* 03:17:00``).
+    Ranges/steps/lists, non-integer minute/hour, and non-wildcard
+    day/month/weekday raise ValueError rather than mis-schedule — a daily cron
+    must never silently become a 30-second timer.
+    """
+    fields = cron.split()
+    if len(fields) != 5:
+        raise ValueError(f"expected a 5-field cron expression, got {cron!r}")
+    minute, hour, dom, month, dow = fields
+    for label, value in (("minute", minute), ("hour", hour)):
+        if not value.isdigit():
+            raise ValueError(f"cron {label}={value!r} must be a fixed integer for a calendar schedule (got {cron!r})")
+    if not (dom == "*" and month == "*" and dow == "*"):
+        raise ValueError(
+            f"cron {cron!r}: only fixed minute+hour with wildcard day/month/weekday is supported "
+            "for the systemd OnCalendar mapping"
+        )
+    return f"*-*-* {int(hour):02d}:{int(minute):02d}:00"
 
 
 # Sanitize instance_id / loop name for unit-file naming. systemd accepts
@@ -162,6 +191,22 @@ Unit={unit_name}.service
 WantedBy=timers.target
 """
 
+_CRON_TIMER_TEMPLATE = """\
+[Unit]
+Description=Empirica canonical loop timer — {name} (instance: {instance_id})
+
+[Timer]
+# Calendar schedule (cron {cron}). Persistent=true so a fire missed while the
+# machine was asleep runs once on wake, rather than being silently skipped.
+OnCalendar={oncalendar}
+Persistent=true
+AccuracySec=1s
+Unit={unit_name}.service
+
+[Install]
+WantedBy=timers.target
+"""
+
 
 # ── Scheduler ────────────────────────────────────────────────────────────
 
@@ -216,6 +261,11 @@ class SystemdLoopScheduler:
         Raises:
             subprocess.CalledProcessError on systemctl failures.
         """
+        if is_placeholder_instance(instance_id):
+            raise ValueError(
+                f"refusing to install a loop under placeholder instance id {instance_id!r} — "
+                "resolve the real ai_id first (guards ghost empirica-loop-<placeholder>-* units)"
+            )
         paths = self.unit_paths(instance_id, name)
         unit_name = _unit_name(instance_id, name)
 
@@ -227,19 +277,31 @@ class SystemdLoopScheduler:
             ),
             encoding="utf-8",
         )
-        paths.timer.write_text(
-            _TIMER_TEMPLATE.format(
+        # cron-shaped interval → OnCalendar timer (a daily cron must never become
+        # a repeating OnUnitActiveSec interval); otherwise the interval timer.
+        if looks_like_cron(interval):
+            oncalendar = cron_to_systemd_oncalendar(str(interval))
+            timer_unit = _CRON_TIMER_TEMPLATE.format(
+                name=name,
+                instance_id=instance_id,
+                cron=interval,
+                oncalendar=oncalendar,
+                unit_name=unit_name,
+            )
+            sched_desc = f"cron {interval!r} → OnCalendar {oncalendar}"
+        else:
+            timer_unit = _TIMER_TEMPLATE.format(
                 name=name,
                 instance_id=instance_id,
                 interval=interval,
                 unit_name=unit_name,
-            ),
-            encoding="utf-8",
-        )
+            )
+            sched_desc = f"every {interval}"
+        paths.timer.write_text(timer_unit, encoding="utf-8")
 
         _systemctl("daemon-reload", check=True)
         _systemctl("enable", "--now", f"{unit_name}.timer", check=True)
-        logger.info(f"systemd loop enabled: {unit_name}.timer (every {interval})")
+        logger.info(f"systemd loop enabled: {unit_name}.timer ({sched_desc})")
         return paths
 
     def disable(self, instance_id: str, name: str) -> bool:

--- a/tests/test_loop_scheduler_cron_guards.py
+++ b/tests/test_loop_scheduler_cron_guards.py
@@ -1,0 +1,100 @@
+"""Canonical-loop ghost-unit guards: placeholder-instance refusal + cron→calendar
+mapping (a daily cron must never silently degrade to a 30-second timer).
+
+Fleet-wide fix (mesh-support-routed): the auto-register→enable path could install
+ghost `com.empirica.loop.project.*` units and map a `kind=cron` loop to
+`StartInterval=30`. These test the caller-independent chokepoint guards.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from empirica.core.loop_scheduler.launchd import (
+    cron_to_launchd_calendar,
+    is_placeholder_instance,
+    looks_like_cron,
+)
+from empirica.core.loop_scheduler.systemd import cron_to_systemd_oncalendar
+
+
+@pytest.mark.parametrize("iid", ["project", "unknown", "none", "None", "", "  ", None])
+def test_placeholder_instances_detected(iid):
+    assert is_placeholder_instance(iid) is True
+
+
+@pytest.mark.parametrize("iid", ["empirica", "cortex", "empirica-autonomy", "outreach"])
+def test_real_instances_not_placeholder(iid):
+    assert is_placeholder_instance(iid) is False
+
+
+def test_looks_like_cron_distinguishes_from_interval():
+    assert looks_like_cron("17 3 * * *") is True
+    assert looks_like_cron("* * * * *") is True  # 5 fields
+    assert looks_like_cron("30s") is False
+    assert looks_like_cron("5m") is False
+    assert looks_like_cron(30) is False  # int interval
+
+
+# ---- launchd StartCalendarInterval mapping -----------------------------------
+
+
+def test_cron_to_launchd_calendar_daily():
+    # message-cleanup: 03:17 daily → Minute/Hour only, wildcards omitted.
+    assert cron_to_launchd_calendar("17 3 * * *") == {"Minute": 17, "Hour": 3}
+
+
+def test_cron_to_launchd_calendar_weekday_passes_through():
+    # cron Weekday 0-7 (0/7=Sun) matches launchd — Sundays 04:00.
+    assert cron_to_launchd_calendar("0 4 * * 0") == {"Minute": 0, "Hour": 4, "Weekday": 0}
+
+
+def test_cron_to_launchd_calendar_rejects_unmappable():
+    # ranges / steps / lists must fail loud, never silently mis-fire.
+    for bad in ("*/5 * * * *", "0-30 3 * * *", "0 3 1,15 * *"):
+        with pytest.raises(ValueError):
+            cron_to_launchd_calendar(bad)
+
+
+def test_cron_to_launchd_calendar_rejects_all_wildcard():
+    with pytest.raises(ValueError):
+        cron_to_launchd_calendar("* * * * *")  # every-minute → use an interval loop
+
+
+# ---- systemd OnCalendar mapping ----------------------------------------------
+
+
+def test_cron_to_systemd_oncalendar_daily():
+    assert cron_to_systemd_oncalendar("17 3 * * *") == "*-*-* 03:17:00"
+    assert cron_to_systemd_oncalendar("0 0 * * *") == "*-*-* 00:00:00"
+
+
+def test_cron_to_systemd_oncalendar_rejects_wildcard_minute_hour():
+    for bad in ("* 3 * * *", "17 * * * *", "*/5 * * * *"):
+        with pytest.raises(ValueError):
+            cron_to_systemd_oncalendar(bad)
+
+
+def test_cron_to_systemd_oncalendar_rejects_dom_month_weekday():
+    for bad in ("0 3 1 * *", "0 3 * 6 *", "0 4 * * 0"):
+        with pytest.raises(ValueError):
+            cron_to_systemd_oncalendar(bad)
+
+
+# ---- loop tick ghost-fire guard ----------------------------------------------
+
+
+def test_loop_tick_skips_placeholder_instance(monkeypatch):
+    """A ghost tick under a placeholder instance must NOT append a fire event."""
+    from types import SimpleNamespace
+
+    from empirica.cli.command_handlers import cockpit_commands as cc
+    from empirica.core.loop_scheduler import SystemdLoopScheduler
+
+    def _must_not_run(*a, **kw):
+        raise AssertionError("SystemdLoopScheduler.tick must not run for a placeholder instance")
+
+    monkeypatch.setattr(SystemdLoopScheduler, "tick", staticmethod(_must_not_run))
+    args = SimpleNamespace(instance_id="project", name="message-cleanup", output="json")
+    rc = cc.handle_loop_tick_command(args)
+    assert rc == 0  # clean skip (ok:True), not the error path — and tick never ran

--- a/tests/test_loop_scheduler_systemd.py
+++ b/tests/test_loop_scheduler_systemd.py
@@ -124,6 +124,26 @@ def test_enable_uses_default_empirica_bin_when_unspecified(fake_systemd_env):
     assert "ExecStart=empirica loop tick inst loop" in paths.service.read_text()
 
 
+def test_enable_refuses_placeholder_instance(fake_systemd_env):
+    """No ghost empirica-loop-<placeholder>-* units — a placeholder instance id
+    is refused before any unit is written."""
+    with patch.object(subprocess, "run", lambda *a, **kw: _fake_run(returncode=0)):
+        sched = SystemdLoopScheduler()
+        with pytest.raises(ValueError, match="placeholder instance"):
+            sched.enable("project", "message-cleanup", "30s")
+
+
+def test_enable_cron_writes_oncalendar_not_interval(fake_systemd_env):
+    """A daily cron installs an OnCalendar timer, never a 30s-ish interval timer."""
+    with patch.object(subprocess, "run", lambda *a, **kw: _fake_run(returncode=0)):
+        sched = SystemdLoopScheduler()
+        paths = sched.enable("empirica", "message-cleanup", "17 3 * * *")
+    timer = paths.timer.read_text()
+    assert "OnCalendar=*-*-* 03:17:00" in timer
+    assert "Persistent=true" in timer
+    assert "OnUnitActiveSec" not in timer
+
+
 # ── disable() ───────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Ghost canonical-loop units (fleet-wide, mesh-support-routed)

Two defects in the auto-register→`enable()` path let ghost launchd/systemd units accumulate across the fleet:
1. an unresolved instance **placeholder** (`project`) → `com.empirica.loop.project.*` units mapping to no real practitioner;
2. a `kind=cron` loop (`"17 3 * * *"` daily) fell back to a **30s `StartInterval` timer** → ~213 ghost fires / 4h (inflating `wakes:N`).

The exact upstream 30s-substitution caller varies (service/shell), so the fix is **caller-independent guards at the chokepoints**:

### 1. Placeholder refusal (`enable()`, both backends)
`is_placeholder_instance` / `PLACEHOLDER_INSTANCE_IDS = {project, unknown, none, ""}` — `enable()` raises before writing any unit. No more ghost `*.project.*` units regardless of caller.

### 2. cron → real calendar schedule (`enable()`, both backends)
A cron-shaped interval (5 fields) installs a real calendar schedule instead of a timer:
- **launchd** → `StartCalendarInterval` (`cron_to_launchd_calendar`)
- **systemd** → `OnCalendar` + `Persistent=true` (`cron_to_systemd_oncalendar`)

Unmappable crons (ranges/steps/lists, all-wildcard, wildcard minute/hour) **raise** rather than mis-fire — a daily cron never silently degrades to a 30s timer.

### 3. `loop tick` ghost-fire guard
`handle_loop_tick_command` refuses a placeholder instance or a loop not in the instance registry (clean skip, exit 0) — a surviving ghost unit can't keep polluting the fires log while it's being cleaned up.

Shared helpers live in `launchd` (single source of truth; `systemd` imports them, no cycle — parity by construction).

### Tests
`test_loop_scheduler_cron_guards.py` (new, 20): placeholder detection, cron-vs-interval detection, launchd + systemd cron mappings incl. the reject-unmappable cases, and the tick placeholder-skip. Plus 2 systemd `enable` tests (placeholder refusal, cron→OnCalendar). **76 loop/cockpit tests green**, ruff + pyright clean.

Interim: mesh-support can quarantine stray `com.empirica.loop.project.*` units on already-affected boxes; this stops new ones fleet-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)