### PR TITLE
feat(postflight): auto-persist structural goal-edges to artifact_edges

### DIFF
--- a/empirica/cli/command_handlers/_workflow_postflight.py
+++ b/empirica/cli/command_handlers/_workflow_postflight.py
@@ -1420,6 +1420,41 @@ def _cortex_extract_transaction_graph(session_id):
         return {}
 
 
+def _write_auto_structural_edges(session_id, transaction_id) -> int:
+    """Auto-edge (Gated Artifact-Graph map, work-stream 3): persist each
+    artifact's structural edge to its goal in the canonical ``artifact_edges``
+    table, so the local graph is connected with ZERO AI effort.
+
+    The cortex-sync path already *computes* these ``attached_to`` (artifact→goal)
+    edges but only ships them to cortex — they never land in the local table the
+    walker / connectivity checks / retrospective read. This persists them
+    locally. Idempotent via the PK ``(from_id, to_id, relation)``; best-effort
+    (a pre-041 DB with no ``artifact_edges`` degrades to a no-op). Returns the
+    number of edges ensured.
+    """
+    if not transaction_id:
+        return 0
+    _sdb = _get_db_for_session(session_id)
+    _nodes, _seen, goal_edges = _cortex_graph_artifact_nodes(_sdb, transaction_id)
+    if not goal_edges:
+        return 0
+    ensured = 0
+    for _e in goal_edges:
+        try:
+            _sdb.conn.execute(
+                "INSERT OR IGNORE INTO artifact_edges (from_id, to_id, relation) VALUES (?, ?, ?)",
+                (_e["from"], _e["to"], _e["relation"]),
+            )
+            ensured += 1
+        except Exception:
+            continue
+    try:
+        _sdb.conn.commit()
+    except Exception:
+        pass
+    return ensured
+
+
 def _cortex_read_calibration_summary(project_path: str | None = None) -> dict:
     """Read calibration summary from .breadcrumbs.yaml. Returns dict.
 
@@ -1807,6 +1842,18 @@ def handle_postflight_submit_command(args):
                     "trajectory_issues": trajectory_issues,
                     "checkpoint_id": checkpoint_id,
                 },
+            )
+
+            # Stage 5b: Auto-edges — persist each artifact's structural goal-edge
+            # to artifact_edges so the local graph is connected with zero AI
+            # effort (Gated Artifact-Graph map, work-stream 3). Runs BEFORE the
+            # grounded verification below so the edges are counted this tx.
+            _soft_run(
+                "auto_structural_edges",
+                warnings,
+                _write_auto_structural_edges,
+                session_id,
+                tx_info["transaction_id"],
             )
 
             # Stage 6: Beliefs + Grounded verification + Storage pipeline

--- a/tests/test_postflight_auto_edges.py
+++ b/tests/test_postflight_auto_edges.py
@@ -1,0 +1,73 @@
+"""POSTFLIGHT auto-edges — persist structural goal-edges to artifact_edges.
+
+Gated Artifact-Graph map, work-stream 3 (goal 43471346). The cortex-sync path
+computes each artifact's `attached_to` (artifact→goal) edge but only ships it to
+cortex; `_write_auto_structural_edges` persists those edges to the local
+`artifact_edges` table so the graph is connected with zero AI effort. Idempotent
+via the PK, best-effort on a pre-041 DB.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from types import SimpleNamespace
+
+from empirica.cli.command_handlers import _workflow_postflight as wp
+
+
+def _mem_db():
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute(
+        "CREATE TABLE artifact_edges (from_id TEXT, to_id TEXT, relation TEXT, PRIMARY KEY (from_id, to_id, relation))"
+    )
+    return SimpleNamespace(conn=conn), conn
+
+
+def test_persists_goal_edges(monkeypatch):
+    sdb, conn = _mem_db()
+    monkeypatch.setattr(wp, "_get_db_for_session", lambda _sid: sdb)
+    monkeypatch.setattr(
+        wp,
+        "_cortex_graph_artifact_nodes",
+        lambda _s, _t: (
+            [],
+            set(),
+            [
+                {"from": "a1", "to": "g1", "relation": "attached_to"},
+                {"from": "a2", "to": "g1", "relation": "attached_to"},
+            ],
+        ),
+    )
+    ensured = wp._write_auto_structural_edges("sess", "tx1")
+    assert ensured == 2
+    rows = {
+        (r["from_id"], r["to_id"], r["relation"])
+        for r in conn.execute("SELECT from_id, to_id, relation FROM artifact_edges").fetchall()
+    }
+    assert ("a1", "g1", "attached_to") in rows
+    assert ("a2", "g1", "attached_to") in rows
+
+
+def test_idempotent(monkeypatch):
+    sdb, conn = _mem_db()
+    monkeypatch.setattr(wp, "_get_db_for_session", lambda _sid: sdb)
+    monkeypatch.setattr(
+        wp,
+        "_cortex_graph_artifact_nodes",
+        lambda _s, _t: ([], set(), [{"from": "a1", "to": "g1", "relation": "attached_to"}]),
+    )
+    wp._write_auto_structural_edges("sess", "tx1")
+    wp._write_auto_structural_edges("sess", "tx1")  # second run must not duplicate/raise
+    assert conn.execute("SELECT COUNT(*) FROM artifact_edges").fetchone()[0] == 1
+
+
+def test_no_transaction_id_is_noop():
+    assert wp._write_auto_structural_edges("sess", "") == 0
+
+
+def test_no_goal_edges_is_noop(monkeypatch):
+    sdb, _conn = _mem_db()
+    monkeypatch.setattr(wp, "_get_db_for_session", lambda _sid: sdb)
+    monkeypatch.setattr(wp, "_cortex_graph_artifact_nodes", lambda _s, _t: ([], set(), []))
+    assert wp._write_auto_structural_edges("sess", "tx1") == 0


### PR DESCRIPTION
First build of the **Gated Artifact-Graph map** (`docs/architecture/GATED_ARTIFACT_GRAPH.md`) — work-stream 3, **auto-edges** (goal `43471346`). The map's "cleanest first ship": connect the graph with **zero AI-behavior change**.

## Problem
The POSTFLIGHT cortex-sync path *computes* each artifact's `attached_to` (artifact→goal) edge but only ships it to **cortex** — it never lands in the local `artifact_edges` table that the `commit-context` walker, connectivity checks, and retrospective read. So the steady state was "0 edges" even though every artifact has a goal.

## Fix
`_write_auto_structural_edges(session_id, transaction_id)` persists those goal-edges to `artifact_edges`, called via `_soft_run` at **stage 5b** (after the sentinel hook, before grounded verification — so the edges are both persisted *and* counted this transaction). Idempotent (PK `(from_id,to_id,relation)`); best-effort (pre-041 DB → no-op).

Net: **structural connectivity is now automatic**; the AI is only responsible for *semantic* edges (`evidence`/`grounded_by`/…). That's the concrete step toward "just log artifacts — the graph builds itself."

## Verify
4 unit tests (persist, idempotent, no-tx no-op, no-goal no-op). `ruff check` + `ruff format --check` + `pyright` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)