### PR TITLE
fix(sentinel): classify cortex mailbox reads noetic + namespace-agg defense

### DIFF
--- a/empirica/plugins/claude-code-integration/hooks/sentinel-gate.py
+++ b/empirica/plugins/claude-code-integration/hooks/sentinel-gate.py
@@ -96,7 +96,39 @@ NOETIC_MCP_CORTEX = {
     "mcp__cortex__cortex_bus_poll",  # Bus polling
     "mcp__cortex__cortex_bus_dispatch",  # Bus dispatch
     "mcp__cortex__cortex_bus_complete",  # Bus completion
+    # Mailbox READS + ack — cortex-confirmed noetic (thread prop_iefo2tdx). The
+    # mailbox-poll family was overlooked when the bus-poll family above was added.
+    "mcp__cortex__cortex_inbox_poll",  # Read mailbox (pure read)
+    "mcp__cortex__cortex_outbox_poll",  # Read own emissions' state (pure read)
+    "mcp__cortex__cortex_get_proposal",  # Fetch proposal by id (pure read)
+    "mcp__cortex__cortex_archive_proposal",  # Archiver-scoped soft-flip (hide-from-my-view; ergonomically noetic)
+    "mcp__cortex__cortex_complete_proposal",  # Ack: closing bracket of a wake→act→ack loop, authorized by the accepted proposal (noetic by policy)
 }
+
+
+def _normalize_aggregated_cortex_tool(tool_name: str, tool_input) -> str:
+    """Resolve a bare `mcp__cortex` namespace to its full `mcp__cortex__<op>`.
+
+    Namespace-aggregating harnesses (e.g. codex/ecodex) may present the bare
+    server namespace as ``tool_name`` with the operation carried in
+    ``tool_input`` (``op`` / ``operation`` / ``name`` / ``tool``), rather than
+    the full ``mcp__cortex__<op>`` that standard MCP PreToolUse hooks receive.
+    Normalizing here — once, at the entry — lets every downstream noetic/praxic
+    classification (NOETIC_MCP_CORTEX membership etc.) work either way.
+
+    Fail-safe: only resolves to a concrete op; a bare namespace with no
+    resolvable op is returned unchanged (so it stays unclassified → gated).
+    """
+    if tool_name in ("mcp__cortex", "mcp__cortex__") and isinstance(tool_input, dict):
+        op = (
+            tool_input.get("op")
+            or tool_input.get("operation")
+            or tool_input.get("name")
+            or tool_input.get("tool")
+        )
+        if op:
+            return f"mcp__cortex__{op}"
+    return tool_name
 
 # Empirica MCP tools — ALL are epistemic workflow, always allowed.
 # The empirica-mcp server wraps CLI commands — same trust as Tier 2.
@@ -3818,6 +3850,12 @@ def main():
 
     tool_name = hook_input.get("tool_name", "unknown")
     tool_input = hook_input.get("tool_input", {})
+
+    # Option 2 — namespace-aggregation defense (codex/ecodex): normalize a bare
+    # `mcp__cortex` namespace (op carried in tool_input) to the full
+    # `mcp__cortex__<op>` at this single entry point, so every downstream
+    # classification works regardless of how the harness dispatches.
+    tool_name = _normalize_aggregated_cortex_tool(tool_name, tool_input)
 
     _track_tool_usage(hook_input, tool_name, tool_input)
     _set_file_relevance_nudge(tool_name, tool_input, hook_input.get("session_id"))

--- a/tests/test_sentinel_cortex_mailbox_noetic.py
+++ b/tests/test_sentinel_cortex_mailbox_noetic.py
@@ -1,0 +1,64 @@
+"""sentinel-gate.py — cortex mailbox reads are noetic + namespace-aggregation normalization.
+
+Regression guard for the ecodex/cortex Sentinel over-gating fix (thread
+prop_3zjsf2cs → prop_iefo2tdx). cortex mailbox READS
+(inbox_poll/outbox_poll/get_proposal/archive_proposal) + the ack
+(complete_proposal) must be classified noetic (present in NOETIC_MCP_CORTEX),
+and a bare `mcp__cortex` namespace (codex/ecodex aggregation) must normalize to
+the full op name so the same classification applies — "option 2".
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+_HOOK = (
+    Path(__file__).parent.parent
+    / "empirica"
+    / "plugins"
+    / "claude-code-integration"
+    / "hooks"
+    / "sentinel-gate.py"
+)
+_spec = importlib.util.spec_from_file_location("sentinel_gate_mod", _HOOK)
+assert _spec is not None and _spec.loader is not None
+sg = importlib.util.module_from_spec(_spec)
+sys.modules["sentinel_gate_mod"] = sg
+_spec.loader.exec_module(sg)
+
+
+def test_cortex_mailbox_reads_and_ack_are_noetic():
+    for op in (
+        "cortex_inbox_poll",
+        "cortex_outbox_poll",
+        "cortex_get_proposal",
+        "cortex_archive_proposal",
+        "cortex_complete_proposal",
+    ):
+        assert f"mcp__cortex__{op}" in sg.NOETIC_MCP_CORTEX
+
+
+def test_praxic_cortex_tools_stay_out_of_noetic():
+    # These are real state mutations / ECO-gated — must NOT be noetic.
+    for op in ("cortex_propose", "cortex_publish"):
+        assert f"mcp__cortex__{op}" not in sg.NOETIC_MCP_CORTEX
+
+
+def test_bare_namespace_normalizes_to_full_op():
+    norm = sg._normalize_aggregated_cortex_tool
+    assert norm("mcp__cortex", {"op": "cortex_inbox_poll"}) == "mcp__cortex__cortex_inbox_poll"
+    assert norm("mcp__cortex", {"operation": "cortex_get_proposal"}) == "mcp__cortex__cortex_get_proposal"
+    assert norm("mcp__cortex", {"name": "cortex_outbox_poll"}) == "mcp__cortex__cortex_outbox_poll"
+    assert norm("mcp__cortex__", {"tool": "cortex_archive_proposal"}) == "mcp__cortex__cortex_archive_proposal"
+
+
+def test_pass_through_full_names_unknown_and_non_cortex():
+    norm = sg._normalize_aggregated_cortex_tool
+    # already-full name unchanged
+    assert norm("mcp__cortex__cortex_inbox_poll", {}) == "mcp__cortex__cortex_inbox_poll"
+    # bare namespace with no resolvable op → unchanged (fail-safe → stays gated)
+    assert norm("mcp__cortex", {}) == "mcp__cortex"
+    # non-cortex tool untouched
+    assert norm("Bash", {"command": "ls"}) == "Bash"


### PR DESCRIPTION
## Gap (verified real)
`NOETIC_MCP_CORTEX` in `sentinel-gate.py` had `cortex_bus_poll` but **not** the mailbox-poll family — so `cortex_inbox_poll` / `cortex_outbox_poll` / `cortex_get_proposal` / `cortex_archive_proposal` / `cortex_complete_proposal` were classified **praxic and gated pre-CHECK**, despite being pure reads (or an archiver-scoped soft-flip / the ack half of a wake→act→ack loop). Confirmed against the live allowlist; cortex authoritatively classified all five as noetic (thread `prop_iefo2tdx`).

## Fix
- Add the 5 mailbox tools to `NOETIC_MCP_CORTEX`.
- **Option 2** (codex/ecodex namespace aggregation): normalize a bare `mcp__cortex` namespace (op in `tool_input`) → full `mcp__cortex__<op>` at the **single** hook entry point (`_normalize_aggregated_cortex_tool`), so classification works regardless of dispatch shape. **Fail-safe:** unresolved namespace passes through unchanged → stays gated.

## Verified NOT a gap (left untouched — accuracy)
- `empirica project-bootstrap` is **already Tier-1 noetic** (`EMPIRICA_TIER1_PREFIXES`) — the report was stale/misattributed.
- The `cd <dir> && <noetic-cmd>` compound claim: there's existing `cd &&` handling but it's narrowed to the recovery/measurement set. Deferred pending ecodex's live `tool_input` confirmation before touching the compound-command classifier — didn't want to change the general noetic-bash path on an unverified claim.

## Tests
4 regression tests (reads noetic, praxic stays out, bare-namespace normalizes, pass-through). ruff clean. Deployed hook copy re-syncs via `setup-claude-code --force`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)