### PR TITLE
feat(postflight): artifact-graph gate verdict (report-only foundation)

### DIFF
--- a/empirica/cli/command_handlers/_workflow_shared.py
+++ b/empirica/cli/command_handlers/_workflow_shared.py
@@ -563,6 +563,66 @@ def _retro_count_edges(cursor, session_id: str, transaction_id: str | None) -> i
     return total
 
 
+_ARTIFACT_GRAPH_GATE_MODES = ("off", "nudge", "soft", "hard")
+
+
+def _weave_gate_block(total_artifacts: int, edges_count: int) -> dict | None:
+    """Artifact-graph gate verdict — the report-only foundation (map work-stream 1).
+
+    Reads the gate mode from ``EMPIRICA_ARTIFACT_GRAPH_GATE`` (off|nudge|soft|hard,
+    default ``nudge``) and reports a connectivity verdict from the transaction's
+    (now-accurate) edge count vs artifact count. **REPORT-ONLY at every mode in
+    this build** (`enforced: False`) — the soft/hard *blocking* behavior is a
+    deliberate follow-up that needs the aggressiveness tuned. Returns None when
+    the gate is ``off`` or there are no artifacts. project.yaml will be the
+    per-practice home for the mode once enforcement lands.
+    """
+    mode = os.environ.get("EMPIRICA_ARTIFACT_GRAPH_GATE", "nudge").strip().lower()
+    if mode not in _ARTIFACT_GRAPH_GATE_MODES:
+        mode = "nudge"
+    if mode == "off" or total_artifacts < 1:
+        return None
+    connected = min(edges_count, total_artifacts)
+    if connected >= total_artifacts:
+        verdict = "connected"
+    elif connected > 0:
+        verdict = "partial"
+    else:
+        verdict = "disconnected"
+    return {
+        "mode": mode,
+        "verdict": verdict,
+        "connected_artifacts": connected,
+        "total_artifacts": total_artifacts,
+        "enforced": False,  # report-only build; soft/hard blocking is a follow-up
+        "note": (
+            f"artifact-graph gate [{mode}, report-only]: {connected}/{total_artifacts} "
+            "artifacts connected. Structural goal-edges are automatic; weave semantic "
+            "edges (log-artifacts) to raise connectivity. Soft/hard blocking not yet active."
+        ),
+    }
+
+
+def _maybe_add_weave_gate(cursor, session_id, transaction_id, retro: dict, total_artifacts: int) -> None:
+    """Attach the report-only artifact-graph gate verdict to the retrospective.
+
+    Kept out of ``_build_retrospective`` to hold that function's complexity down
+    (mirrors ``_maybe_add_untriaged_notes``). Reuses the already-computed edge
+    count when present, else counts once. Best-effort; no-op on any failure.
+    """
+    if total_artifacts < 1:
+        return
+    try:
+        edges = retro.get("edges_with_artifacts")
+        if edges is None:
+            edges = _retro_count_edges(cursor, session_id, transaction_id)
+        gate = _weave_gate_block(total_artifacts, edges)
+        if gate:
+            retro["weave_gate"] = gate
+    except Exception:
+        pass
+
+
 def _build_retrospective(session_id: str, transaction_id: str | None) -> dict:
     """Build retrospective feedback: artifact breadth, commit discipline, completion hints.
 
@@ -619,6 +679,9 @@ def _build_retrospective(session_id: str, transaction_id: str | None) -> dict:
                     )
             except Exception:
                 pass
+
+        # Artifact-graph gate verdict (report-only foundation, map work-stream 1).
+        _maybe_add_weave_gate(cursor, session_id, transaction_id, retro, total_artifacts)
 
         try:
             _gr = _sp.run(["git", "status", "--porcelain"], capture_output=True, text=True, timeout=5)

--- a/tests/test_weave_gate_block.py
+++ b/tests/test_weave_gate_block.py
@@ -1,0 +1,48 @@
+"""_weave_gate_block — report-only artifact-graph gate verdict.
+
+Gated Artifact-Graph map, work-stream 1 foundation (goal 43471346). Reports the
+gate mode (env EMPIRICA_ARTIFACT_GRAPH_GATE, default nudge) + a connectivity
+verdict, but NEVER blocks in this build (`enforced: False`) — the soft/hard
+blocking is a deliberate follow-up.
+"""
+
+from __future__ import annotations
+
+from empirica.cli.command_handlers._workflow_shared import _weave_gate_block
+
+
+def test_connected_verdict_default_nudge(monkeypatch):
+    monkeypatch.delenv("EMPIRICA_ARTIFACT_GRAPH_GATE", raising=False)
+    g = _weave_gate_block(total_artifacts=3, edges_count=3)
+    assert g is not None
+    assert g["mode"] == "nudge"
+    assert g["verdict"] == "connected"
+    assert g["enforced"] is False
+
+
+def test_partial_and_disconnected(monkeypatch):
+    monkeypatch.delenv("EMPIRICA_ARTIFACT_GRAPH_GATE", raising=False)
+    assert _weave_gate_block(3, 1)["verdict"] == "partial"
+    assert _weave_gate_block(3, 0)["verdict"] == "disconnected"
+
+
+def test_off_returns_none(monkeypatch):
+    monkeypatch.setenv("EMPIRICA_ARTIFACT_GRAPH_GATE", "off")
+    assert _weave_gate_block(3, 3) is None
+
+
+def test_no_artifacts_returns_none(monkeypatch):
+    monkeypatch.delenv("EMPIRICA_ARTIFACT_GRAPH_GATE", raising=False)
+    assert _weave_gate_block(0, 0) is None
+
+
+def test_invalid_mode_falls_back_to_nudge(monkeypatch):
+    monkeypatch.setenv("EMPIRICA_ARTIFACT_GRAPH_GATE", "bogus")
+    assert _weave_gate_block(1, 1)["mode"] == "nudge"
+
+
+def test_never_enforces_even_in_hard_mode(monkeypatch):
+    monkeypatch.setenv("EMPIRICA_ARTIFACT_GRAPH_GATE", "hard")
+    g = _weave_gate_block(2, 0)
+    assert g["mode"] == "hard"
+    assert g["enforced"] is False  # report-only build — blocking is a follow-up


### PR DESCRIPTION
Gated Artifact-Graph map, **work-stream 1 (gate-promotion)** — the setting + verdict, **report-only** (goal `43471346`).

## What
POSTFLIGHT's retrospective now carries a **`weave_gate`** block: the gate **mode** (env `EMPIRICA_ARTIFACT_GRAPH_GATE` — `off|nudge|soft|hard`, default `nudge`) + a **connectivity verdict** (`connected`/`partial`/`disconnected`) from the now-accurate edge count (#251) vs artifact count.

## Report-only — zero behavior change
`enforced: False` at **every** mode in this PR. This lays the switch **without flipping it**. The soft/hard *blocking* behavior is a deliberate follow-up that needs the aggressiveness tuned (a product decision). `project.yaml` is the noted per-practice home for the mode when enforcement lands.

## Notes
- Gate wiring extracted to `_maybe_add_weave_gate` to hold `_build_retrospective`'s complexity under C901 (mirrors `_maybe_add_untriaged_notes`).
- This completes the map's **foundation**: edges written (#249) + surfaced (#250) + counted (#251) + now a mode-aware verdict surfaced (#252). The remaining work-streams (soft/hard *blocking*, adaptive weave-enforcement, `ungrounded_bypass`) are the behavior-changing half.

## Verify
6 tests (verdicts, all modes, report-only-never-enforces). `ruff check` + `ruff format --check` + `pyright` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)