### PR TITLE
fix(session-create): --auto-init adopts existing project_id instead of minting

### DIFF
--- a/empirica/cli/command_handlers/session_create.py
+++ b/empirica/cli/command_handlers/session_create.py
@@ -330,6 +330,18 @@ def _handle_auto_init(args, output_format, project_id):
         if output_format != "json":
             print("🔧 Auto-initializing Empirica in this repository...")
 
+        # Adopt-before-mint (data-integrity fix, mesh prop_xa6djztv5rfbnhvkcts63q6vba):
+        # if this path already has a canonical project_id in any authoritative
+        # local source (sessions.db → registry.yaml → workspace.db), ADOPT it so
+        # project-init links to it instead of minting a fresh id that would then
+        # "correct" the canonical workspace row AWAY toward the mint. adopted_id
+        # is None for a genuinely-new project → project-init mints as before.
+        from empirica.cli.command_handlers.workspace_init import _adopt_existing_project_id
+
+        adopted_id, adopted_source = _adopt_existing_project_id(git_root)
+        if adopted_id and output_format != "json":
+            print(f"   🔗 Adopting existing project_id {adopted_id[:8]}… (from {adopted_source})")
+
         try:
             from types import SimpleNamespace
 
@@ -343,6 +355,7 @@ def _handle_auto_init(args, output_format, project_id):
                 enable_beads=False,
                 create_semantic_index=False,
                 force=False,
+                project_id=adopted_id,  # None → mint (new); set → adopt canonical
             )
 
             result = handle_project_init_command(init_args)

--- a/empirica/cli/command_handlers/workspace_init.py
+++ b/empirica/cli/command_handlers/workspace_init.py
@@ -839,6 +839,74 @@ def _get_existing_project_id_from_local_db(repo_path: Path) -> str | None:
         return None
 
 
+def _adopt_existing_project_id(  # pyright: ignore[reportUnusedFunction]  # used by session_create._handle_auto_init
+    git_root: Path,
+) -> tuple[str | None, str | None]:
+    """Find a pre-existing canonical project_id for this path, to ADOPT not mint.
+
+    Data-integrity fix (recurring, mesh prop_xa6djztv5rfbnhvkcts63q6vba):
+    ``session-create --auto-init`` used to mint a fresh id whenever
+    ``project.yaml`` was absent — even when the path already had a canonical id
+    in the local sessions.db, the daemon registry, or workspace.db. The fresh
+    mint then flowed into ``_register_in_workspace_db``, which "corrected" the
+    canonical ``global_projects`` row TOWARD the mint (an inverted correction
+    that stranded the live session + open transaction + N artifacts under a
+    phantom id). Adopt the existing id instead; mint only when all sources are
+    empty (genuinely new project).
+
+    Resolution order — most authoritative first, and **offline-only** (auto-init
+    is a hot path that must not block on the network; the cortex roster is a
+    deferred network-guarded source):
+
+      1. local sessions.db — the client-UUID-wins source of truth for identity
+      2. registry.yaml     — the daemon's served set (match by filesystem path)
+      3. workspace.db      — global_projects (match by trajectory_path); this is
+                             where the repro's canonical id demonstrably lived
+
+    Returns ``(project_id, source_label)`` or ``(None, None)``. A source that
+    *raises* (locked/corrupt DB) logs a warning and falls through — the
+    fall-through to mint must never be silent (it would re-introduce the bug).
+    """
+    # 1. Local sessions.db — source of truth for project identity.
+    local_id = _get_existing_project_id_from_local_db(git_root)
+    if local_id:
+        return local_id, "local sessions.db"
+
+    # 2. registry.yaml — the daemon's served set, matched by filesystem path.
+    try:
+        from empirica.api.registry import load_registry
+
+        target = str(git_root)
+        for entry in load_registry().get("projects", []):
+            if entry.get("path") == target and entry.get("project_id"):
+                return entry["project_id"], "registry.yaml"
+    except Exception as e:
+        logger.warning(f"auto-init adopt: registry.yaml lookup failed (falling through): {e}")
+
+    # 3. workspace.db global_projects — keyed by trajectory_path.
+    try:
+        import sqlite3
+
+        workspace_db = Path.home() / ".empirica" / "workspace" / "workspace.db"
+        if workspace_db.exists():
+            conn = sqlite3.connect(str(workspace_db))
+            try:
+                cursor = conn.cursor()
+                cursor.execute(
+                    "SELECT id FROM global_projects WHERE trajectory_path = ? LIMIT 1",
+                    (str(git_root / ".empirica"),),
+                )
+                row = cursor.fetchone()
+                if row and row[0]:
+                    return row[0], "workspace.db"
+            finally:
+                conn.close()
+    except Exception as e:
+        logger.warning(f"auto-init adopt: workspace.db lookup failed (falling through): {e}")
+
+    return None, None
+
+
 def _generate_project_config(repo_path: Path, project_id: str, repo_info: dict):
     """Generate .empirica-project/PROJECT_CONFIG.yaml"""
     config_dir = repo_path / ".empirica-project"

--- a/tests/test_auto_init_adopt.py
+++ b/tests/test_auto_init_adopt.py
@@ -1,0 +1,111 @@
+"""_adopt_existing_project_id — adopt-before-mint for session-create --auto-init.
+
+Regression guard for the recurring inverted-correction data-integrity bug
+(mesh prop_xa6djztv5rfbnhvkcts63q6vba): --auto-init minted a fresh project_id
+whenever project.yaml was absent, even when the path already carried a canonical
+id in the local sessions.db / registry.yaml / workspace.db — then the mint
+"corrected" the canonical workspace row away, stranding the live session under a
+phantom id. The helper adopts the existing id (authority order: sessions.db →
+registry.yaml → workspace.db); mints only when all three are empty.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from empirica.cli.command_handlers.workspace_init import _adopt_existing_project_id
+
+_CANON = "e15a54eb-0000-4000-8000-000000000001"
+_OTHER = "9e2b958f-0000-4000-8000-000000000002"
+
+
+def _mk_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "empirica-screenshot"
+    (repo / ".empirica").mkdir(parents=True)
+    return repo
+
+
+def _seed_local_sessions_db(repo: Path, project_id: str) -> None:
+    db = repo / ".empirica" / "sessions" / "sessions.db"
+    db.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(db))
+    conn.execute("CREATE TABLE projects (id TEXT, name TEXT, created_timestamp REAL)")
+    conn.execute("INSERT INTO projects VALUES (?, ?, 0)", (project_id, repo.name))
+    conn.commit()
+    conn.close()
+
+
+def _seed_workspace_db(home: Path, trajectory_path: str, project_id: str) -> None:
+    db = home / ".empirica" / "workspace" / "workspace.db"
+    db.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(db))
+    conn.execute("CREATE TABLE global_projects (id TEXT, trajectory_path TEXT)")
+    conn.execute("INSERT INTO global_projects VALUES (?, ?)", (project_id, trajectory_path))
+    conn.commit()
+    conn.close()
+
+
+def _seed_registry(home: Path, repo: Path, project_id: str) -> None:
+    import yaml
+
+    reg = home / ".empirica" / "registry.yaml"
+    reg.parent.mkdir(parents=True, exist_ok=True)
+    reg.write_text(
+        yaml.dump({"version": 1, "projects": [{"project_id": project_id, "path": str(repo)}]}),
+        encoding="utf-8",
+    )
+
+
+def test_adopts_from_local_sessions_db(tmp_path, monkeypatch):
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path / "home"))
+    repo = _mk_repo(tmp_path)
+    _seed_local_sessions_db(repo, _CANON)
+    pid, source = _adopt_existing_project_id(repo)
+    assert pid == _CANON
+    assert source == "local sessions.db"
+
+
+def test_adopts_from_registry_when_no_local_db(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    repo = _mk_repo(tmp_path)
+    _seed_registry(home, repo, _CANON)
+    # DEFAULT_REGISTRY_PATH is bound at import time, so Path.home() patching
+    # alone doesn't redirect load_registry() — point the constant at the tmp file.
+    monkeypatch.setattr(
+        "empirica.api.registry.DEFAULT_REGISTRY_PATH",
+        home / ".empirica" / "registry.yaml",
+    )
+    pid, source = _adopt_existing_project_id(repo)
+    assert pid == _CANON
+    assert source == "registry.yaml"
+
+
+def test_adopts_from_workspace_db_as_last_local_source(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    repo = _mk_repo(tmp_path)
+    _seed_workspace_db(home, str(repo / ".empirica"), _CANON)
+    pid, source = _adopt_existing_project_id(repo)
+    assert pid == _CANON
+    assert source == "workspace.db"
+
+
+def test_local_db_wins_over_workspace_on_disagreement(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    repo = _mk_repo(tmp_path)
+    _seed_local_sessions_db(repo, _CANON)  # authoritative
+    _seed_workspace_db(home, str(repo / ".empirica"), _OTHER)  # drifted
+    pid, source = _adopt_existing_project_id(repo)
+    assert pid == _CANON  # client-UUID-wins — sessions.db is source of truth
+    assert source == "local sessions.db"
+
+
+def test_returns_none_for_genuinely_new_project(tmp_path, monkeypatch):
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path / "home"))
+    repo = _mk_repo(tmp_path)  # no sessions.db, no registry, no workspace.db
+    pid, source = _adopt_existing_project_id(repo)
+    assert pid is None
+    assert source is None


### PR DESCRIPTION
## The bug (recurring data-integrity, 3rd occurrence, mesh-endorsed)

`session-create --auto-init` **minted a fresh `project_id`** whenever `project.yaml` was absent — even when the path already had a canonical id in the local sessions.db, the daemon registry, or workspace.db. The fresh mint then flowed into `_register_in_workspace_db`, which "corrected" the canonical `global_projects` row (keyed by `trajectory_path`) **toward** the mint:

```
Correcting UUID mismatch for empirica-screenshot:
  workspace had e15a54eb..., using 9e2b958f...
```

That correction is **inverted** — it corrects *away* from the canonical, stranding the live session + open transaction + N artifacts under a phantom id.

## Root cause

`project-init` already honors `args.project_id` (adopt path, no mint — `_resolve_or_create_project` line 36–39), but `--auto-init` never supplied one. **Minting ran before any adoption lookup.**

## Fix — adopt-before-mint

New `_adopt_existing_project_id(git_root)` resolves a canonical id from local sources in authority order and hands it to `project-init` as `init_args.project_id` (`None` → mint, for genuinely-new projects):

1. **local sessions.db** — client-UUID-wins source of truth for identity
2. **registry.yaml** — the daemon's served set (filesystem-path match)
3. **workspace.db** — `global_projects` (trajectory_path match) — where the repro's canonical id demonstrably lived

**Offline-only by design:** auto-init is a hot path that must not block on the network, and the three local sources cover all three reported repros. Cortex-roster adoption (Philipp's spec step 3) is a deferred network-guarded follow-up. Adoption-source read failures **log a warning, never silent** — a silent fall-through to mint would re-introduce the bug (fallback-masks-primary).

`_register_in_workspace_db`'s correction is left intact: it's correct once the incoming id is truly canonical (client-UUID-wins); the defect was auto-init supplying a non-canonical mint, not the correction itself.

## Tests
5 unit tests on `_adopt_existing_project_id` — each source, resolution order (local-db wins on drift), genuinely-new → `(None, None)`. Existing `test_session_create_auto_init_wiring` + `test_project_init_chicken_egg` stay green (25 passed in the related suites).

`py_compile` ✓ · `ruff check` ✓ · `ruff format --check` ✓ · `pyright` 0/0/0 ✓

Fixes the recurring mesh-reported inverted-correction. Endorsed spec from Philipp's mesh-support; routed to core.

🤖 Generated with [Claude Code](https://claude.com/claude-code)