### PR TITLE
fix(hooks): vendor-agnostic practice resolution in post-compact (ecodex)

### DIFF
--- a/empirica/plugins/claude-code-integration/hooks/post-compact.py
+++ b/empirica/plugins/claude-code-integration/hooks/post-compact.py
@@ -228,23 +228,43 @@ def _load_calibration_from_breadcrumbs_yaml() -> str:
 
 
 def _resolve_project_and_setup(claude_session_id: str) -> tuple:
-    """Resolve project root, set CWD, and compute instance_id.
+    """Resolve practice root, set CWD, and compute instance_id.
 
-    Exits with error if project root cannot be resolved.
-    Returns (project_root, instance_id).
+    Practice (project/ai_id) resolves from the practitioner cache
+    (active_work/instance_projects) and — when the harness declares CWD is the
+    verified practice via ``EMPIRICA_CWD_RELIABLE=true`` — from the filesystem
+    (CWD/git-root) too. This makes session-boundary resolution vendor-agnostic (a
+    fresh practitioner with an empty cache still resolves, e.g. codex/ecodex)
+    without re-opening the cross-project-bleed bug (KNOWN_ISSUES 11.10): in a
+    multiplexer where CWD is the empirica *launch* dir rather than the user's
+    project, the flag is unset, so the CWD/git fallback stays off and we never
+    grab the wrong practice.
+
+    If nothing resolves, exits 0 — a session-boundary hook with no resolvable
+    practice is a no-op, not a failure (matches pre-compact.py). Returns
+    (project_root, instance_id) on success.
     """
-    project_root = find_project_root(claude_session_id, check_compact_handoff=True)
+    # Harness-declared CWD reliability (Karson's #91 contract). session-init sets
+    # EMPIRICA_CWD_RELIABLE=true after chdir'ing to the verified practice; vendor
+    # harnesses (ecodex/codex) set it likewise. Absent it, CWD is untrusted (could
+    # be the launch dir) → filesystem fallback stays off.
+    cwd_reliable = os.environ.get("EMPIRICA_CWD_RELIABLE", "").lower() == "true"
+    project_root = find_project_root(
+        claude_session_id,
+        check_compact_handoff=True,
+        allow_cwd_fallback=cwd_reliable,
+        allow_git_root=cwd_reliable,
+    )
     if project_root is None:
+        # Graceful no-op (not exit 1): a boundary hook that can't resolve a
+        # practice has nothing to do — surface a stderr diagnostic and skip.
         print(
-            json.dumps(
-                {
-                    "error": "Could not resolve project root. No active_work file, instance_projects, or EMPIRICA_WORKSPACE_ROOT found.",
-                    "claude_session_id": claude_session_id,
-                    "tmux_pane": os.environ.get("TMUX_PANE"),
-                }
-            )
+            f"post-compact: no resolvable empirica practice "
+            f"(session={claude_session_id}, cwd_reliable={cwd_reliable}) — skipping",
+            file=sys.stderr,
         )
-        sys.exit(1)
+        print(json.dumps({}))
+        sys.exit(0)
     os.chdir(project_root)
     instance_id = get_instance_id()
     sys.path.insert(0, str(Path.home() / "empirical-ai" / "empirica"))

--- a/tests/test_post_compact_practice_resolution.py
+++ b/tests/test_post_compact_practice_resolution.py
@@ -1,0 +1,70 @@
+"""_resolve_project_and_setup in post-compact.py — n-gated filesystem fallback + graceful exit.
+
+Regression guard for the ecodex instance-isolation design-intent fix
+(prop_upsyzrpgg). A fresh practitioner (empty instance_projects cache) must
+resolve the practice from the filesystem when the harness declares CWD is the
+verified practice (``n=true``), and must exit 0 — not 1 — when nothing resolves:
+a session-boundary hook with no practice is a no-op, not a failure. The ``n``
+gate keeps CWD/git fallback OFF in a multiplexer where CWD is the empirica launch
+dir rather than the user's project (KNOWN_ISSUES 11.10 cross-project bleed).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+_HOOK_DIR = Path(__file__).parent.parent / "empirica" / "plugins" / "claude-code-integration" / "hooks"
+# post-compact.py inserts its sibling lib on sys.path at import; do the same so
+# `from project_resolver import ...` resolves during exec_module.
+sys.path.insert(0, str(_HOOK_DIR.parent / "lib"))
+_spec = importlib.util.spec_from_file_location("post_compact_hook", _HOOK_DIR / "post-compact.py")
+assert _spec is not None and _spec.loader is not None
+post_compact = importlib.util.module_from_spec(_spec)
+sys.modules["post_compact_hook"] = post_compact
+_spec.loader.exec_module(post_compact)
+
+_resolve = post_compact._resolve_project_and_setup
+
+
+def test_cwd_fallback_enabled_when_n_true(monkeypatch, tmp_path):
+    """n=true → the harness vouches for CWD → filesystem fallback is enabled."""
+    monkeypatch.setenv("EMPIRICA_CWD_RELIABLE", "true")
+    with (
+        patch.object(post_compact, "find_project_root", return_value=tmp_path) as fpr,
+        patch.object(post_compact.os, "chdir"),
+        patch.object(post_compact, "get_instance_id", return_value="i"),
+    ):
+        _resolve("cc-1")
+    kwargs = fpr.call_args.kwargs
+    assert kwargs["allow_cwd_fallback"] is True
+    assert kwargs["allow_git_root"] is True
+
+
+def test_cwd_fallback_off_when_n_unset(monkeypatch, tmp_path):
+    """No n → CWD is untrusted (could be the launch dir) → fallback stays off."""
+    monkeypatch.delenv("EMPIRICA_CWD_RELIABLE", raising=False)
+    with (
+        patch.object(post_compact, "find_project_root", return_value=tmp_path) as fpr,
+        patch.object(post_compact.os, "chdir"),
+        patch.object(post_compact, "get_instance_id", return_value="i"),
+    ):
+        _resolve("cc-1")
+    kwargs = fpr.call_args.kwargs
+    assert kwargs["allow_cwd_fallback"] is False
+    assert kwargs["allow_git_root"] is False
+
+
+def test_unresolved_exits_zero_not_one(monkeypatch):
+    """Nothing resolves → graceful no-op (exit 0), not a 'hook failed' (exit 1)."""
+    monkeypatch.delenv("EMPIRICA_CWD_RELIABLE", raising=False)
+    with (
+        patch.object(post_compact, "find_project_root", return_value=None),
+        pytest.raises(SystemExit) as exc,
+    ):
+        _resolve("cc-fresh")
+    assert exc.value.code == 0


### PR DESCRIPTION
## Symptom
ecodex (codex fork running empirica's vendored hooks) shows **"SessionStart hook (failed) exit 1"** every fresh session start.

## Root cause
`post-compact.py` was the **lone session-boundary hook** that both:
1. resolved the practice **without** filesystem fallback — `find_project_root(check_compact_handoff=True)` with `allow_cwd_fallback`/`allow_git_root` defaulted off, while `session-init.py:1539` passes both and `session-end-postflight` passes `allow_cwd_fallback`; and
2. **hard-failed `sys.exit(1)`** on `None`, where `pre-compact.py` gracefully `sys.exit(0)`.

On a fresh practitioner (empty `instance_projects` cache) priorities 1–6 miss, 7–8 are gated off → `None` → exit 1.

## Why the gate existed (not an oversight)
CWD fallback was **deliberately removed** from this path (KNOWN_ISSUES 11.10): in a multiplexer, CWD is the empirica *launch* dir — itself a valid empirica project, so `has_valid_db()` can't distinguish it → unconditional fallback grabs the **wrong** practice (cross-project bleed).

## Fix
- **Gate CWD/git fallback on `EMPIRICA_CWD_RELIABLE=true`** — the existing harness contract (Karson's #91) by which a caller that `chdir`'d to the verified practice vouches for CWD. `session-init` already sets it (`session-init.py:612`); vendor harnesses (ecodex/codex) set it likewise. In a multiplexer the flag is unset → fallback stays off → **no bleed**. On a vendor-agnostic harness → the fresh practitioner resolves from the filesystem.
- **`sys.exit(1)` → `sys.exit(0)`** when unresolved — a session-boundary hook with no resolvable practice is a no-op, not a failure (matches `pre-compact.py`); stderr diagnostic retained.

## Scope
Practice-resolution only (ecodex design-check **part 1**). The `practitioner_id` formalization (part 2) and the cortex mesh-identity question remain in the design thread — not touched here.

## Verification
- 3 regression tests: fallback enabled iff `EMPIRICA_CWD_RELIABLE=true`; graceful exit-0 when unresolved.
- `ruff` + `pyright` clean on the change (pre-existing unused-var warnings elsewhere in the file untouched).

Deployed hook copy re-syncs via `setup-claude-code --force` (separate step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)