### PR TITLE
feat(hygiene): sources-check link-rot + resilient dispatch (P1 fix)

### DIFF
--- a/empirica/cli/cli_core.py
+++ b/empirica/cli/cli_core.py
@@ -390,6 +390,7 @@ _HELP_CATEGORIES = {
         "source-list",
         "sources-map",
         "sources-reconcile",
+        "sources-check",
         "source-archive",
         "act-log",
         "investigate-log",
@@ -632,6 +633,33 @@ def _maybe_autosync_plugin(command: str) -> None:
         return  # self-heal must never break the user's command
 
 
+def _life_support_handlers() -> dict:
+    """The minimal dispatch that must survive a feature-verb registration failure.
+
+    If the full command table (built in ``main``) raises ``NameError`` because a
+    feature verb's handler failed to import, the loop-opening verbs must still
+    resolve — otherwise the praxic firewall fail-closes on a broken
+    ``preflight-submit`` into an *unrecoverable* deadlock: you can't preflight to
+    fix the thing that broke preflight (incident prop_m2orjtozsvco5ansfqdxi2g5fu).
+
+    Resolved defensively from module globals so a genuinely-missing handler is
+    simply absent here, never a second crash. These verbs open transactions,
+    switch context, and provide the recovery escape (doctor/diagnose/sentinel).
+    """
+    g = globals()
+    wanted = {
+        "preflight-submit": "handle_preflight_submit_command",
+        "check-submit": "handle_check_submit_command",
+        "postflight-submit": "handle_postflight_submit_command",
+        "session-create": "handle_session_create_command",
+        "project-bootstrap": "handle_project_bootstrap_command",
+        "doctor": "handle_doctor_command",
+        "diagnose": "handle_diagnose_command",
+        "sentinel": "handle_sentinel_group_command",
+    }
+    return {verb: g[name] for verb, name in wanted.items() if callable(g.get(name))}
+
+
 def main(args=None):
     """Main CLI entry point"""
     start_time = time.time()
@@ -687,7 +715,12 @@ def main(args=None):
         except Exception as e:
             print(f"[VERBOSE] Database: (unavailable: {e})", file=sys.stderr)
 
-    # Command handler mapping
+    # Command handler mapping. Pre-seed with the life-support set FIRST: if the
+    # full table below raises NameError (a feature verb's handler failed to
+    # import), the failed dict-literal assignment leaves THIS value in place, so
+    # the loop-opening verbs never share fate with a feature verb (prop_m2orjtoz).
+    command_handlers = _life_support_handlers()
+    _dispatch_reached = False  # distinguishes a table-build NameError from one raised inside a handler
     try:
         command_handlers = {
             # Session commands
@@ -865,6 +898,7 @@ def main(args=None):
             "source-list": handle_source_list_command,
             "sources-map": handle_sources_map_command,
             "sources-reconcile": handle_sources_reconcile_command,
+            "sources-check": handle_sources_check_command,
             "source-archive": handle_source_archive_command,
             "epp-activate": handle_epp_activate_command,
             # Training data export
@@ -1044,6 +1078,7 @@ def main(args=None):
 
         if parsed_args.command in command_handlers:
             handler = command_handlers[parsed_args.command]
+            _dispatch_reached = True  # past table build — a NameError now is the handler's, not registration
             result = handler(parsed_args)
 
             # Handle result output and exit code
@@ -1059,6 +1094,32 @@ def main(args=None):
             print(f"❌ Unknown command: {parsed_args.command}")
             sys.exit(1)
 
+    except NameError as _reg_err:
+        # A feature verb's handler failed to import while BUILDING the dispatch
+        # table (not while running a handler — that's gated by _dispatch_reached).
+        # Do NOT let it brick the loop: dispatch from the pre-seeded life-support
+        # set so preflight/check/postflight + recovery verbs still work and the
+        # firewall never fail-closes into a deadlock (incident prop_m2orjtoz).
+        if _dispatch_reached:
+            handle_cli_error(_reg_err, getattr(parsed_args, "command", None))
+            sys.exit(1)
+        import logging as _logging
+
+        _logging.getLogger(__name__).error(
+            "empirica CLI: a command handler failed to register (%s); feature verbs "
+            "degraded, life-support verbs remain available. Reinstall/repair the package.",
+            _reg_err,
+        )
+        cmd = getattr(parsed_args, "command", None)
+        if cmd in command_handlers:  # life-support set (pre-seeded above)
+            sys.exit(_handle_command_result(command_handlers[cmd](parsed_args), parsed_args))
+        print(
+            f"⚠ empirica: '{cmd}' is unavailable due to a command-registration error "
+            f"({_reg_err}); core verbs (preflight/check/postflight/session-create/"
+            f"doctor/diagnose/sentinel) still work. Reinstall/repair the package.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
     except Exception as e:
         handle_cli_error(e, parsed_args.command)
         sys.exit(1)

--- a/empirica/cli/command_handlers/__init__.py
+++ b/empirica/cli/command_handlers/__init__.py
@@ -249,6 +249,7 @@ from .skill_commands import (
     handle_skill_fetch_command,
     handle_skill_suggest_command,
 )
+from .sources_check_commands import handle_sources_check_command
 from .sources_reconcile_commands import handle_sources_reconcile_command
 from .sync_commands import (
     handle_rebuild_command,
@@ -490,6 +491,7 @@ __all__ = [  # noqa: RUF022
     "handle_source_archive_command",
     "handle_source_list_command",
     "handle_sources_map_command",
+    "handle_sources_check_command",
     "handle_sources_reconcile_command",
     # Sync commands (git notes synchronization)
     "handle_sync_config_command",

--- a/empirica/cli/command_handlers/sources_check_commands.py
+++ b/empirica/cli/command_handlers/sources_check_commands.py
@@ -1,0 +1,186 @@
+"""`empirica sources-check` — source link-rot detection (artifact-hygiene WS1).
+
+Probes the http(s) URLs in ``epistemic_sources`` and flags dead / auth-walled /
+errored links. **SURFACE-ONLY**: it reports rot, it never deletes — per the
+ARTIFACT_HYGIENE.md safety rule, "stale" is a judgment and any deletion goes
+through ``delete-artifacts`` (dry-run + receipt) or ``source-archive``, the
+operator's call. This is the smallest, safest mechanical slice of the
+artifact-hygiene design (spec §7, work-stream 1).
+
+Dependency-injected (``_list_sources`` / ``_probe``) so tests never touch the
+network.
+"""
+
+from __future__ import annotations
+
+import json
+import ssl
+import sys
+import urllib.error
+import urllib.request
+from collections.abc import Callable
+
+# Status → category. Redirects resolve to live (the link works, maybe moved);
+# 401/403 are auth-walled, not rot; 404/410 are the real dead signal; other
+# non-2xx are surfaced as errors for review (could be transient 5xx).
+_GATED_CODES = frozenset({401, 403})
+_DEAD_CODES = frozenset({404, 410})
+
+
+def _classify_status(status: int) -> tuple[str, str]:
+    if 200 <= status < 400:
+        return "live", str(status)
+    if status in _GATED_CODES:
+        return "gated", str(status)
+    if status in _DEAD_CODES:
+        return "dead", str(status)
+    return "error", str(status)
+
+
+def _default_probe(url: str, timeout: float = 6.0) -> tuple[str, str]:
+    """Probe a URL → (category, detail); category ∈ live|dead|gated|error.
+
+    HEAD first (cheap, no body); on 405/501 (server rejects HEAD) retry GET.
+    A connection/DNS/timeout failure is treated as ``dead`` (unreachable).
+    Caller-agnostic to redirects — urllib follows them, so a 3xx that lands on
+    a 2xx reads as live.
+    """
+    ctx = ssl.create_default_context()
+    headers = {"User-Agent": "empirica-sources-check/1.0"}
+
+    def _attempt(method: str) -> tuple[str, str]:
+        req = urllib.request.Request(url, method=method, headers=headers)
+        with urllib.request.urlopen(req, timeout=timeout, context=ctx) as resp:
+            return _classify_status(resp.status)
+
+    # HEAD first (cheap); if the server rejects HEAD (405/501) fall through to GET.
+    try:
+        return _attempt("HEAD")
+    except urllib.error.HTTPError as e:
+        if e.code not in (405, 501):
+            return _classify_status(e.code)
+    except (urllib.error.URLError, TimeoutError, ConnectionError, OSError) as e:
+        return "dead", f"{type(e).__name__}: {e}"
+    except Exception as e:  # defensive — a probe must not crash the sweep
+        return "error", f"{type(e).__name__}: {e}"
+
+    try:
+        return _attempt("GET")
+    except urllib.error.HTTPError as e:
+        return _classify_status(e.code)
+    except (urllib.error.URLError, TimeoutError, ConnectionError, OSError) as e:
+        return "dead", f"{type(e).__name__}: {e}"
+    except Exception as e:  # defensive
+        return "error", f"{type(e).__name__}: {e}"
+
+
+def _default_list_sources(project_id: str) -> list[dict]:
+    """List this project's epistemic_sources (reuses the canonical lister)."""
+    from empirica.cli.command_handlers.artifact_log_commands import _query_epistemic_sources
+    from empirica.data.session_database import SessionDatabase
+
+    db = SessionDatabase()
+    return _query_epistemic_sources(db, project_id, None, "all", include_archived=False)
+
+
+def _resolve_project_id(args) -> str | None:
+    project_id = getattr(args, "project_id", None)
+    if project_id:
+        return project_id
+    from empirica.utils.session_resolver import InstanceResolver as R
+
+    try:
+        project_path = R.project_path()
+        if project_path:
+            return R.project_id_from_db(project_path)
+    except Exception:
+        pass
+    return None
+
+
+def _is_probeable(url) -> bool:
+    return isinstance(url, str) and url.startswith(("http://", "https://"))
+
+
+def _format_human(result: dict) -> str:
+    lines = [
+        f"🔗 sources-check — {result['checked']} URL(s) probed "
+        f"({result['live']} live, {len(result['dead'])} dead, "
+        f"{len(result['gated'])} gated, {len(result['errored'])} errored; "
+        f"{result['skipped_no_url']} non-URL sources skipped)",
+    ]
+    for tag, rows in (("DEAD", result["dead"]), ("GATED", result["gated"]), ("ERROR", result["errored"])):
+        for r in rows:
+            lines.append(f"  [{tag}] {r['status']:<20} {r.get('title') or '?'} — {r['url']}")
+    if not (result["dead"] or result["gated"] or result["errored"]):
+        lines.append("  ✅ all probed source links resolve")
+    else:
+        lines.append(
+            "  (surface-only — dead links stay logged. To retire one: "
+            "`empirica delete-artifacts` (dry-run+receipt) or `source-archive`.)"
+        )
+    return "\n".join(lines)
+
+
+def handle_sources_check_command(
+    args,
+    *,
+    _list_sources: Callable[[str], list[dict]] = _default_list_sources,
+    _probe: Callable[[str, float], tuple[str, str]] = _default_probe,
+) -> int:
+    """`empirica sources-check` — probe source URLs, surface link-rot.
+
+    Exit 1 iff any source URL is confirmed DEAD (404/410/unreachable) — usable
+    as a CI/hygiene gate. gated/errored do NOT fail (auth-walled or transient).
+    """
+    output_format = getattr(args, "output", "human")
+    timeout = float(getattr(args, "timeout", 6.0))
+
+    project_id = _resolve_project_id(args)
+    if not project_id:
+        sys.stderr.write("sources-check: could not resolve project_id — pass --project-id.\n")
+        return 1
+
+    try:
+        sources = _list_sources(project_id)
+    except Exception as e:
+        sys.stderr.write(f"sources-check: failed to list sources: {type(e).__name__}: {e}\n")
+        return 1
+
+    probeable = [s for s in sources if _is_probeable(s.get("url") or s.get("source_url"))]
+    skipped = len(sources) - len(probeable)
+
+    live = 0
+    dead: list[dict] = []
+    gated: list[dict] = []
+    errored: list[dict] = []
+    for s in probeable:
+        url = s.get("url") or s.get("source_url")
+        category, detail = _probe(url, timeout)
+        rec = {"id": s.get("id"), "title": s.get("title"), "url": url, "status": detail}
+        if category == "live":
+            live += 1
+        elif category == "gated":
+            gated.append(rec)
+        elif category == "dead":
+            dead.append(rec)
+        else:
+            errored.append(rec)
+
+    result = {
+        "ok": True,
+        "project_id": project_id,
+        "checked": len(probeable),
+        "live": live,
+        "dead": dead,
+        "gated": gated,
+        "errored": errored,
+        "skipped_no_url": skipped,
+    }
+
+    if output_format == "json":
+        sys.stdout.write(json.dumps(result, indent=2) + "\n")
+    else:
+        sys.stdout.write(_format_human(result) + "\n")
+
+    return 1 if dead else 0

--- a/empirica/cli/parsers/checkpoint_parsers.py
+++ b/empirica/cli/parsers/checkpoint_parsers.py
@@ -1451,6 +1451,26 @@ def add_checkpoint_parsers(subparsers):
     sources_reconcile_parser.add_argument("--output", choices=["human", "json"], default="human", help="Output format")
     sources_reconcile_parser.add_argument("--verbose", action="store_true", help="Verbose output")
 
+    # sources-check — link-rot detection (artifact-hygiene WS1)
+    sources_check_parser = subparsers.add_parser(
+        "sources-check",
+        help=(
+            "Probe the http(s) URLs in this project's epistemic sources and "
+            "surface link-rot (dead / auth-walled / errored). SURFACE-ONLY — "
+            "reports rot, never deletes (retire a dead source via "
+            "delete-artifacts or source-archive). Exit 1 if any URL is dead. "
+            "The smallest mechanical slice of artifact-hygiene "
+            "(docs/architecture/ARTIFACT_HYGIENE.md)."
+        ),
+    )
+    sources_check_parser.add_argument(
+        "--project-id", help="Project UUID (auto-derived from active session when omitted)"
+    )
+    sources_check_parser.add_argument(
+        "--timeout", type=float, default=6.0, help="Per-URL probe timeout in seconds (default: 6.0)"
+    )
+    sources_check_parser.add_argument("--output", choices=["human", "json"], default="human", help="Output format")
+
     # Graph artifact commands — batch logging and resolution
     log_artifacts_parser = subparsers.add_parser(
         "log-artifacts",

--- a/tests/test_cli_dispatch_resilience.py
+++ b/tests/test_cli_dispatch_resilience.py
@@ -1,0 +1,68 @@
+"""Dispatch resilience — a feature verb's broken registration must NOT brick
+the life-support verbs (preflight/check/postflight/recovery).
+
+Regression guard for the P1 incident (prop_m2orjtozsvco5ansfqdxi2g5fu): a single
+feature verb whose handler failed to import raised NameError while building the
+dispatch table, which took down EVERY verb including preflight — and because
+preflight is the verb the praxic firewall needs, it fail-closed into an
+unrecoverable deadlock (can't preflight to fix what broke preflight).
+
+The fix pre-seeds the dispatch with a life-support set and, on a table-build
+NameError, dispatches from it — so the loop-opening + recovery verbs always work.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from empirica.cli import cli_core
+
+
+def test_life_support_handlers_has_core_verbs():
+    ls = cli_core._life_support_handlers()
+    # The epistemic loop's spine + recovery escape must all resolve to callables.
+    for verb in (
+        "preflight-submit",
+        "check-submit",
+        "postflight-submit",
+        "session-create",
+        "doctor",
+        "diagnose",
+    ):
+        assert verb in ls, f"life-support missing {verb}"
+        assert callable(ls[verb])
+
+
+def test_dispatch_survives_feature_verb_nameerror(monkeypatch):
+    """Break a feature verb's handler, then confirm a life-support verb still
+    dispatches (rather than the whole CLI dying with NameError)."""
+    called = {}
+
+    def stub_doctor(args):
+        called["doctor"] = True
+        return 0
+
+    # Route the life-support 'doctor' to a recording stub...
+    monkeypatch.setattr(cli_core, "handle_doctor_command", stub_doctor)
+    # ...and BREAK a feature verb so the full dispatch-table literal NameErrors
+    # while it's being built (the exact failure mode of the incident).
+    monkeypatch.delattr(cli_core, "handle_sources_check_command", raising=False)
+
+    with pytest.raises(SystemExit) as exc:
+        cli_core.main(["doctor"])
+
+    assert called.get("doctor") is True, "life-support verb did not dispatch after a table-build NameError"
+    assert exc.value.code == 0  # stub returned 0 → clean exit, no deadlock
+
+
+def test_unknown_verb_after_nameerror_reports_unavailable(monkeypatch, capsys):
+    """A NON-life-support verb, when the table failed to build, reports itself
+    unavailable (loudly) — it does not silently succeed or hang."""
+    monkeypatch.delattr(cli_core, "handle_sources_check_command", raising=False)
+
+    with pytest.raises(SystemExit) as exc:
+        cli_core.main(["goals-list"])  # a feature verb, not in life-support
+
+    assert exc.value.code == 1
+    err = capsys.readouterr().err
+    assert "unavailable" in err and "registration error" in err

--- a/tests/test_sources_check.py
+++ b/tests/test_sources_check.py
@@ -1,0 +1,146 @@
+"""Tests for `empirica sources-check` — source link-rot detection (hygiene WS1).
+
+Dependency-injected (`_list_sources` / `_probe`) — no network. Verifies the
+surface-only receipt, the dead→exit-1 gate, and that gated/errored/non-URL
+sources don't fail the run.
+"""
+
+from __future__ import annotations
+
+import json
+import types
+
+from empirica.cli.command_handlers.sources_check_commands import (
+    _classify_status,
+    _is_probeable,
+    handle_sources_check_command,
+)
+
+
+def _args(**overrides):
+    defaults = {"project_id": "proj-1", "timeout": 6.0, "output": "json"}
+    defaults.update(overrides)
+    return types.SimpleNamespace(**defaults)
+
+
+def _sources(*rows):
+    return list(rows)
+
+
+def _src(sid, url, title="t"):
+    return {"id": sid, "url": url, "title": title}
+
+
+# ── classification ──────────────────────────────────────────────────────
+
+
+def test_classify_status():
+    assert _classify_status(200)[0] == "live"
+    assert _classify_status(301)[0] == "live"  # redirect resolves
+    assert _classify_status(403)[0] == "gated"
+    assert _classify_status(401)[0] == "gated"
+    assert _classify_status(404)[0] == "dead"
+    assert _classify_status(410)[0] == "dead"
+    assert _classify_status(500)[0] == "error"
+
+
+def test_is_probeable():
+    assert _is_probeable("https://x.com") is True
+    assert _is_probeable("http://x.com") is True
+    assert _is_probeable("/local/path.md") is False
+    assert _is_probeable("mailto:a@b.com") is False
+    assert _is_probeable(None) is False
+
+
+# ── handler ─────────────────────────────────────────────────────────────
+
+
+def test_all_live_exits_zero(capsys):
+    srcs = _sources(_src("s1", "https://a.com"), _src("s2", "https://b.com"))
+    rc = handle_sources_check_command(
+        _args(),
+        _list_sources=lambda pid: srcs,
+        _probe=lambda url, t: ("live", "200"),
+    )
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["checked"] == 2
+    assert out["live"] == 2
+    assert out["dead"] == []
+
+
+def test_dead_link_exits_one(capsys):
+    srcs = _sources(_src("s1", "https://ok.com"), _src("s2", "https://gone.com", "Gone"))
+
+    def probe(url, t):
+        return ("dead", "404") if "gone" in url else ("live", "200")
+
+    rc = handle_sources_check_command(_args(), _list_sources=lambda pid: srcs, _probe=probe)
+    assert rc == 1  # dead → gate fails
+    out = json.loads(capsys.readouterr().out)
+    assert out["live"] == 1
+    assert len(out["dead"]) == 1
+    assert out["dead"][0]["id"] == "s2"
+    assert out["dead"][0]["url"] == "https://gone.com"
+
+
+def test_gated_and_errored_do_not_fail(capsys):
+    srcs = _sources(_src("s1", "https://paywall.com"), _src("s2", "https://flaky.com"))
+
+    def probe(url, t):
+        return ("gated", "403") if "paywall" in url else ("error", "500")
+
+    rc = handle_sources_check_command(_args(), _list_sources=lambda pid: srcs, _probe=probe)
+    assert rc == 0  # gated/errored surfaced but not a failure
+    out = json.loads(capsys.readouterr().out)
+    assert len(out["gated"]) == 1
+    assert len(out["errored"]) == 1
+    assert out["dead"] == []
+
+
+def test_non_url_sources_skipped(capsys):
+    srcs = _sources(
+        _src("s1", "https://a.com"),
+        _src("s2", "/local/doc.md"),  # not probeable
+        _src("s3", "mailto:x@y.com"),  # not probeable
+        {"id": "s4", "url": None, "title": "no url"},
+    )
+    rc = handle_sources_check_command(_args(), _list_sources=lambda pid: srcs, _probe=lambda url, t: ("live", "200"))
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["checked"] == 1  # only s1
+    assert out["skipped_no_url"] == 3
+
+
+def test_missing_project_id_exits_one(capsys, monkeypatch):
+    # Force the session fallback to yield nothing (running from a real project
+    # dir would otherwise resolve the active project_id).
+    monkeypatch.setattr(
+        "empirica.cli.command_handlers.sources_check_commands._resolve_project_id",
+        lambda args: None,
+    )
+    rc = handle_sources_check_command(_args(project_id=None), _list_sources=lambda pid: [])
+    assert rc == 1
+    assert "project_id" in capsys.readouterr().err
+
+
+def test_list_failure_surfaces(capsys):
+    def boom(pid):
+        raise RuntimeError("db locked")
+
+    rc = handle_sources_check_command(_args(), _list_sources=boom)
+    assert rc == 1
+    assert "failed to list sources" in capsys.readouterr().err
+
+
+def test_human_output(capsys):
+    srcs = _sources(_src("s1", "https://gone.com", "Gone Doc"))
+    rc = handle_sources_check_command(
+        _args(output="human"),
+        _list_sources=lambda pid: srcs,
+        _probe=lambda url, t: ("dead", "404"),
+    )
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "sources-check" in out
+    assert "DEAD" in out and "Gone Doc" in out


### PR DESCRIPTION
Two changes, one atomic commit — the second is the P1 fix the first's rollout exposed.

## 1. Artifact-hygiene WS1 — `empirica sources-check`

Probes the http(s) URLs in `epistemic_sources` and surfaces link-rot (dead / auth-walled / errored). **Surface-only** — never deletes (retire a dead source via `delete-artifacts`' dry-run+receipt or `source-archive`). Reuses `_query_epistemic_sources`; HEAD→GET probe; dependency-injected for tests. Exit 1 iff any URL is confirmed dead (CI/hygiene gate). Smallest slice of `ARTIFACT_HYGIENE.md` §7. **Dogfooded live:** 12 URLs probed, all live, 32 non-URL sources skipped.

## 2. Resilient dispatch — life-support verbs never share fate with a feature verb

Fixes **P1 `prop_m2orjtoz`** (raised by autonomy). The dispatch table is one ~200-entry dict **literal**; a single mis-registered feature verb's undefined handler → `NameError` building the *whole* table → every verb dead **including preflight** → the praxic firewall fail-closes on broken preflight into an **unrecoverable deadlock** (can't preflight to fix what broke preflight).

**Fix:** pre-seed `command_handlers` with `_life_support_handlers()` (preflight/check/postflight/session-create/project-bootstrap/doctor/diagnose/sentinel, resolved defensively from globals) *before* the table-build `try`. On a build-time `NameError` the failed dict-literal assignment leaves the life-support value in place, and a new `except NameError` branch dispatches from it (gated by `_dispatch_reached` so it only fires for build-time, not handler-time, NameErrors). A bad feature import now degrades to "that verb unavailable", never a firewall deadlock.

## Tests
9 for `sources-check` (DI, no network) + 3 for dispatch resilience — including the proof that `doctor` still dispatches after `sources-check` is deliberately broken. `ruff` + `pyright` clean.

## Root cause (owned)
The incident was mine: I edited the live editable-install source non-atomically (dispatch reference before the import), so the fleet's editable installs captured a broken window. Mistake logged; shared-source edits now go through a git worktree or strict definitions-before-references ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)