### PR TITLE
docs(architecture): artifact-hygiene design spec (cross-transaction, per-practice)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,40 @@ All notable changes to Empirica will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **`empirica mailbox poll` / `show` / `archive` — the receive side of the mesh
+  CLI.** Symmetric with `empirica mailbox reply` (send/ack). `poll` wraps the
+  cortex inbox/outbox HTTP endpoints (`--ai-id`, `--status`, `--since`,
+  `--limit`, `--related`, `--outbox`); `show` fetches one proposal; `archive`
+  soft-deletes from the inbox view. Gives any CLI surface a reliable receive
+  path without the MCP tool-namespace round-trip.
+- **Artifact-graph gate — scalar control surface (report-only).** The
+  POSTFLIGHT connectivity gate is now driven by three orthogonal 0.0–1.0
+  dimensions — `strictness` / `connectivity_floor` / `patience` — that a host UI
+  drives as sliders, replacing the discrete `off/nudge/soft/hard` mode. Defaults
+  keep it report-only + forgiving; blocking is a follow-up.
+
+### Fixed
+- **Sentinel: file redirects laundered through shell chain segments.**
+  `cd /x && grep foo > /tmp/out` classified noetic despite writing a file — the
+  chain classifier short-circuited before the top-level redirect check. The
+  per-segment classifier now rejects dangerous redirects (`> f`, `>> f`, `< f`),
+  aligning chain-segment behavior with single-command behavior. Security fix.
+- **Sentinel: the `empirica mailbox` CLI family was denied pre-transaction.**
+  The mailbox verbs weren't in the tiered CLI whitelist, so a woken idle
+  practitioner running `empirica mailbox poll` as its first action hit "No open
+  transaction". Reads (`poll`/`show`) are now Tier 1, state-changing verbs
+  (`reply`/`archive`) Tier 2 — all flow pre-transaction.
+- **`session-create --auto-init` minted a fresh `project_id` instead of adopting
+  an existing one.** When `project.yaml` was absent but the path already had a
+  canonical id in the local sessions.db / registry / workspace.db, auto-init
+  minted a new id and "corrected" the canonical workspace row toward it —
+  stranding the session under a phantom id. Auto-init now adopts the existing id
+  (local sessions.db → registry.yaml → workspace.db) and mints only when all are
+  empty.
+
 ## [1.12.13] — 2026-07-04
 
 ### Removed

--- a/docs/architecture/ARTIFACT_HYGIENE.md
+++ b/docs/architecture/ARTIFACT_HYGIENE.md
@@ -1,0 +1,157 @@
+# Artifact Hygiene — the cross-transaction, per-practice sweep
+
+> **Status: design spec.** Companion to [GATED_ARTIFACT_GRAPH.md](GATED_ARTIFACT_GRAPH.md).
+> That map governs *within-transaction* connectivity at POSTFLIGHT; this one
+> governs the *whole-practice, cross-transaction* upkeep POSTFLIGHT structurally
+> can't see. The primitives already exist — this is an **orchestration + policy**
+> problem, not a build-from-scratch.
+
+## 1. The problem
+
+Epistemic artifacts decay across transactions in ways a single POSTFLIGHT can't
+observe:
+
+- **Unknowns** that a later finding/decision already answered, never resolved.
+- **Goals** with completion evidence (a commit, a passing test) still sitting
+  `in_progress`; or stale/abandoned; or duplicated.
+- **Sources** whose URLs 404 or moved (link-rot), or whose *content* drifted.
+- **Edges** — orphan artifacts (0 edges), or artifacts wired to a weaker edge
+  than the graph now warrants.
+- **Noise** — test-run artifacts, exact duplicates, superseded findings.
+
+POSTFLIGHT already does the *within-transaction* half — weave-gate (orphans /
+connectivity), breadth, edge-density, sources-discipline, deferred-proposals.
+What's missing is the **whole-practice sweep**: link-check across every source,
+cross-goal dedup, long-open-unknown triage, orphan re-wiring across transactions.
+
+## 2. What already exists (build on these, don't reinvent)
+
+| Primitive | Does |
+|---|---|
+| `empirica goals-get-stale` | detect stale goals (dry-run detection) |
+| `empirica resolve-artifacts -` | batch-resolve unknowns / assumptions / goals |
+| `empirica delete-artifacts -` | batch delete — **dry-run default + receipt logged as a decision for audit** |
+| `empirica log-artifacts -` | node + edge writes (edge re-wiring) |
+| `empirica sources-reconcile` | source-identity dedup vs the catalogue (`--apply`, dry-run default) |
+| `empirica docs-link-check` | link-rot detection for docs (extend to sources — §7) |
+| POSTFLIGHT hooks | within-tx: weave-gate, breadth, edge-density, sources-discipline, deferred-proposals |
+
+The hygiene loop **wires these together** across the whole practice; it does not
+add new destructive primitives.
+
+## 3. The model — two tiers, split by reversibility
+
+| Tier | Examples | Behavior |
+|---|---|---|
+| **Mechanical** (deterministic detection) | dead source links (404 probe), exact-duplicate artifacts, evidence-backed goals still open, source-identity drift | May **act** — but only through `delete-artifacts`' existing dry-run → receipt path |
+| **Semantic** (needs judgment) | "unknown X is answered by finding Y", "artifact should move to edge Z", source *content* staleness (not just link) | **Surface a triage queue** — never auto-act |
+
+**Decided default (surface + safe-mechanical auto):** auto-action is limited to
+the provably-safe mechanical cases; everything semantic becomes a triage queue
+the practitioner approves. This mirrors the artifact-graph gate's report-only
+default — earned autonomy, dialed by policy (§4).
+
+## 4. Per-practice — one loop body, per-practice via config
+
+Artifact hygiene is **per-practice** — a research practice's open unknowns *are*
+the work (don't reap them); a code practice should close evidence-backed goals
+fast; outreach lives and dies by source freshness (links rot weekly). The
+resolution is **not per-practice loop code** — it's **one canonical loop body
+that reads a per-practice `hygiene_policy`**, the exact pattern the artifact-graph
+gate uses for its `strictness / connectivity_floor / patience` scalars (#253).
+
+`.empirica/project.yaml`:
+
+```yaml
+hygiene_policy:
+  source_staleness_days: 30      # outreach: 7 · code: 90
+  unknown_triage_days: 14        # research: 60 (unknowns ARE the work) · code: 7
+  goal_auto_close: evidence_only # evidence_only | surface_only
+  auto_delete: test_noise_only   # off | test_noise_only  — NEVER semantic-on-age
+  dedup: exact_only              # exact_only | fuzzy
+```
+
+Per-`work_type` defaults seed it (research vs code vs outreach differ exactly as
+you'd expect); the practice overrides. A `_resolve_hygiene_policy()` reader
+mirrors `_resolve_gate_scalars()` — single source of truth for defaults + config,
+clamped, fallback-safe.
+
+## 5. The load-bearing safety rule
+
+`message-cleanup` (the sibling loop) is safe because messages carry an explicit
+`expiry_at` — deletion is contractual, not a judgment. **Artifacts have no
+expiry.** "Stale" is a judgment, and deleting a finding/unknown *loses
+knowledge*. Therefore:
+
+- **Default surface-not-act.** Auto-action only on provably-safe mechanical cases.
+- **Never auto-delete a finding/unknown on age alone.** Age flags for *triage*, it
+  does not authorize deletion.
+- **Keep the `delete-artifacts` dry-run → receipt discipline.** Every auto-delete
+  is dry-run-previewed and logs a decision artifact — the audit trail is the
+  guardrail, and the loop respects it.
+- **Reversibility gradient.** Flag (free) < re-wire edge (reversible) < resolve
+  unknown (reversible) < delete (destructive, receipted). Auto-action climbs the
+  gradient only as far as `hygiene_policy` authorizes.
+
+## 6. Delivery — loop **and** skill
+
+Decided: **both**, each for what it's good at.
+
+- **Canonical loop** (`artifact-hygiene`, low-frequency ~daily) — the cheap
+  mechanical sweep + triage-queue emission. Self-throttles when a transaction is
+  open (like `cortex-mailbox-poll` / `message-cleanup`). Emits a **hygiene
+  receipt** (N dead sources, M closable goals, K unknowns to triage, L orphans)
+  — surfaced, not silently actioned.
+- **On-demand skill** (`/artifact-hygiene`) — the deep semantic pass, run when
+  wanted (like `/code-audit`, `/eat-the-broccoli`). Does the judgment work the
+  loop deliberately defers: which unknowns look answered, which edges to re-wire,
+  which sources drifted in content.
+
+Loop for continuous mechanical upkeep; skill for the deep pass. They share the
+`hygiene_policy` and the receipt format.
+
+## 7. Net-new work (the gaps — each a work-stream)
+
+1. **Source link-rot check.** Extend `docs-link-check`'s URL probe to the
+   `sources` table → flag 404 / moved (dead-ref), gated by
+   `source_staleness_days`. Smallest, safest slice — mechanical, surface-only.
+2. **`hygiene_policy` schema + resolver.** `_resolve_hygiene_policy()` mirroring
+   `_resolve_gate_scalars` (#253): defaults + env/config, per-`work_type` seeds,
+   clamped, fallback-safe.
+3. **The canonical loop body.** Orchestrates the existing verbs + emits the
+   hygiene receipt / triage queue. Registered via the canonical-loop catalog
+   (`canonical_loops.py`), installed like `message-cleanup`.
+4. **Semantic-candidate surfacing.** "Which unknowns look answered / which edges
+   to re-wire" via the artifact graph + semantic search — the judgment layer the
+   `/artifact-hygiene` skill drives.
+
+## 8. Relationship to the artifact-graph map
+
+This is the **cross-transaction complement** to GATED_ARTIFACT_GRAPH.md:
+
+| | Artifact-graph gate (that map) | Artifact hygiene (this spec) |
+|---|---|---|
+| **Scope** | one transaction, at POSTFLIGHT | whole practice, across transactions |
+| **When** | at the gate (write time) | on a loop / on demand |
+| **Concern** | *is this transaction's work woven?* | *has the whole graph decayed?* |
+| **Shared** | the per-practice scalar/policy config pattern; connectivity/orphan vocabulary |
+
+The gate keeps *new* work connected; hygiene keeps the *accumulated* graph clean.
+Orphan re-wiring is where they meet — the gate flags an orphan at write time; the
+hygiene sweep re-homes orphans the gate flagged in past transactions.
+
+## 9. Decisions (settled) + open questions
+
+**Settled:**
+- Autonomy default = **surface + safe-mechanical auto** (semantic → triage queue).
+- Delivery = **both** canonical loop + `/artifact-hygiene` skill.
+
+**Open:**
+- `hygiene_policy` home — `.empirica/project.yaml` (per-practice, filesystem) vs
+  the `entity_registry` practice row (DB, travels with the practice id)? Lean
+  project.yaml for parity with the gate scalars, but the practice-model row is
+  the more canonical home long-term.
+- Loop cadence — fixed daily vs adaptive (backoff when the receipt is empty, like
+  `cortex-mailbox-poll`)? Link-check is network-slow; daily is likely enough.
+- Semantic-match confidence bar for auto-surfacing "unknown answered by finding"
+  — reuse the artifact-graph edge-inference, or a dedicated semantic threshold?

--- a/docs/human/developers/CLI_COMMANDS_UNIFIED.md
+++ b/docs/human/developers/CLI_COMMANDS_UNIFIED.md
@@ -23,7 +23,7 @@
 > dictionary, then running this script.
 
 **Framework version:** 1.12.13
-**Generated:** 2026-07-04 14:17:03 UTC
+**Generated:** 2026-07-05 12:02:13 UTC
 **Total commands:** 256 (across 26 categories)
 
 For the most up-to-date detail on any single command, prefer
@@ -3649,6 +3649,54 @@ Atomic propose + complete in one call — fixes the AI ack-discipline gap (skip 
   Send reply WITHOUT closing parent (follow-up question case)
 - `--no-archive` — optional · flag
   Close the parent but do NOT archive it. Default behaviour archives the parent after close to keep your inbox view focused on un-actioned work. Use --no-archive when you want the parent to stay visible in audit / status=accepted polls.
+- `--output` — optional · type=`choice` · choices={human, json} · default=`json`
+  Output format (default: json)
+
+
+##### `empirica mailbox poll`
+
+Poll your cortex mesh inbox (or --outbox) — a CLI receive path so tool-aggregating harnesses skip the MCP namespace call
+
+**Arguments:**
+
+- `--ai-id` — optional
+  Your ai_id (canonical 3-form or basename; default: from .empirica/project.yaml)
+- `--outbox` — optional · flag
+  Poll your OUTBOX (status changes on proposals YOU sent) instead of the inbox
+- `--status` — optional
+  Comma-separated status filter (default: 'accepted,changed' for inbox, 'completed,changed,declined' for outbox). Choices: eco_review, accepted, changed, declined, completed, expired.
+- `--since` — optional
+  ISO-8601 timestamp — only proposals created_at >= since (incremental polling)
+- `--limit` — optional · type=`int` · default=`20`
+  Max proposals (default: 20, cortex caps at 200)
+- `--related` — optional · flag
+  Include per-proposal related_goals[] semantic hints (default off — faster polls)
+- `--output` — optional · type=`choice` · choices={human, json} · default=`json`
+  Output format (default: json)
+
+
+##### `empirica mailbox show`
+
+Show one proposal's full body — GET /v1/orchestration/<id>
+
+**Arguments:**
+
+- `proposal_id` — **required**
+  Proposal id (prop_…) to fetch
+- `--output` — optional · type=`choice` · choices={human, json} · default=`json`
+  Output format (default: json)
+
+
+##### `empirica mailbox archive`
+
+Archive a proposal (soft-delete from inbox view) — POST /v1/orchestration/<id>/archive
+
+**Arguments:**
+
+- `proposal_id` — **required**
+  Proposal id (prop_…) to archive
+- `--reason` — optional
+  Optional archive reason (audit trail)
 - `--output` — optional · type=`choice` · choices={human, json} · default=`json`
   Output format (default: json)
 

--- a/empirica/plugins/claude-code-integration/skills/cortex-mailbox-poll/SKILL.md
+++ b/empirica/plugins/claude-code-integration/skills/cortex-mailbox-poll/SKILL.md
@@ -34,6 +34,32 @@ a flat tool in Claude Code, the `mcp__cortex` namespace tool + `operation`
 param in codex/ecodex. The operations and their params are identical across
 harnesses; only the invocation shape differs.
 
+### Simpler: the `empirica mailbox poll` CLI (harness-agnostic receive path)
+
+The whole namespace-shape problem above **evaporates** if you poll via the
+CLI instead of the MCP tool. `empirica mailbox poll` is a thin wrapper over the
+same `GET /v1/orchestration/inbox` that `cortex_inbox_poll` hits — a plain shell
+command every harness runs identically, no namespace gymnastics:
+
+```bash
+empirica mailbox poll --ai-id <your-canonical-3-form> --output json
+# receive side, symmetric with `empirica mailbox reply` (the send/ack side)
+#   --outbox                  poll YOUR emissions' status changes instead
+#   --status accepted,changed default wake-react set (NOT eco_review — the CLI
+#                             exists to react to ECO-decided wakes)
+#   --since <ISO8601>         incremental polling
+#   --limit 20 · --related    match cortex_inbox_poll defaults
+empirica mailbox show <proposal_id> --output json   # one proposal's full body
+empirica mailbox archive <proposal_id>              # soft-delete from inbox view
+```
+
+**Prefer the CLI on tool-aggregating harnesses (codex/ecodex).** A woken *idle*
+practitioner told to run `empirica mailbox poll` as its FIRST action succeeds
+with no open transaction — the mailbox verbs are Sentinel-whitelisted (reads →
+Tier 1, reply/archive → Tier 2), so they flow pre-transaction. The MCP
+`cortex_inbox_poll` remains valid everywhere; the CLI is the reliable receive
+path when the namespace call shape is fragile.
+
 ---
 
 ## When to Use

--- a/tests/test_sentinel_shell_constructs.py
+++ b/tests/test_sentinel_shell_constructs.py
@@ -525,8 +525,16 @@ class TestNoeticCompoundAndBootstrap:
         "cmd",
         [
             "cd /home/u/proj && rm -rf /",
-            "cd /home/u/proj && grep x file > /tmp/out",
+            "cd /home/u/proj && grep x file > /tmp/out",  # redirect (#256)
             "cd /home/u/proj && python3 -c 'import os; os.remove(\"x\")'",
+            # Write-FLAG holes on otherwise-inert tools — a leading `cd` must not
+            # launder these through a chain segment either (broccoli sweep guard:
+            # locks the _matches_safe_prefix → _has_dangerous_tool_flags path at
+            # the chain-segment integration level, not just the unit level).
+            "cd /home/u/proj && find . -delete",
+            "cd /home/u/proj && sed -i 's/a/b/' f",
+            "cd /home/u/proj && yq -i '.x=1' f",
+            "cd /home/u/proj && sort -o out in",
         ],
     )
     def test_leading_cd_does_not_smuggle_praxic(self, gate, cmd):


### PR DESCRIPTION
## What

Design spec for **artifact hygiene** — the whole-practice, cross-transaction upkeep that POSTFLIGHT's within-transaction hooks structurally can't see: stale/answered unknowns, evidence-backed goals left open, source link-rot, orphan/mis-wired edges, duplicate + test-noise artifacts.

Floated by David for looping; the "it's per-practice, needs thinking about" nuance is the crux this spec resolves.

## Key framing

The hygiene **primitives already exist** (`goals-get-stale`, `resolve-artifacts`, `delete-artifacts` with dry-run+receipt, `log-artifacts` edges, `sources-reconcile`, `docs-link-check`). This is an **orchestration + policy** problem, not build-from-scratch.

## Design

- **Two tiers by reversibility** — mechanical (deterministic → may auto-act via the existing dry-run+receipt path) vs semantic (needs judgment → triage queue).
- **Per-practice via `hygiene_policy` config** read by one canonical loop body — the same "one gate, per-practice via config" pattern as the #253 artifact-graph scalar gate. Research keeps unknowns open (they *are* the work); code closes evidence-backed goals fast; outreach watches link-rot.
- **Safety rule** — default surface-not-act; **never auto-delete a finding/unknown on age alone**; `delete-artifacts` dry-run→receipt is the guardrail.
- **Delivery** — canonical daily loop (mechanical sweep + hygiene receipt) **and** an on-demand `/artifact-hygiene` skill (deep semantic pass), like `/code-audit`.

## Decisions settled (with David)
- Autonomy default: **surface + safe-mechanical auto**
- Delivery: **both** loop + skill

Positioned as the cross-transaction complement to `GATED_ARTIFACT_GRAPH.md` (that map keeps *new* work woven at write time; this keeps the *accumulated* graph clean). Implementation tracked as planned goal `a729201b` (4 work-streams).

**Spec only — no feature code.** Link-check clean (192 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)