### PR TITLE
fix(sentinel): dangerous file redirects no longer laundered through chain segments

### DIFF
--- a/empirica/plugins/claude-code-integration/hooks/sentinel-gate.py
+++ b/empirica/plugins/claude-code-integration/hooks/sentinel-gate.py
@@ -1795,6 +1795,16 @@ def _is_segment_safe(segment: str) -> bool:
     if not clean:
         return True
 
+    # 0. A dangerous file redirect (`> f`, `>> f`, `< f`) is a praxic side effect
+    # even when the command word is a safe prefix — `grep x > out` WRITES a file.
+    # A single command is caught by is_safe_bash_command's top-level redirect
+    # check, but a CHAIN segment reaches here via _classify_chain BEFORE that
+    # check runs — so without this, `cd /x && grep foo > /tmp/out` launders a
+    # redirect past the gate. (Safe redirects like `2>/dev/null` were already
+    # stripped from `clean` above, so anything left is a real one.)
+    if _has_dangerous_redirects(clean):
+        return False
+
     # 1. Validate every embedded $() and backtick substitution. The inner
     # command must independently be safe — we treat substitutions as
     # opaque-but-validated; their text doesn't hide unsafe commands.

--- a/tests/test_sentinel_shell_constructs.py
+++ b/tests/test_sentinel_shell_constructs.py
@@ -475,3 +475,61 @@ class TestNoeticAllowlistExpansion:
     def test_guard_no_false_positive(self, gate, cmd):
         assert gate._has_dangerous_tool_flags(cmd) is False
         assert gate._matches_safe_prefix(cmd) is True
+
+
+class TestNoeticCompoundAndBootstrap:
+    """Regression lock for ecodex's noetic-whitelist gap report (prop_3ucy5y7f).
+
+    ecodex reported two shapes CHECK-gated on a stale-vendored sentinel-gate.py:
+      (1) `cd <dir> && <noetic>` (grep / `empirica noetic-batch`) — allegedly
+          gated because the whitelist "prefix-matches so a leading cd defeats it";
+      (2) `empirica project-bootstrap` — allegedly treated praxic.
+
+    Both are ALREADY noetic in current develop: `_classify_chain` segment-classifies
+    &&/;/|| chains (a leading `cd` no longer defeats it — every segment is checked),
+    and project-bootstrap is Tier-1. These tests lock that contract so the reported
+    shapes can't silently regress, and stand as executable proof the fix is in-tree
+    (the report was a stale vendored copy — re-vendor resolves it).
+    """
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "cd /home/u/proj && grep -rn pattern src/",
+            "cd /home/u/proj && rg pattern",
+            "cd /home/u/proj && empirica noetic-batch -",
+            "cd /home/u/proj && empirica project-search --task 'foo'",
+            "cd /home/u/proj && empirica project-bootstrap",
+            "cd /home/u/proj && empirica goals-list",
+        ],
+    )
+    def test_cd_then_noetic_is_safe(self, gate, cmd):
+        # A leading `cd` must NOT defeat the whitelist — the chain is
+        # segment-classified, so each segment (cd + the noetic op) is checked.
+        assert gate.is_safe_bash_command({"command": cmd}) is True
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "empirica project-bootstrap",
+            "empirica project-bootstrap --output json",
+            "empirica project-bootstrap --session-id abc123",
+            "empirica noetic-batch -",
+        ],
+    )
+    def test_bootstrap_and_noetic_batch_are_tier1(self, gate, cmd):
+        assert gate.is_safe_empirica_command(cmd) is True
+        assert gate.is_safe_bash_command({"command": cmd}) is True
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "cd /home/u/proj && rm -rf /",
+            "cd /home/u/proj && grep x file > /tmp/out",
+            "cd /home/u/proj && python3 -c 'import os; os.remove(\"x\")'",
+        ],
+    )
+    def test_leading_cd_does_not_smuggle_praxic(self, gate, cmd):
+        # The security invariant behind the fix: segment-classification means a
+        # safe leading `cd` can't launder an unsafe tail past the gate.
+        assert gate.is_safe_bash_command({"command": cmd}) is False


### PR DESCRIPTION
## Context

Verifying ecodex's noetic-whitelist gap report (`prop_3ucy5y7f`). **Both cited shapes are already noetic in current develop** — `cd && grep` / `cd && empirica noetic-batch` are segment-classified by `_classify_chain`, and `empirica project-bootstrap` is Tier-1. ecodex is on a **stale vendored copy** of `sentinel-gate.py`; re-vendoring resolves their report. No fix was needed for what they reported.

## The real gap (found by a negative-control test)

While locking their shapes with regression tests, the security negative-control caught a genuine bug:

```
cd /x && grep foo > /tmp/out   →  classified NOETIC  (but it WRITES /tmp/out)
```

**Root cause:** `_classify_chain` short-circuits `is_safe_bash_command` *before* its top-level `_has_dangerous_redirects` check, and `_is_segment_safe` matched the `grep ` safe-prefix without checking for a redirect. So a file redirect (a praxic write) was **laundered past the gate whenever it followed a chain operator** — even though the single-command form `grep foo > /tmp/out` was correctly gated. Redirect gating was inconsistent between single commands and chain segments.

## Fix

`_is_segment_safe` now rejects a segment carrying a dangerous redirect (`> f`, `>> f`, `< f`), aligning chain-segment classification with single-command behavior. Safe redirects (`2>/dev/null`) are already stripped from the segment before the check, so only real ones trip it. One added guard, early-return.

## Tests

New `TestNoeticCompoundAndBootstrap` (13 cases) locks:
- ecodex's exact shapes as **noetic** — `cd && grep/rg/noetic-batch/project-search/goals-list`, bare `project-bootstrap` + `noetic-batch` as Tier-1 (executable proof the report was stale)
- the **security invariant** — a leading `cd` can't smuggle `rm -rf`, a `> redirect`, or `python3 -c` past the gate

122 `shell_constructs` + 236 `sentinel` tests green. `py_compile` ✓ · `ruff check` ✓ · `ruff format --check` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)