### PR TITLE
docs: document the mailbox receive CLI + CHANGELOG [Unreleased] (sweep remediation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,40 @@ All notable changes to Empirica will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **`empirica mailbox poll` / `show` / `archive` — the receive side of the mesh
+  CLI.** Symmetric with `empirica mailbox reply` (send/ack). `poll` wraps the
+  cortex inbox/outbox HTTP endpoints (`--ai-id`, `--status`, `--since`,
+  `--limit`, `--related`, `--outbox`); `show` fetches one proposal; `archive`
+  soft-deletes from the inbox view. Gives any CLI surface a reliable receive
+  path without the MCP tool-namespace round-trip.
+- **Artifact-graph gate — scalar control surface (report-only).** The
+  POSTFLIGHT connectivity gate is now driven by three orthogonal 0.0–1.0
+  dimensions — `strictness` / `connectivity_floor` / `patience` — that a host UI
+  drives as sliders, replacing the discrete `off/nudge/soft/hard` mode. Defaults
+  keep it report-only + forgiving; blocking is a follow-up.
+
+### Fixed
+- **Sentinel: file redirects laundered through shell chain segments.**
+  `cd /x && grep foo > /tmp/out` classified noetic despite writing a file — the
+  chain classifier short-circuited before the top-level redirect check. The
+  per-segment classifier now rejects dangerous redirects (`> f`, `>> f`, `< f`),
+  aligning chain-segment behavior with single-command behavior. Security fix.
+- **Sentinel: the `empirica mailbox` CLI family was denied pre-transaction.**
+  The mailbox verbs weren't in the tiered CLI whitelist, so a woken idle
+  practitioner running `empirica mailbox poll` as its first action hit "No open
+  transaction". Reads (`poll`/`show`) are now Tier 1, state-changing verbs
+  (`reply`/`archive`) Tier 2 — all flow pre-transaction.
+- **`session-create --auto-init` minted a fresh `project_id` instead of adopting
+  an existing one.** When `project.yaml` was absent but the path already had a
+  canonical id in the local sessions.db / registry / workspace.db, auto-init
+  minted a new id and "corrected" the canonical workspace row toward it —
+  stranding the session under a phantom id. Auto-init now adopts the existing id
+  (local sessions.db → registry.yaml → workspace.db) and mints only when all are
+  empty.
+
 ## [1.12.13] — 2026-07-04
 
 ### Removed

--- a/docs/human/developers/CLI_COMMANDS_UNIFIED.md
+++ b/docs/human/developers/CLI_COMMANDS_UNIFIED.md
@@ -23,7 +23,7 @@
 > dictionary, then running this script.
 
 **Framework version:** 1.12.13
-**Generated:** 2026-07-04 14:17:03 UTC
+**Generated:** 2026-07-05 12:02:13 UTC
 **Total commands:** 256 (across 26 categories)
 
 For the most up-to-date detail on any single command, prefer
@@ -3649,6 +3649,54 @@ Atomic propose + complete in one call — fixes the AI ack-discipline gap (skip 
   Send reply WITHOUT closing parent (follow-up question case)
 - `--no-archive` — optional · flag
   Close the parent but do NOT archive it. Default behaviour archives the parent after close to keep your inbox view focused on un-actioned work. Use --no-archive when you want the parent to stay visible in audit / status=accepted polls.
+- `--output` — optional · type=`choice` · choices={human, json} · default=`json`
+  Output format (default: json)
+
+
+##### `empirica mailbox poll`
+
+Poll your cortex mesh inbox (or --outbox) — a CLI receive path so tool-aggregating harnesses skip the MCP namespace call
+
+**Arguments:**
+
+- `--ai-id` — optional
+  Your ai_id (canonical 3-form or basename; default: from .empirica/project.yaml)
+- `--outbox` — optional · flag
+  Poll your OUTBOX (status changes on proposals YOU sent) instead of the inbox
+- `--status` — optional
+  Comma-separated status filter (default: 'accepted,changed' for inbox, 'completed,changed,declined' for outbox). Choices: eco_review, accepted, changed, declined, completed, expired.
+- `--since` — optional
+  ISO-8601 timestamp — only proposals created_at >= since (incremental polling)
+- `--limit` — optional · type=`int` · default=`20`
+  Max proposals (default: 20, cortex caps at 200)
+- `--related` — optional · flag
+  Include per-proposal related_goals[] semantic hints (default off — faster polls)
+- `--output` — optional · type=`choice` · choices={human, json} · default=`json`
+  Output format (default: json)
+
+
+##### `empirica mailbox show`
+
+Show one proposal's full body — GET /v1/orchestration/<id>
+
+**Arguments:**
+
+- `proposal_id` — **required**
+  Proposal id (prop_…) to fetch
+- `--output` — optional · type=`choice` · choices={human, json} · default=`json`
+  Output format (default: json)
+
+
+##### `empirica mailbox archive`
+
+Archive a proposal (soft-delete from inbox view) — POST /v1/orchestration/<id>/archive
+
+**Arguments:**
+
+- `proposal_id` — **required**
+  Proposal id (prop_…) to archive
+- `--reason` — optional
+  Optional archive reason (audit trail)
 - `--output` — optional · type=`choice` · choices={human, json} · default=`json`
   Output format (default: json)
 

--- a/empirica/plugins/claude-code-integration/skills/cortex-mailbox-poll/SKILL.md
+++ b/empirica/plugins/claude-code-integration/skills/cortex-mailbox-poll/SKILL.md
@@ -34,6 +34,32 @@ a flat tool in Claude Code, the `mcp__cortex` namespace tool + `operation`
 param in codex/ecodex. The operations and their params are identical across
 harnesses; only the invocation shape differs.
 
+### Simpler: the `empirica mailbox poll` CLI (harness-agnostic receive path)
+
+The whole namespace-shape problem above **evaporates** if you poll via the
+CLI instead of the MCP tool. `empirica mailbox poll` is a thin wrapper over the
+same `GET /v1/orchestration/inbox` that `cortex_inbox_poll` hits — a plain shell
+command every harness runs identically, no namespace gymnastics:
+
+```bash
+empirica mailbox poll --ai-id <your-canonical-3-form> --output json
+# receive side, symmetric with `empirica mailbox reply` (the send/ack side)
+#   --outbox                  poll YOUR emissions' status changes instead
+#   --status accepted,changed default wake-react set (NOT eco_review — the CLI
+#                             exists to react to ECO-decided wakes)
+#   --since <ISO8601>         incremental polling
+#   --limit 20 · --related    match cortex_inbox_poll defaults
+empirica mailbox show <proposal_id> --output json   # one proposal's full body
+empirica mailbox archive <proposal_id>              # soft-delete from inbox view
+```
+
+**Prefer the CLI on tool-aggregating harnesses (codex/ecodex).** A woken *idle*
+practitioner told to run `empirica mailbox poll` as its FIRST action succeeds
+with no open transaction — the mailbox verbs are Sentinel-whitelisted (reads →
+Tier 1, reply/archive → Tier 2), so they flow pre-transaction. The MCP
+`cortex_inbox_poll` remains valid everywhere; the CLI is the reliable receive
+path when the namespace call shape is fragile.
+
 ---
 
 ## When to Use

--- a/tests/test_sentinel_shell_constructs.py
+++ b/tests/test_sentinel_shell_constructs.py
@@ -525,8 +525,16 @@ class TestNoeticCompoundAndBootstrap:
         "cmd",
         [
             "cd /home/u/proj && rm -rf /",
-            "cd /home/u/proj && grep x file > /tmp/out",
+            "cd /home/u/proj && grep x file > /tmp/out",  # redirect (#256)
             "cd /home/u/proj && python3 -c 'import os; os.remove(\"x\")'",
+            # Write-FLAG holes on otherwise-inert tools — a leading `cd` must not
+            # launder these through a chain segment either (broccoli sweep guard:
+            # locks the _matches_safe_prefix → _has_dangerous_tool_flags path at
+            # the chain-segment integration level, not just the unit level).
+            "cd /home/u/proj && find . -delete",
+            "cd /home/u/proj && sed -i 's/a/b/' f",
+            "cd /home/u/proj && yq -i '.x=1' f",
+            "cd /home/u/proj && sort -o out in",
         ],
     )
     def test_leading_cd_does_not_smuggle_praxic(self, gate, cmd):


### PR DESCRIPTION
## Context

Remediation for the `code-docs-align` sentinel-lifecycle sweep — the mailbox receive CLI (#255) shipped without docs, and the poll skill routed AIs to the MCP path the CLI was built to replace.

## Fixes

- **`CLI_COMMANDS_UNIFIED.md`** — regenerated from the live argparse tree (`scripts/generate_cli_docs.py`); `empirica mailbox poll` / `show` / `archive` now appear (previously only `reply`).
- **`cortex-mailbox-poll/SKILL.md`** — new *"harness-agnostic receive path"* section. The MCP tool-namespace-shape problem the skill spends a section explaining **evaporates** if you poll via `empirica mailbox poll` (a plain shell command every harness runs identically). Calls out preferring the CLI on tool-aggregating harnesses (codex/ecodex), and that the mailbox verbs are Sentinel-whitelisted so a woken *idle* practitioner can poll as its first action. The skill previously routed the receive path **exclusively** through the MCP call it also flags as fragile — the highest-impact drift the sweep found.
- **`CHANGELOG.md`** — added `[Unreleased]` with this session's shipped changes (mailbox receive CLI, artifact-graph scalar gate, sentinel redirect-launder fix, mailbox whitelist, auto-init adopt-before-mint).

## Sweep verdict
Docs-only. Link-check clean (0 broken / 191 files). Areas the sweep verified **clean** (no change): artifact-graph gate-mode refs (scalar migration complete), Noetic Firewall general rule (chain-segment is impl detail), auto-init flag docs (non-asserting).

🤖 Generated with [Claude Code](https://claude.com/claude-code)