### PR TITLE
feat(check): inject log-artifacts weave schema at the gate

### DIFF
--- a/empirica/cli/command_handlers/_workflow_check.py
+++ b/empirica/cli/command_handlers/_workflow_check.py
@@ -14,6 +14,7 @@ from ..cli_utils import handle_cli_error, parse_json_safely
 from ._workflow_shared import (
     _auto_bootstrap,
     _build_retrospective,
+    _build_weave_guidance,
     _check_bootstrap_status,
     _get_db_for_session,
     _invoke_sentinel_hook,
@@ -1210,9 +1211,13 @@ def handle_check_submit_command(args):
             # Stage 14: Pattern retrieval + codebase context
             _check_enrich_context(result, bootstrap_result, bootstrap_status, vectors, reasoning)
 
-            # Stage 15: Praxic reminders (only when proceeding)
+            # Stage 15: Praxic reminders + weave guidance (only when proceeding)
             if decision == "proceed":
                 result["praxic_reminders"] = _check_build_praxic_reminders(session_id, check_transaction_id)
+                # Gated Artifact-Graph map, work-stream 2 (schema-injection): give
+                # the log-artifacts node/relation vocabulary at the gate so weaving
+                # is cheap (no more guessing the shape / unknown-relation errors).
+                result["weave_guidance"] = _build_weave_guidance()
 
             # AUTO-POSTFLIGHT REMOVED (2026-03-02):
             # CHECK is a noetic->praxic gate, not a completion event.

--- a/empirica/cli/command_handlers/_workflow_shared.py
+++ b/empirica/cli/command_handlers/_workflow_shared.py
@@ -26,6 +26,7 @@ __all__ = [
     "_build_noetic_guidance",
     "_build_retrospective",
     "_build_voice_guidance",
+    "_build_weave_guidance",
     "_check_bootstrap_status",
     "_extract_all_vectors",
     "_extract_numeric_value",
@@ -267,6 +268,40 @@ def _build_noetic_guidance(work_type: str | None) -> dict | None:
         "skip_if": (
             "Fewer than 3 investigation operations. Use Read/Grep/Glob/investigate "
             "directly — they're already noetic and don't need batching."
+        ),
+    }
+
+
+def _build_weave_guidance() -> dict:
+    """Surface the log-artifacts weave schema at the CHECK gate.
+
+    Gated Artifact-Graph map, work-stream 2 (schema-injection). At CHECK→proceed
+    the AI is entering the praxic phase and will weave its artifacts into a
+    connected sub-graph; giving it the node-type + relation vocabulary here — the
+    exact shape AIs fumble (recurring "unknown relation" errors) — makes weaving
+    cheap enough that the eventual hard gate doesn't hurt. Structural
+    artifact→goal edges are written automatically (work-stream 3); this is for
+    the SEMANTIC edges the AI must assert. Best-effort; returns {} on failure.
+    """
+    try:
+        from .graph_commands import NODE_REQUIRED_FIELDS, VALID_RELATIONS
+    except Exception:
+        return {}
+    return {
+        "tool": "empirica log-artifacts -   (or mcp__empirica__log_artifacts)",
+        "node_types": sorted(NODE_REQUIRED_FIELDS.keys()),
+        "relations": sorted(VALID_RELATIONS),
+        "node_required_fields": dict(NODE_REQUIRED_FIELDS),
+        "shape": {
+            "nodes": [{"ref": "<local id e.g. f1>", "type": "<node_type>", "data": {"<required field>": "..."}}],
+            "edges": [{"from": "<ref|uuid>", "to": "<ref|uuid>", "relation": "<relation>"}],
+        },
+        "hint": (
+            "Weave, don't just log: connect this transaction's artifacts into a "
+            "sub-graph in ONE log-artifacts call. Structural artifact→goal edges "
+            "are written for you — assert only the SEMANTIC edges "
+            "(evidence / grounded_by / caused_by / resolves / invalidates). Use "
+            "ONLY the relations listed above; unknown relations are rejected."
         ),
     }
 

--- a/tests/test_check_weave_guidance.py
+++ b/tests/test_check_weave_guidance.py
@@ -1,0 +1,36 @@
+"""_build_weave_guidance — schema-injection at the CHECK gate.
+
+Gated Artifact-Graph map, work-stream 2 (goal 43471346). The CHECK→proceed
+response injects the log-artifacts node/relation vocabulary so weaving is cheap
+(no guessing the shape / recurring "unknown relation" errors). The relation set
+must stay in lockstep with graph_commands' canonical VALID_RELATIONS.
+"""
+
+from __future__ import annotations
+
+from empirica.cli.command_handlers._workflow_shared import _build_weave_guidance
+
+
+def test_weave_guidance_carries_the_schema():
+    g = _build_weave_guidance()
+    assert "finding" in g["node_types"]
+    assert "decision" in g["node_types"]
+    assert "evidence" in g["relations"]
+    assert "grounded_by" in g["relations"]
+    assert "nodes" in g["shape"]
+    assert "edges" in g["shape"]
+    assert g["node_required_fields"]["decision"] == ["choice", "rationale"]
+
+
+def test_relations_stay_in_lockstep_with_graph_commands():
+    from empirica.cli.command_handlers.graph_commands import VALID_RELATIONS
+
+    g = _build_weave_guidance()
+    assert set(g["relations"]) == set(VALID_RELATIONS)
+
+
+def test_node_types_stay_in_lockstep_with_graph_commands():
+    from empirica.cli.command_handlers.graph_commands import NODE_REQUIRED_FIELDS
+
+    g = _build_weave_guidance()
+    assert set(g["node_types"]) == set(NODE_REQUIRED_FIELDS.keys())


### PR DESCRIPTION
Gated Artifact-Graph map, **work-stream 2 (schema-injection)** — the make-or-break (goal `43471346`).

## What
`CHECK→proceed` now returns a **`weave_guidance`** block: the log-artifacts node-type enum + relation vocabulary + shape + hint, sourced **live** from `graph_commands` (`NODE_REQUIRED_FIELDS` / `VALID_RELATIONS`) so it can't drift.

## Why
AIs repeatedly fumble the `log-artifacts` JSON shape — several `unknown relation` errors this session alone. Surfacing the exact schema **at the gate** (the moment the AI enters the praxic phase and will weave) makes weaving cheap enough that the eventual hard gate doesn't hurt. Structural `attached_to` goal-edges are automatic (work-stream 3, #249); this guidance is for the **semantic** edges the AI asserts.

## Scope
Schema only (the fumble-prone part). Dynamic linkable-ids (open goals + this-tx artifact ids) are a clean follow-up — deferred to avoid a circular import. Mirrors the existing `noetic_guidance` pattern.

## Verify
3 tests keep the injected vocab in lockstep with `graph_commands`. `ruff check` + `ruff format --check` + `pyright` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)