### PR TITLE
test(sentinel): lock tool-flag-in-chain guard at the integration level

### DIFF
--- a/tests/test_sentinel_shell_constructs.py
+++ b/tests/test_sentinel_shell_constructs.py
@@ -525,8 +525,16 @@ class TestNoeticCompoundAndBootstrap:
         "cmd",
         [
             "cd /home/u/proj && rm -rf /",
-            "cd /home/u/proj && grep x file > /tmp/out",
+            "cd /home/u/proj && grep x file > /tmp/out",  # redirect (#256)
             "cd /home/u/proj && python3 -c 'import os; os.remove(\"x\")'",
+            # Write-FLAG holes on otherwise-inert tools — a leading `cd` must not
+            # launder these through a chain segment either (broccoli sweep guard:
+            # locks the _matches_safe_prefix → _has_dangerous_tool_flags path at
+            # the chain-segment integration level, not just the unit level).
+            "cd /home/u/proj && find . -delete",
+            "cd /home/u/proj && sed -i 's/a/b/' f",
+            "cd /home/u/proj && yq -i '.x=1' f",
+            "cd /home/u/proj && sort -o out in",
         ],
     )
     def test_leading_cd_does_not_smuggle_praxic(self, gate, cmd):


### PR DESCRIPTION
## What

Broccoli-sweep follow-up (test-only, no behavior change). #256 locked the "a leading `cd` can't launder a praxic tail through a chain segment" invariant for **redirects / `rm` / `python3`**, but the write-**flag** holes (`find -delete`, `sed -i`, `yq -i`, `sort -o`) were only tested at the `_matches_safe_prefix` *unit* level.

Empirically they're already rejected per-segment (`_is_segment_safe` step 4 → `_matches_safe_prefix` → `_has_dangerous_tool_flags`) — verified in the sweep — but nothing locked that at the **chain-segment integration level**. A future `_is_segment_safe` refactor could silently reintroduce the laundering.

## Change

4 cases added to `test_leading_cd_does_not_smuggle_praxic`:
`cd && find -delete`, `cd && sed -i`, `cd && yq -i`, `cd && sort -o` → all classify praxic.

17 cases in `TestNoeticCompoundAndBootstrap`; sentinel suite green. ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)