### PR TITLE
feat(postflight): scalar control surface for the artifact-graph gate

### DIFF
--- a/docs/architecture/GATED_ARTIFACT_GRAPH.md
+++ b/docs/architecture/GATED_ARTIFACT_GRAPH.md
@@ -75,11 +75,14 @@ PRE ─▶ [ capture: note ] ─▶ ⟦weave-gate⟧ ─▶ CHECK ─▶ [ captu
 
 ## 5. Net-new work (the gaps — each a work-stream)
 
-1. **Gate promotion (Sentinel setting + ramp).** Flip the existing note-aware
-   soft-gate + connectivity checks from report/nudge → Sentinel gate. Ship as a
-   **setting** with a ramp: `off → nudge (today) → soft (warn, still pass) →
-   hard`. Default nudge; flip to hard once (2) is proven. Per-practice
-   configurable.
+1. **Gate promotion — scalar control surface (built: report-only).** The gate is
+   driven by **three orthogonal 0.0–1.0 scalar dimensions**, not a discrete
+   `off/nudge/soft/hard` mode. The extension's Sentinel config owns them as
+   **sliders**; the human sets them, the AI inherits them (see §5a). This build
+   ships the scalars + verdict computation **report-only** (`enforced: False` at
+   every setting); the actual soft/hard *blocking* keyed on `strictness` is the
+   remaining half of this work-stream. Per-practice configurable via env
+   transport (`EMPIRICA_ARTIFACT_GRAPH_STRICTNESS` / `_FLOOR` / `_PATIENCE`).
 2. **Schema-injection at the gate — the make-or-break.** CHECK and POSTFLIGHT
    responses inject the `log-artifacts` schema (node-type enum + relation
    vocabulary from `graph_commands.py`) **plus the transaction's linkable ids**
@@ -97,8 +100,44 @@ PRE ─▶ [ capture: note ] ─▶ ⟦weave-gate⟧ ─▶ CHECK ─▶ [ captu
    artifacts — **not** on absent notes (a single throwaway note must not satisfy
    it). Applied to the *next* transaction, and it **decays on compliance**
    (weave once → back to freedom). Earned-autonomy in both directions, matching
-   the Sentinel's adaptive thresholds.
+   the Sentinel's adaptive thresholds. The **`patience` scalar** (§5a) sets the
+   consecutive-miss tolerance before escalation — high patience forgives more
+   before it bites.
 5. **`ungrounded_bypass` (the `--yolo` bypass).** See §6.
+
+### 5a. The gate's control surface — three scalar dimensions (built)
+
+A discrete `off/nudge/soft/hard` mode is the wrong shape: it forces the human to
+pick a bucket when the real settings are continuous and *orthogonal*. The gate is
+instead three independent 0.0–1.0 sliders — the AI shaping how its own discipline
+gets enforced, via the extension's Sentinel config, which inherits how the human
+sets it:
+
+| Dimension | Slider question | Drives | Default |
+|---|---|---|---|
+| **strictness** | *How loud when connectivity is low?* | Response band: `silent` (<0.05) → `report` (<0.40) → `warn` (<0.70) → `enforce` (≥0.70) | `0.25` (report) |
+| **connectivity_floor** | *What fraction of artifacts must be woven?* | `satisfied = connected_ratio ≥ floor` | `0.50` |
+| **patience** | *How forgiving of consecutive misses?* | Adaptive-escalation window (work-stream 4) | `0.80` |
+
+Defaults keep a fresh install **report-only + forgiving** — the gate never blocks
+until a human dials `strictness` up. `strictness` *is* the axis the old ramp
+expressed, but as a continuum: old `off` = 0.0 (silent), `nudge` ≈ 0.25 (report),
+`soft` ≈ 0.5 (warn), `hard` ≈ 0.9 (enforce). What a single mode couldn't express
+is the split between **floor** (how much to weave) and **strictness** (how hard to
+push): a practice can now demand high connectivity but only warn, or tolerate low
+connectivity yet hard-block on it.
+
+Single source of truth: `_GATE_SCALARS` in `_workflow_shared.py` (default + env
+name per dimension, deliberately not duplicated across call sites — the
+engagement_gate's 12-site duplicated-default drift is the anti-pattern this
+avoids). Bad slider values clamp to `[0,1]` / fall back to default, so a bad
+config never breaks the retrospective. `_resolve_gate_scalars()` reads them;
+`_gate_response_for()` owns the strictness→band ladder (the *only* place that
+mapping lives); `_weave_gate_block()` returns `{scalars, response, verdict,
+connected_ratio, satisfied, enforced, note}`.
+
+`ungrounded_bypass` (§6) stays a **separate boolean**, not a fourth scalar — it's
+a categorical human capability-toggle, not a continuous dimension.
 
 ## 6. The bypass — `--yolo` (human-only)
 
@@ -145,8 +184,11 @@ by feeling the difference. Constraints that keep it honest, not theatrical:
 
 ## 9. Open questions
 
-- Default gate strictness per `work_type`? (e.g. `release` = nudge; `research` =
-  hard.)
+- Default scalar values per `work_type`? Now that strictness/floor/patience are
+  continuous (§5a), the question is which *triple* each work_type seeds (e.g.
+  `release` = low strictness + low floor; `research` = high floor, moderate
+  strictness) — and whether work_type sets defaults the human slider then
+  overrides, or the slider is absolute.
 - Reconcile the promotion-trigger with the existing "0 artifacts + 0 notes =
   strongest" soft-gate logic in `_workflow_preflight.py` — is the trigger a
   refinement of that function or a sibling signal?

--- a/empirica/cli/command_handlers/_workflow_shared.py
+++ b/empirica/cli/command_handlers/_workflow_shared.py
@@ -563,43 +563,123 @@ def _retro_count_edges(cursor, session_id: str, transaction_id: str | None) -> i
     return total
 
 
-_ARTIFACT_GRAPH_GATE_MODES = ("off", "nudge", "soft", "hard")
+# --- Artifact-graph gate: three orthogonal scalar dimensions -----------------
+# The extension's Sentinel config owns these as SLIDERS; the env vars are the
+# transport into the CLI. This dict is the SINGLE source of truth for both the
+# default values and the env-var names — deliberately not split across call
+# sites (the engagement_gate's 12-site duplicated-default mess is the anti-
+# pattern this avoids). Defaults keep a fresh install report-only + forgiving:
+# the gate never blocks until a human dials strictness up.
+_GATE_SCALARS = {
+    # key                  (default, env var)
+    "strictness": (0.25, "EMPIRICA_ARTIFACT_GRAPH_STRICTNESS"),
+    "connectivity_floor": (0.50, "EMPIRICA_ARTIFACT_GRAPH_FLOOR"),
+    "patience": (0.80, "EMPIRICA_ARTIFACT_GRAPH_PATIENCE"),
+}
+
+
+def _resolve_gate_scalars() -> dict:
+    """Resolve the gate's three scalar dimensions from env (Sentinel sliders).
+
+    - **strictness** — response intensity (drives ``_gate_response_for``).
+    - **connectivity_floor** — fraction of artifacts that must carry ≥1 edge to
+      count as satisfied.
+    - **patience** — adaptive forgiveness (consecutive-miss escalation; consumed
+      by the follow-up adaptive-enforcement work-stream, surfaced here so the
+      extension can render it).
+
+    Each is clamped to ``[0.0, 1.0]``; an absent or unparseable env value falls
+    back to its default. Never raises — a bad slider value must not break the
+    retrospective.
+    """
+    out: dict = {}
+    for key, (default, env) in _GATE_SCALARS.items():
+        raw = os.environ.get(env)
+        if raw is None:
+            out[key] = default
+            continue
+        try:
+            out[key] = max(0.0, min(1.0, float(raw)))
+        except (TypeError, ValueError):
+            out[key] = default
+    return out
+
+
+def _gate_response_for(strictness: float) -> str:
+    """Map the strictness scalar to a response band (the ONLY place this lives).
+
+    A single monotonic ladder — quieter below, louder above:
+
+    - ``silent`` (<0.05) — gate computes nothing, returns None (fully dialed down).
+    - ``report`` (<0.40) — verdict attached, no pressure (default band).
+    - ``warn``   (<0.70) — verdict + explicit "should weave more" language.
+    - ``enforce`` (≥0.70) — verdict + would-block signal. Blocking itself is a
+      follow-up work-stream; this build still returns ``enforced: False``.
+    """
+    if strictness < 0.05:
+        return "silent"
+    if strictness < 0.40:
+        return "report"
+    if strictness < 0.70:
+        return "warn"
+    return "enforce"
 
 
 def _weave_gate_block(total_artifacts: int, edges_count: int) -> dict | None:
-    """Artifact-graph gate verdict — the report-only foundation (map work-stream 1).
+    """Artifact-graph gate verdict — scalar-driven (map work-stream 1 foundation).
 
-    Reads the gate mode from ``EMPIRICA_ARTIFACT_GRAPH_GATE`` (off|nudge|soft|hard,
-    default ``nudge``) and reports a connectivity verdict from the transaction's
-    (now-accurate) edge count vs artifact count. **REPORT-ONLY at every mode in
-    this build** (`enforced: False`) — the soft/hard *blocking* behavior is a
-    deliberate follow-up that needs the aggressiveness tuned. Returns None when
-    the gate is ``off`` or there are no artifacts. project.yaml will be the
-    per-practice home for the mode once enforcement lands.
+    Reports a connectivity verdict from the transaction's (now-accurate) edge
+    count vs artifact count, shaped by the three scalar dimensions resolved from
+    the extension's Sentinel sliders (``_resolve_gate_scalars``). ``satisfied``
+    is measured against ``connectivity_floor``; the loudness of the ``note`` is
+    scaled by the ``strictness``-derived response band.
+
+    **REPORT-ONLY in this build** — ``enforced`` is always ``False``, even at the
+    ``enforce`` band. The actual soft/hard *blocking* is a deliberate follow-up
+    keyed on ``strictness`` (and ``patience`` for the adaptive escalation).
+    Returns None when strictness dials the gate fully ``silent`` (<0.05) or there
+    are no artifacts.
     """
-    mode = os.environ.get("EMPIRICA_ARTIFACT_GRAPH_GATE", "nudge").strip().lower()
-    if mode not in _ARTIFACT_GRAPH_GATE_MODES:
-        mode = "nudge"
-    if mode == "off" or total_artifacts < 1:
+    scalars = _resolve_gate_scalars()
+    response = _gate_response_for(scalars["strictness"])
+    if response == "silent" or total_artifacts < 1:
         return None
     connected = min(edges_count, total_artifacts)
+    connected_ratio = connected / total_artifacts if total_artifacts else 0.0
+    satisfied = connected_ratio >= scalars["connectivity_floor"]
     if connected >= total_artifacts:
         verdict = "connected"
     elif connected > 0:
         verdict = "partial"
     else:
         verdict = "disconnected"
+    pct = round(connected_ratio * 100)
+    floor_pct = round(scalars["connectivity_floor"] * 100)
+    if satisfied:
+        note = (
+            f"artifact-graph gate [{response}, report-only]: "
+            f"{connected}/{total_artifacts} artifacts connected ({pct}%) — "
+            f"meets the {floor_pct}% floor."
+        )
+    else:
+        lead = "SHOULD weave more" if response in ("warn", "enforce") else "consider weaving"
+        note = (
+            f"artifact-graph gate [{response}, report-only]: "
+            f"{connected}/{total_artifacts} artifacts connected ({pct}%), below the "
+            f"{floor_pct}% floor — {lead}. Structural goal-edges are automatic; add "
+            "semantic edges (log-artifacts nodes+edges, or --related-to / --edge on "
+            "any *-log) to raise connectivity. Blocking not yet active."
+        )
     return {
-        "mode": mode,
+        "scalars": scalars,
+        "response": response,
         "verdict": verdict,
+        "connected_ratio": round(connected_ratio, 3),
         "connected_artifacts": connected,
         "total_artifacts": total_artifacts,
-        "enforced": False,  # report-only build; soft/hard blocking is a follow-up
-        "note": (
-            f"artifact-graph gate [{mode}, report-only]: {connected}/{total_artifacts} "
-            "artifacts connected. Structural goal-edges are automatic; weave semantic "
-            "edges (log-artifacts) to raise connectivity. Soft/hard blocking not yet active."
-        ),
+        "satisfied": satisfied,
+        "enforced": False,  # report-only build; blocking keyed on strictness is a follow-up
+        "note": note,
     }
 
 

--- a/tests/test_weave_gate_block.py
+++ b/tests/test_weave_gate_block.py
@@ -1,48 +1,109 @@
-"""_weave_gate_block — report-only artifact-graph gate verdict.
+"""_weave_gate_block — scalar-driven artifact-graph gate verdict.
 
-Gated Artifact-Graph map, work-stream 1 foundation (goal 43471346). Reports the
-gate mode (env EMPIRICA_ARTIFACT_GRAPH_GATE, default nudge) + a connectivity
-verdict, but NEVER blocks in this build (`enforced: False`) — the soft/hard
-blocking is a deliberate follow-up.
+Gated Artifact-Graph map, work-stream 1 foundation (goal 43471346). Three
+orthogonal 0.0–1.0 dimensions — strictness / connectivity_floor / patience —
+resolved from env (the extension's Sentinel sliders). REPORT-ONLY in this
+build: `enforced` is always False even at the `enforce` response band; the
+soft/hard *blocking* is a deliberate follow-up keyed on strictness.
 """
 
 from __future__ import annotations
 
-from empirica.cli.command_handlers._workflow_shared import _weave_gate_block
+from empirica.cli.command_handlers._workflow_shared import (
+    _gate_response_for,
+    _resolve_gate_scalars,
+    _weave_gate_block,
+)
+
+_ENV = (
+    "EMPIRICA_ARTIFACT_GRAPH_STRICTNESS",
+    "EMPIRICA_ARTIFACT_GRAPH_FLOOR",
+    "EMPIRICA_ARTIFACT_GRAPH_PATIENCE",
+)
 
 
-def test_connected_verdict_default_nudge(monkeypatch):
-    monkeypatch.delenv("EMPIRICA_ARTIFACT_GRAPH_GATE", raising=False)
+def _clear(monkeypatch):
+    for e in _ENV:
+        monkeypatch.delenv(e, raising=False)
+
+
+def test_default_scalars_are_report_only_and_forgiving(monkeypatch):
+    _clear(monkeypatch)
+    assert _resolve_gate_scalars() == {
+        "strictness": 0.25,
+        "connectivity_floor": 0.50,
+        "patience": 0.80,
+    }
+
+
+def test_scalars_env_driven_and_clamped(monkeypatch):
+    _clear(monkeypatch)
+    monkeypatch.setenv("EMPIRICA_ARTIFACT_GRAPH_STRICTNESS", "0.9")
+    monkeypatch.setenv("EMPIRICA_ARTIFACT_GRAPH_FLOOR", "1.5")  # clamps to 1.0
+    monkeypatch.setenv("EMPIRICA_ARTIFACT_GRAPH_PATIENCE", "-3")  # clamps to 0.0
+    s = _resolve_gate_scalars()
+    assert s["strictness"] == 0.9
+    assert s["connectivity_floor"] == 1.0
+    assert s["patience"] == 0.0
+
+
+def test_bad_env_value_falls_back_to_default(monkeypatch):
+    _clear(monkeypatch)
+    monkeypatch.setenv("EMPIRICA_ARTIFACT_GRAPH_STRICTNESS", "not-a-number")
+    assert _resolve_gate_scalars()["strictness"] == 0.25
+
+
+def test_response_bands_ladder():
+    assert _gate_response_for(0.0) == "silent"
+    assert _gate_response_for(0.04) == "silent"
+    assert _gate_response_for(0.05) == "report"
+    assert _gate_response_for(0.25) == "report"
+    assert _gate_response_for(0.40) == "warn"
+    assert _gate_response_for(0.69) == "warn"
+    assert _gate_response_for(0.70) == "enforce"
+    assert _gate_response_for(1.0) == "enforce"
+
+
+def test_connected_verdict_at_default(monkeypatch):
+    _clear(monkeypatch)
     g = _weave_gate_block(total_artifacts=3, edges_count=3)
     assert g is not None
-    assert g["mode"] == "nudge"
+    assert g["response"] == "report"
     assert g["verdict"] == "connected"
+    assert g["connected_ratio"] == 1.0
+    assert g["satisfied"] is True
     assert g["enforced"] is False
 
 
 def test_partial_and_disconnected(monkeypatch):
-    monkeypatch.delenv("EMPIRICA_ARTIFACT_GRAPH_GATE", raising=False)
-    assert _weave_gate_block(3, 1)["verdict"] == "partial"
+    _clear(monkeypatch)
+    partial = _weave_gate_block(4, 1)
+    assert partial["verdict"] == "partial"
+    assert partial["satisfied"] is False  # 0.25 ratio < 0.50 floor
     assert _weave_gate_block(3, 0)["verdict"] == "disconnected"
 
 
-def test_off_returns_none(monkeypatch):
-    monkeypatch.setenv("EMPIRICA_ARTIFACT_GRAPH_GATE", "off")
+def test_connectivity_floor_governs_satisfied(monkeypatch):
+    _clear(monkeypatch)
+    monkeypatch.setenv("EMPIRICA_ARTIFACT_GRAPH_FLOOR", "0.25")
+    # 1/4 connected = 0.25 ratio, now meets a 0.25 floor
+    assert _weave_gate_block(4, 1)["satisfied"] is True
+
+
+def test_silent_strictness_returns_none(monkeypatch):
+    _clear(monkeypatch)
+    monkeypatch.setenv("EMPIRICA_ARTIFACT_GRAPH_STRICTNESS", "0.0")
     assert _weave_gate_block(3, 3) is None
 
 
 def test_no_artifacts_returns_none(monkeypatch):
-    monkeypatch.delenv("EMPIRICA_ARTIFACT_GRAPH_GATE", raising=False)
+    _clear(monkeypatch)
     assert _weave_gate_block(0, 0) is None
 
 
-def test_invalid_mode_falls_back_to_nudge(monkeypatch):
-    monkeypatch.setenv("EMPIRICA_ARTIFACT_GRAPH_GATE", "bogus")
-    assert _weave_gate_block(1, 1)["mode"] == "nudge"
-
-
-def test_never_enforces_even_in_hard_mode(monkeypatch):
-    monkeypatch.setenv("EMPIRICA_ARTIFACT_GRAPH_GATE", "hard")
+def test_never_enforces_even_at_enforce_band(monkeypatch):
+    _clear(monkeypatch)
+    monkeypatch.setenv("EMPIRICA_ARTIFACT_GRAPH_STRICTNESS", "0.9")
     g = _weave_gate_block(2, 0)
-    assert g["mode"] == "hard"
+    assert g["response"] == "enforce"
     assert g["enforced"] is False  # report-only build — blocking is a follow-up


### PR DESCRIPTION
## What

Replaces the discrete `off|nudge|soft|hard` artifact-graph gate mode with **three orthogonal 0.0–1.0 scalar dimensions** the extension's Sentinel config drives as **sliders** — the AI shaping how its own discipline enforcement gets handled, inheriting how the human sets it.

| Dimension | Slider question | Drives | Default |
|---|---|---|---|
| **strictness** | *How loud when connectivity is low?* | response band: `silent`<0.05 / `report`<0.40 / `warn`<0.70 / `enforce`≥0.70 | `0.25` |
| **connectivity_floor** | *What fraction of artifacts must be woven?* | `satisfied = connected_ratio ≥ floor` | `0.50` |
| **patience** | *How forgiving of consecutive misses?* | adaptive-escalation window (work-stream 4) | `0.80` |

## Why scalars, not a mode

A single mode forces the human to pick a bucket when the real settings are continuous **and orthogonal**. The floor/strictness split is exactly what a mode couldn't express: a practice can now demand high connectivity but only warn, or tolerate low connectivity yet hard-block on it. `strictness` *is* the old ramp as a continuum (`off`=0.0 silent, `nudge`≈0.25 report, `soft`≈0.5 warn, `hard`≈0.9 enforce).

## Still report-only

`enforced` stays `False` at every setting in this build. The actual soft/hard **blocking** keyed on `strictness` is the remaining half of map work-stream 1. `ungrounded_bypass` (`--yolo`) stays a **separate boolean**, not a fourth scalar.

## Single source of truth

`_GATE_SCALARS` carries `(default, env-name)` per dimension — deliberately not duplicated across call sites (the engagement_gate's 12-site duplicated-default drift is the anti-pattern avoided). `_resolve_gate_scalars()` reads + clamps `[0,1]` with default fallback (a bad slider value never breaks the retrospective); `_gate_response_for()` owns the strictness→band ladder (the only place that mapping lives); `_weave_gate_block()` returns `{scalars, response, verdict, connected_ratio, satisfied, enforced, note}`.

## Changes
- `_workflow_shared.py` — `_GATE_SCALARS`, `_resolve_gate_scalars()`, `_gate_response_for()`, scalar-driven `_weave_gate_block()` (old `_ARTIFACT_GRAPH_GATE_MODES` + `EMPIRICA_ARTIFACT_GRAPH_GATE` removed)
- `GATED_ARTIFACT_GRAPH.md` — new §5a (control surface), work-stream 1/4 + open-questions updated
- `test_weave_gate_block.py` — rewritten (10 tests)

## Checks
`py_compile` ✓ · `ruff check` ✓ · `ruff format --check` ✓ · `pyright` 0/0/0 ✓ · `pytest` 16/16 ✓ (weave-gate + edge-counter + weave-guidance + postflight-auto-edges)

Part of the Gated Artifact-Graph Discipline map (goal `43471346`), continuing PRs #249–#252.

🤖 Generated with [Claude Code](https://claude.com/claude-code)