### PR TITLE
fix(presence): re-stamp session_pid on claude --resume (liveness T3, part 3/3)

### DIFF
--- a/empirica/plugins/claude-code-integration/hooks/session-init.py
+++ b/empirica/plugins/claude-code-integration/hooks/session-init.py
@@ -1079,6 +1079,46 @@ def _bootstrap_for_existing_session(session_id: str, project_root: Path) -> bool
         return False
 
 
+def _write_practitioner_presence(claude_session_id: str, ai_id: str, empirica_session_id: str) -> None:
+    """Best-effort presence write/refresh, keyed on the durable claude_session_id.
+
+    Stamps ``session_pid`` = ``os.getppid()`` (the Claude Code parent — this hook
+    is spawned by CC). That pid is the daemon's liveness anchor: both
+    ``refresh_live_presence`` and ``list_presence``'s pid-liveness override
+    (``kill -0``) key off it to keep an alive-but-quiet session visible. Called on
+    BOTH new-session init AND resume — on ``claude --resume`` the OS gives the
+    session a fresh CC parent, so re-stamping keeps the pid current (a stale pid
+    would make the resumed session read as dead and vanish from the fleet).
+    Never fails session-init on a presence write.
+    """
+    if not claude_session_id:
+        return
+    try:
+        subprocess.run(
+            [
+                "empirica",
+                "practitioner",
+                "write",
+                "--session",
+                claude_session_id,
+                "--ai-id",
+                ai_id,
+                "--empirica-session",
+                empirica_session_id,
+                "--session-pid",
+                str(os.getppid()),
+                "--output",
+                "json",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            stdin=subprocess.DEVNULL,
+        )
+    except Exception:
+        pass
+
+
 def _handle_resume_path(claude_session_id: str, project_root: Path, ai_id: str) -> bool:
     """Handle resume path: detect existing session, update anchors, exit if found.
 
@@ -1092,6 +1132,12 @@ def _handle_resume_path(claude_session_id: str, project_root: Path, ai_id: str) 
     session_id = existing["session_id"]
     _write_instance_projects(str(project_root), claude_session_id, session_id)
     bootstrap_ok = _bootstrap_for_existing_session(session_id, project_root)
+
+    # Re-stamp presence with the RESUMED session's fresh CC-parent pid. A resume
+    # runs under a new process, so the pid captured at first launch is now dead;
+    # without this re-stamp the pid-liveness readers (part 1) kill -0 a dead pid
+    # and mark the resumed session gone, vanishing it from the fleet view.
+    _write_practitioner_presence(claude_session_id, ai_id, session_id)
 
     output = {
         "ok": True,
@@ -1513,36 +1559,8 @@ def main():
         _write_instance_projects(str(project_root), claude_session_id, result["session_id"])
         # Register practitioner presence, keyed on the durable claude_session_id
         # (survives compaction; the empirica session_id rotates per compact
-        # window). Best-effort — never fail session-init on a presence write.
-        if claude_session_id:
-            try:
-                subprocess.run(
-                    [
-                        "empirica",
-                        "practitioner",
-                        "write",
-                        "--session",
-                        claude_session_id,
-                        "--ai-id",
-                        ai_id,
-                        "--empirica-session",
-                        result["session_id"],
-                        # The Claude Code parent PID — this hook is spawned by CC,
-                        # so getppid() is CC. It's the daemon's liveness anchor:
-                        # refresh_live_presence() probes it to keep an alive-but-
-                        # quiet session (blocked on a question) non-stale.
-                        "--session-pid",
-                        str(os.getppid()),
-                        "--output",
-                        "json",
-                    ],
-                    capture_output=True,
-                    text=True,
-                    timeout=10,
-                    stdin=subprocess.DEVNULL,
-                )
-            except Exception:
-                pass
+        # window). Same call re-stamps the pid on resume — see the helper.
+        _write_practitioner_presence(claude_session_id, ai_id, result["session_id"])
 
     if result.get("error"):
         _emit_session_error(result["error"], ai_id)

--- a/tests/test_session_init_presence_restamp.py
+++ b/tests/test_session_init_presence_restamp.py
@@ -1,0 +1,50 @@
+"""_write_practitioner_presence in session-init.py — presence write + pid re-stamp.
+
+Part 3 of the presence-liveness fix: on `claude --resume` the session runs under a
+fresh CC parent, so the session_pid captured at first launch is now dead. The
+resume path re-stamps presence via this helper (shared with new-session init),
+keeping part 1's kill-0 pid-liveness accurate for resumed sessions.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+HOOK_PATH = (
+    Path(__file__).parent.parent / "empirica" / "plugins" / "claude-code-integration" / "hooks" / "session-init.py"
+)
+_spec = importlib.util.spec_from_file_location("session_init_presence_restamp", HOOK_PATH)
+assert _spec is not None and _spec.loader is not None
+session_init = importlib.util.module_from_spec(_spec)
+sys.modules["session_init_presence_restamp"] = session_init
+_spec.loader.exec_module(session_init)
+
+_write = session_init._write_practitioner_presence
+
+
+def test_writes_presence_with_current_getppid():
+    with patch.object(session_init.subprocess, "run") as run:
+        _write("cc-123", "empirica", "es-456")
+    assert run.call_count == 1
+    argv = run.call_args[0][0]
+    assert argv[:3] == ["empirica", "practitioner", "write"]
+    assert argv[argv.index("--session") + 1] == "cc-123"  # durable key
+    assert argv[argv.index("--ai-id") + 1] == "empirica"
+    assert argv[argv.index("--empirica-session") + 1] == "es-456"
+    # stamps the CURRENT parent pid — the whole point on resume
+    assert argv[argv.index("--session-pid") + 1] == str(os.getppid())
+
+
+def test_empty_session_id_is_noop():
+    with patch.object(session_init.subprocess, "run") as run:
+        _write("", "empirica", "es-1")
+    run.assert_not_called()
+
+
+def test_never_raises_on_subprocess_error():
+    with patch.object(session_init.subprocess, "run", side_effect=OSError("boom")):
+        _write("cc-1", "empirica", "es-1")  # best-effort — must not raise


### PR DESCRIPTION
## Presence liveness — part 3/3 (re-stamp pid on resume)

Closes the "Liveness T3: refresh captured PID on resume/SessionStart" goal and the last piece of the mesh-support-routed 3-part presence-liveness fix.

### The gap

`_handle_resume_path` updated anchors, bootstrapped, and exited — but **never re-wrote presence**. So on `claude --resume`, the presence record kept the `session_pid` captured at *first* launch, which is now a **dead process**. Part 1's pid-liveness (`kill -0`) then reads the resumed session as gone → it vanishes from the fleet view.

### Fix

Extract the `empirica practitioner write` call into **`_write_practitioner_presence`** (single source) and call it from **both** the new-session branch and the resume path — so a resume re-stamps `session_pid` with the current CC parent (`os.getppid()`).

### Why this is the *only* remaining part-3 piece

- **ai_id resolution before the write** already exists (`_resolve_ai_id_for_session`: env → project.yaml → basename), so `practice_ai_id='unknown'` is already handled.
- **Periodic heartbeat (part 2)** already runs via `practitioner_heartbeat` → `refresh_live_presence`.
- The stale-pid-on-resume was the real outstanding gap, and it directly complements part 1 (#242) — pid-liveness needs a *live* pid, which a resumed session must re-stamp.

### Tests (+3, importlib-loaded hook)

stamps the current `getppid` + durable session key · empty session id is a no-op · best-effort never raises. 13 pass, ruff + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)