### PR TITLE
fix(postflight): retrospective edge-counter reads canonical artifact_edges

### DIFF
--- a/empirica/cli/command_handlers/_workflow_shared.py
+++ b/empirica/cli/command_handlers/_workflow_shared.py
@@ -526,35 +526,39 @@ def _retro_count_sources(cursor, session_id: str, transaction_id: str | None) ->
 
 
 def _retro_count_edges(cursor, session_id: str, transaction_id: str | None) -> int:
-    """Count artifacts in this transaction that have at least one declared edge.
+    """Count artifacts in this transaction that have ≥1 edge in the canonical
+    ``artifact_edges`` table (migration 041) — i.e. appear as an edge's ``from_id``.
 
-    Edges live in <type>_data.edges (or just data.edges for assumptions/decisions).
-    Counts rows whose data column has json_array_length(edges) > 0.
+    Reads ``artifact_edges``, the source BOTH ``log-artifacts`` and the POSTFLIGHT
+    auto-edge writer persist to — NOT the legacy inline ``<type>_data.edges`` JSON,
+    which neither actually writes, so it chronically reported a false ``0`` even
+    when edges existed. Best-effort: a pre-041 DB with no ``artifact_edges``
+    degrades to 0 (each table query raises and is skipped).
     """
-    by_table = [
-        ("project_findings", "finding_data"),
-        ("project_unknowns", "unknown_data"),
-        ("project_dead_ends", "dead_end_data"),
-        ("mistakes_made", "mistake_data"),
-        ("assumptions", "data"),
-        ("decisions", "data"),
-    ]
+    by_table = (
+        "project_findings",
+        "project_unknowns",
+        "project_dead_ends",
+        "mistakes_made",
+        "assumptions",
+        "decisions",
+    )
     total = 0
-    for table, data_col in by_table:
+    for table in by_table:
         try:
             sql = (
-                f"SELECT COUNT(*) FROM {table} "
-                f"WHERE session_id = ? "
-                f"AND COALESCE(json_array_length(json_extract({data_col}, '$.edges')), 0) > 0"
+                f"SELECT COUNT(*) FROM {table} t "
+                "WHERE t.session_id = ? "
+                "AND EXISTS (SELECT 1 FROM artifact_edges e WHERE e.from_id = t.id)"
             )
             params: tuple = (session_id,)
             if transaction_id:
-                sql += " AND transaction_id = ?"
+                sql += " AND t.transaction_id = ?"
                 params = (session_id, transaction_id)
             cursor.execute(sql, params)
             total += cursor.fetchone()[0]
         except Exception:
-            # Column may not exist on older rows / table; ignore silently.
+            # Table/column absent (old DB) or pre-041 (no artifact_edges); skip.
             pass
     return total
 

--- a/tests/test_retro_count_edges_canonical.py
+++ b/tests/test_retro_count_edges_canonical.py
@@ -1,0 +1,47 @@
+"""_retro_count_edges reads the canonical artifact_edges table, not legacy JSON.
+
+Regression guard for the chronic false "0 edges": the counter used to read the
+inline `<type>_data.edges` JSON (which neither log-artifacts nor the auto-edge
+writer populate), so real edges in the canonical `artifact_edges` table (mig 041)
+were invisible. It now counts artifacts that appear as an edge `from_id`.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+from empirica.cli.command_handlers._workflow_shared import _retro_count_edges
+
+
+def _db(with_edges_table: bool = True) -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE project_findings (id TEXT, session_id TEXT, transaction_id TEXT)")
+    if with_edges_table:
+        conn.execute(
+            "CREATE TABLE artifact_edges (from_id TEXT, to_id TEXT, relation TEXT, "
+            "PRIMARY KEY (from_id, to_id, relation))"
+        )
+    return conn
+
+
+def test_counts_artifacts_with_a_canonical_edge():
+    conn = _db()
+    conn.execute("INSERT INTO project_findings VALUES ('a1', 's1', 'tx1')")  # has an edge
+    conn.execute("INSERT INTO project_findings VALUES ('a2', 's1', 'tx1')")  # no edge
+    conn.execute("INSERT INTO artifact_edges VALUES ('a1', 'g1', 'attached_to')")
+    assert _retro_count_edges(conn.cursor(), "s1", "tx1") == 1
+
+
+def test_scoped_to_transaction():
+    conn = _db()
+    conn.execute("INSERT INTO project_findings VALUES ('a1', 's1', 'tx1')")
+    conn.execute("INSERT INTO project_findings VALUES ('a3', 's1', 'tx2')")
+    conn.execute("INSERT INTO artifact_edges VALUES ('a1', 'g1', 'attached_to')")
+    conn.execute("INSERT INTO artifact_edges VALUES ('a3', 'g1', 'attached_to')")
+    assert _retro_count_edges(conn.cursor(), "s1", "tx1") == 1  # a3 is tx2, excluded
+
+
+def test_pre_041_db_without_artifact_edges_is_zero_not_error():
+    conn = _db(with_edges_table=False)
+    conn.execute("INSERT INTO project_findings VALUES ('a1', 's1', 'tx1')")
+    assert _retro_count_edges(conn.cursor(), "s1", "tx1") == 0


### PR DESCRIPTION
## The bug (my own logged finding, now fixed)
`_retro_count_edges` counted artifacts whose **legacy inline `<type>_data.edges` JSON** was non-empty — but neither `log-artifacts` nor the auto-edge writer (#249) populate that JSON; both write the canonical **`artifact_edges`** table (mig 041). So `edges_with_artifacts` reported a **false 0** even when edges existed (the "I wove a real edge and the retrospective still said 0 edges" symptom this session), and it made the #249 auto-edges invisible.

## Fix
Count artifacts that appear as an edge `from_id` in `artifact_edges` (EXISTS subquery), scoped to session+transaction, best-effort (pre-041 DB → 0).

## Why it matters
Completes the connectivity foundation for the Gated Artifact-Graph map: with #249 auto-edges *written* and this making them *counted*, a future connectivity **gate** finally has an accurate signal instead of a broken counter.

## Verify
3 regression tests (canonical read, tx-scoping, pre-041 graceful) + 7 sibling workflow tests still pass. `ruff check` + `ruff format --check` + `pyright` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)