### PR TITLE
fix(sentinel): whitelist the empirica mailbox CLI family (wake-first receive path)

### DIFF
--- a/empirica/plugins/claude-code-integration/hooks/sentinel-gate.py
+++ b/empirica/plugins/claude-code-integration/hooks/sentinel-gate.py
@@ -716,6 +716,13 @@ EMPIRICA_TIER1_PREFIXES = (
     "empirica status",  # Multi-instance status overview
     "empirica tui",  # Interactive cockpit (Textual app — destructive ops are modal-confirmed)
     "empirica notify ",  # Notification primitive — loops/hooks call this in any phase
+    # Mailbox RECEIVE side (pure reads) — MUST be Tier 1 so a mesh-woken IDLE
+    # practitioner can run `empirica mailbox poll` as its FIRST action (no open
+    # transaction). Without this, the wake→poll→react last mile the mailbox CLI
+    # (#255) exists to close is denied "No open transaction". Cortex classified
+    # mailbox reads as noetic (prop_iefo2tdx); the poll/show verbs only GET.
+    "empirica mailbox poll",  # Read cortex inbox/outbox (pure read)
+    "empirica mailbox show",  # Read one proposal body (pure read)
 )
 
 # Tier 2: State-changing commands - allowed (these ARE the epistemic workflow)
@@ -735,6 +742,12 @@ EMPIRICA_TIER2_PREFIXES = (
     "empirica log-artifacts",
     "empirica resolve-artifacts",
     "empirica delete-artifacts",  # Batch artifact operations
+    # Mailbox SEND/hygiene side — state-changing but part of the mesh workflow
+    # (ack + inbox hygiene), so they flow pre-transaction like the *-log verbs.
+    # `reply` is the atomic propose+complete ack (mesh ack is noetic per
+    # prop_iefo2tdx); `archive` soft-deletes from the inbox view.
+    "empirica mailbox reply",  # Atomic propose + complete (mesh ack)
+    "empirica mailbox archive",  # Soft-delete a proposal from inbox view
     "empirica goals-create",
     "empirica goal-create",
     "empirica gc",  # Goal create + aliases

--- a/tests/test_sentinel_mailbox_cli_whitelist.py
+++ b/tests/test_sentinel_mailbox_cli_whitelist.py
@@ -1,0 +1,75 @@
+"""Sentinel whitelist coverage for the `empirica mailbox` CLI family.
+
+Regression lock for ecodex prop_b77tsh6o: #255 shipped `empirica mailbox
+poll/show/reply/archive` but never added them to sentinel-gate.py's tiered CLI
+whitelist. Consequence: `is_safe_empirica_command("empirica mailbox poll …")`
+was False, so in `_handle_no_preflight` (mesh-woken IDLE practitioner, no open
+transaction) the command was denied "No open transaction" — breaking the exact
+wake→poll→react last mile the mailbox CLI exists to close.
+
+Fix: reads (poll/show) → Tier 1 (any phase); state-changing workflow verbs
+(reply/archive) → Tier 2. Both satisfy is_safe_empirica_command → all four flow
+pre-transaction, preserving the read-vs-mutation split.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+PLUGIN_HOOKS = Path(__file__).parent.parent / "empirica" / "plugins" / "claude-code-integration" / "hooks"
+
+
+def _load_sentinel_gate():
+    if "sentinel_gate" in sys.modules:
+        del sys.modules["sentinel_gate"]
+    spec = importlib.util.spec_from_file_location("sentinel_gate", PLUGIN_HOOKS / "sentinel-gate.py")
+    mod = importlib.util.module_from_spec(spec)
+    sys.path.insert(0, str(PLUGIN_HOOKS.parent / "lib"))
+    try:
+        spec.loader.exec_module(mod)
+    finally:
+        sys.path.pop(0)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def gate():
+    return _load_sentinel_gate()
+
+
+# All four verbs must classify as safe empirica commands (flow pre-transaction).
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        "empirica mailbox poll --ai-id empirica.david.empirica --output json",
+        "empirica mailbox poll --outbox --status completed,changed",
+        "empirica mailbox show prop_abc123 --output json",
+        "empirica mailbox reply --parent-id prop_x --summary 'done' --result shipped",
+        "empirica mailbox archive prop_x --reason cleanup",
+    ],
+)
+def test_mailbox_verbs_are_safe_empirica_commands(gate, cmd):
+    assert gate.is_safe_empirica_command(cmd) is True
+    assert gate.is_safe_bash_command({"command": cmd}) is True
+
+
+# Read-vs-mutation split: poll/show are Tier 1, reply/archive are Tier 2.
+def test_reads_are_tier1(gate):
+    assert "empirica mailbox poll" in gate.EMPIRICA_TIER1_PREFIXES
+    assert "empirica mailbox show" in gate.EMPIRICA_TIER1_PREFIXES
+
+
+def test_mutations_are_tier2(gate):
+    assert "empirica mailbox reply" in gate.EMPIRICA_TIER2_PREFIXES
+    assert "empirica mailbox archive" in gate.EMPIRICA_TIER2_PREFIXES
+
+
+# Load-bearing case: the wake-first-action poll — segment-safe inside a
+# `cd <dir> && …` chain too (a woken practitioner's first shell line).
+def test_wake_first_poll_in_cd_chain_is_safe(gate):
+    cmd = "cd /home/u/proj && empirica mailbox poll --ai-id empirica.david.empirica --output json"
+    assert gate.is_safe_bash_command({"command": cmd}) is True


### PR DESCRIPTION
## The gap (my #255 omission, verified canonical)

#255 shipped `empirica mailbox poll/show/reply/archive` but never added them to `sentinel-gate.py`'s tiered CLI whitelist. So `is_safe_empirica_command("empirica mailbox poll …")` returned **False** → in `_handle_no_preflight` (a mesh-woken **idle** practitioner, no open transaction) the command was denied *"No open transaction"* — blocking the exact wake→poll→react last mile the mailbox CLI exists to close.

Live in the **canonical** hook, not a stale copy (ecodex verified in `prop_b77tsh6o`). This fix mirrors their vendored `e1662ee27a` to keep core + ecodex converged.

## Fix — read/mutation split

Mirrors the `loop`/`listener`/`notify` whitelisting precedent + cortex's "mailbox reads + ack are noetic" (`prop_iefo2tdx`):

| Verb | Tier | Why |
|---|---|---|
| `mailbox poll`, `mailbox show` | **Tier 1** (read, any phase) | pure GETs |
| `mailbox reply`, `mailbox archive` | **Tier 2** (state-changing workflow) | ack + inbox hygiene — flow like the `*-log` verbs |

Both tiers satisfy `is_safe_empirica_command`, so all four flow pre-transaction; the split preserves read-vs-mutation semantics.

## Tests
New `test_sentinel_mailbox_cli_whitelist.py` (8 cases): all four verbs safe, Tier1/Tier2 placement, and the **load-bearing** wake-first case (`cd <dir> && empirica mailbox poll` allowed with no open tx). 244 sentinel tests green. `py_compile` ✓ · `ruff` ✓.

**Lesson:** adding a CLI verb requires a matching Sentinel whitelist entry — otherwise it's silently denied pre-transaction. (Directly closes the receive-side wake path #255 opened.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)