### PR TITLE
feat(hygiene): WS2 — per-practice hygiene_policy resolver + sources-check staleness

### DIFF
--- a/empirica/cli/command_handlers/sources_check_commands.py
+++ b/empirica/cli/command_handlers/sources_check_commands.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import json
 import ssl
 import sys
+import time
 import urllib.error
 import urllib.request
 from collections.abc import Callable
@@ -102,12 +103,50 @@ def _is_probeable(url) -> bool:
     return isinstance(url, str) and url.startswith(("http://", "https://"))
 
 
+def _parse_discovered_at(value) -> float | None:
+    """Best-effort parse of a source's discovered_at into a unix timestamp."""
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        s = value.strip()
+        try:
+            return float(s)  # already a unix-ts string
+        except ValueError:
+            pass
+        try:
+            from datetime import datetime
+
+            return datetime.fromisoformat(s.replace("Z", "+00:00")).timestamp()
+        except (ValueError, OSError):
+            return None
+    return None
+
+
+def _should_probe(discovered_at, staleness_days: int, now: float) -> bool:
+    """True if a source is due for a re-probe.
+
+    ``staleness_days <= 0`` probes everything. Otherwise a source is probed once
+    it's older than the threshold; fresh sources (just added, presumed live) are
+    skipped to keep the sweep cheap. An unparseable/absent ``discovered_at``
+    probes anyway — never skip on missing data.
+    """
+    if staleness_days <= 0:
+        return True
+    ts = _parse_discovered_at(discovered_at)
+    if ts is None:
+        return True
+    return (now - ts) >= staleness_days * 86400
+
+
 def _format_human(result: dict) -> str:
     lines = [
         f"🔗 sources-check — {result['checked']} URL(s) probed "
         f"({result['live']} live, {len(result['dead'])} dead, "
         f"{len(result['gated'])} gated, {len(result['errored'])} errored; "
-        f"{result['skipped_no_url']} non-URL sources skipped)",
+        f"{result['skipped_no_url']} non-URL + {result.get('skipped_fresh', 0)} "
+        f"fresh(<{result.get('staleness_days', 0)}d) skipped)",
     ]
     for tag, rows in (("DEAD", result["dead"]), ("GATED", result["gated"]), ("ERROR", result["errored"])):
         for r in rows:
@@ -147,8 +186,20 @@ def handle_sources_check_command(
         sys.stderr.write(f"sources-check: failed to list sources: {type(e).__name__}: {e}\n")
         return 1
 
-    probeable = [s for s in sources if _is_probeable(s.get("url") or s.get("source_url"))]
-    skipped = len(sources) - len(probeable)
+    has_url = [s for s in sources if _is_probeable(s.get("url") or s.get("source_url"))]
+    skipped = len(sources) - len(has_url)
+
+    # Per-practice staleness (hygiene_policy WS2): only re-probe sources older
+    # than the threshold — fresh ones are presumed live. --staleness-days
+    # overrides the policy; 0 probes everything.
+    staleness_days = getattr(args, "staleness_days", None)
+    if staleness_days is None:
+        from empirica.config.hygiene_policy import resolve_hygiene_policy
+
+        staleness_days = int(resolve_hygiene_policy().get("source_staleness_days", 30))
+    now = time.time()
+    probeable = [s for s in has_url if _should_probe(s.get("discovered_at"), staleness_days, now)]
+    fresh_skipped = len(has_url) - len(probeable)
 
     live = 0
     dead: list[dict] = []
@@ -176,6 +227,8 @@ def handle_sources_check_command(
         "gated": gated,
         "errored": errored,
         "skipped_no_url": skipped,
+        "skipped_fresh": fresh_skipped,
+        "staleness_days": staleness_days,
     }
 
     if output_format == "json":

--- a/empirica/cli/parsers/checkpoint_parsers.py
+++ b/empirica/cli/parsers/checkpoint_parsers.py
@@ -1469,6 +1469,17 @@ def add_checkpoint_parsers(subparsers):
     sources_check_parser.add_argument(
         "--timeout", type=float, default=6.0, help="Per-URL probe timeout in seconds (default: 6.0)"
     )
+    sources_check_parser.add_argument(
+        "--staleness-days",
+        type=int,
+        default=None,
+        dest="staleness_days",
+        help=(
+            "Only re-probe sources older than N days (fresh ones presumed live); "
+            "0 probes everything. Default: the practice's hygiene_policy "
+            "source_staleness_days (30)."
+        ),
+    )
     sources_check_parser.add_argument("--output", choices=["human", "json"], default="human", help="Output format")
 
     # Graph artifact commands — batch logging and resolution

--- a/empirica/config/hygiene_policy.py
+++ b/empirica/config/hygiene_policy.py
@@ -1,0 +1,90 @@
+"""Per-practice artifact-hygiene policy resolution (artifact-hygiene WS2).
+
+Reads the ``hygiene_policy`` block from ``.empirica/project.yaml`` over a single
+source-of-truth default set — mirroring the artifact-graph gate's scalar resolver
+(``_resolve_gate_scalars``, #253): a host/extension config owns these values; the
+resolver clamps + validates and **never raises** (a bad policy must not break a
+hygiene sweep). The policy governs how aggressively each practice cleans:
+research keeps unknowns open longer (they *are* the work), code closes
+evidence-backed goals fast, outreach watches link-rot. See
+``docs/architecture/ARTIFACT_HYGIENE.md`` §4.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Single source of truth: the default for every policy field. Numeric fields
+# clamp to >= 0; enum fields validate against their allowed set (unknown value
+# → default). Keep this the ONLY place defaults live.
+HYGIENE_POLICY_DEFAULTS: dict = {
+    "source_staleness_days": 30,  # re-probe sources older than this; 0 = probe all
+    "unknown_triage_days": 14,  # flag unknowns open longer than this for triage
+    "goal_auto_close": "evidence_only",  # evidence_only | surface_only
+    "auto_delete": "test_noise_only",  # off | test_noise_only  (never semantic-on-age)
+    "dedup": "exact_only",  # exact_only | fuzzy
+}
+
+_ENUM_FIELDS: dict = {
+    "goal_auto_close": {"evidence_only", "surface_only"},
+    "auto_delete": {"off", "test_noise_only"},
+    "dedup": {"exact_only", "fuzzy"},
+}
+_INT_FIELDS = frozenset({"source_staleness_days", "unknown_triage_days"})
+
+
+def _coerce(field: str, value) -> object:
+    """Coerce + validate one policy field; return its default on anything off."""
+    default = HYGIENE_POLICY_DEFAULTS[field]
+    if field in _INT_FIELDS:
+        try:
+            n = int(value)
+        except (TypeError, ValueError):
+            return default
+        return n if n >= 0 else default
+    if field in _ENUM_FIELDS:
+        return value if value in _ENUM_FIELDS[field] else default
+    return default
+
+
+def _find_project_root() -> Path | None:
+    """Walk up from cwd for a directory containing ``.empirica/project.yaml``."""
+    cwd = Path.cwd()
+    for parent in [cwd, *cwd.parents]:
+        if (parent / ".empirica" / "project.yaml").exists():
+            return parent
+    return None
+
+
+def resolve_hygiene_policy(project_root: Path | str | None = None) -> dict:
+    """Resolve the per-practice hygiene policy.
+
+    Defaults overlaid with the ``.empirica/project.yaml`` ``hygiene_policy``
+    block. Each supplied field is coerced/validated; anything invalid falls back
+    to its default. Never raises — a missing/unparseable project.yaml yields the
+    pure defaults.
+    """
+    policy = dict(HYGIENE_POLICY_DEFAULTS)
+    try:
+        import yaml
+
+        root = Path(project_root) if project_root else _find_project_root()
+        if root is None:
+            return policy
+        proj_yaml = Path(root) / ".empirica" / "project.yaml"
+        if not proj_yaml.exists():
+            return policy
+        data = yaml.safe_load(proj_yaml.read_text(encoding="utf-8")) or {}
+        block = data.get("hygiene_policy")
+        if isinstance(block, dict):
+            for field in HYGIENE_POLICY_DEFAULTS:
+                if field in block:
+                    policy[field] = _coerce(field, block[field])
+    except Exception as e:
+        # A bad policy / unreadable yaml must not break a hygiene sweep — but
+        # surface it at debug so a mis-set policy is diagnosable, not silent.
+        logger.debug("hygiene_policy: resolve failed, using defaults (%s)", e)
+    return policy

--- a/tests/test_hygiene_policy.py
+++ b/tests/test_hygiene_policy.py
@@ -1,0 +1,89 @@
+"""Tests for resolve_hygiene_policy — per-practice artifact-hygiene policy (WS2).
+
+Mirrors the #253 scalar-resolver discipline: defaults are the single source of
+truth, project.yaml overrides are clamped/validated, and a bad policy never
+raises (falls back to defaults).
+"""
+
+from __future__ import annotations
+
+import yaml
+
+from empirica.config.hygiene_policy import (
+    HYGIENE_POLICY_DEFAULTS,
+    resolve_hygiene_policy,
+)
+
+
+def _write_policy(tmp_path, block):
+    empdir = tmp_path / ".empirica"
+    empdir.mkdir(parents=True, exist_ok=True)
+    (empdir / "project.yaml").write_text(yaml.dump({"project_id": "p", "hygiene_policy": block}), encoding="utf-8")
+    return tmp_path
+
+
+def test_defaults_when_no_project_yaml(tmp_path):
+    assert resolve_hygiene_policy(tmp_path) == HYGIENE_POLICY_DEFAULTS
+
+
+def test_full_override(tmp_path):
+    root = _write_policy(
+        tmp_path,
+        {
+            "source_staleness_days": 7,
+            "unknown_triage_days": 60,
+            "goal_auto_close": "surface_only",
+            "auto_delete": "off",
+            "dedup": "fuzzy",
+        },
+    )
+    p = resolve_hygiene_policy(root)
+    assert p["source_staleness_days"] == 7
+    assert p["unknown_triage_days"] == 60
+    assert p["goal_auto_close"] == "surface_only"
+    assert p["auto_delete"] == "off"
+    assert p["dedup"] == "fuzzy"
+
+
+def test_partial_override_keeps_other_defaults(tmp_path):
+    root = _write_policy(tmp_path, {"source_staleness_days": 90})
+    p = resolve_hygiene_policy(root)
+    assert p["source_staleness_days"] == 90
+    assert p["unknown_triage_days"] == HYGIENE_POLICY_DEFAULTS["unknown_triage_days"]
+    assert p["goal_auto_close"] == HYGIENE_POLICY_DEFAULTS["goal_auto_close"]
+
+
+def test_negative_int_clamps_to_default(tmp_path):
+    root = _write_policy(tmp_path, {"source_staleness_days": -5})
+    assert resolve_hygiene_policy(root)["source_staleness_days"] == HYGIENE_POLICY_DEFAULTS["source_staleness_days"]
+
+
+def test_bad_int_falls_back(tmp_path):
+    root = _write_policy(tmp_path, {"source_staleness_days": "soon"})
+    assert resolve_hygiene_policy(root)["source_staleness_days"] == HYGIENE_POLICY_DEFAULTS["source_staleness_days"]
+
+
+def test_unknown_enum_falls_back(tmp_path):
+    root = _write_policy(tmp_path, {"goal_auto_close": "yolo", "dedup": "aggressive"})
+    p = resolve_hygiene_policy(root)
+    assert p["goal_auto_close"] == HYGIENE_POLICY_DEFAULTS["goal_auto_close"]
+    assert p["dedup"] == HYGIENE_POLICY_DEFAULTS["dedup"]
+
+
+def test_unknown_keys_ignored(tmp_path):
+    root = _write_policy(tmp_path, {"source_staleness_days": 10, "bogus_field": 99})
+    p = resolve_hygiene_policy(root)
+    assert p["source_staleness_days"] == 10
+    assert "bogus_field" not in p
+
+
+def test_malformed_yaml_returns_defaults(tmp_path):
+    empdir = tmp_path / ".empirica"
+    empdir.mkdir(parents=True)
+    (empdir / "project.yaml").write_text("hygiene_policy: [not: a: mapping", encoding="utf-8")
+    assert resolve_hygiene_policy(tmp_path) == HYGIENE_POLICY_DEFAULTS
+
+
+def test_non_dict_block_returns_defaults(tmp_path):
+    root = _write_policy(tmp_path, "not-a-dict")
+    assert resolve_hygiene_policy(root) == HYGIENE_POLICY_DEFAULTS

--- a/tests/test_sources_check.py
+++ b/tests/test_sources_check.py
@@ -8,6 +8,7 @@ sources don't fail the run.
 from __future__ import annotations
 
 import json
+import time
 import types
 
 from empirica.cli.command_handlers.sources_check_commands import (
@@ -18,7 +19,8 @@ from empirica.cli.command_handlers.sources_check_commands import (
 
 
 def _args(**overrides):
-    defaults = {"project_id": "proj-1", "timeout": 6.0, "output": "json"}
+    # staleness_days=0 → probe all regardless of discovered_at (deterministic).
+    defaults = {"project_id": "proj-1", "timeout": 6.0, "output": "json", "staleness_days": 0}
     defaults.update(overrides)
     return types.SimpleNamespace(**defaults)
 
@@ -144,3 +146,36 @@ def test_human_output(capsys):
     out = capsys.readouterr().out
     assert "sources-check" in out
     assert "DEAD" in out and "Gone Doc" in out
+
+
+# ── staleness filter (WS2) ──────────────────────────────────────────────
+
+
+def test_should_probe():
+    from empirica.cli.command_handlers.sources_check_commands import _should_probe
+
+    now = 1_000_000.0
+    day = 86400
+    assert _should_probe(now - 40 * day, 30, now) is True  # older than threshold → probe
+    assert _should_probe(now - 5 * day, 30, now) is False  # fresh → skip
+    assert _should_probe(None, 30, now) is True  # unknown age → probe (never skip on missing)
+    assert _should_probe(now - 5 * day, 0, now) is True  # 0 → probe everything
+
+
+def test_staleness_skips_fresh_sources(capsys):
+    now = time.time()
+    day = 86400
+    srcs = _sources(
+        {"id": "old", "url": "https://old.com", "title": "old", "discovered_at": now - 60 * day},
+        {"id": "fresh", "url": "https://fresh.com", "title": "fresh", "discovered_at": now - 2 * day},
+    )
+    rc = handle_sources_check_command(
+        _args(staleness_days=30),  # skip anything newer than 30d
+        _list_sources=lambda pid: srcs,
+        _probe=lambda url, t: ("live", "200"),
+    )
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["checked"] == 1  # only the 60d-old one
+    assert out["skipped_fresh"] == 1
+    assert out["staleness_days"] == 30


### PR DESCRIPTION
Artifact-hygiene **work-stream 2** (`ARTIFACT_HYGIENE.md` §4/§7).

## `resolve_hygiene_policy()`
New `empirica/config/hygiene_policy.py`. Reads the `hygiene_policy` block from `.empirica/project.yaml` over a single-source-of-truth default set — mirroring the #253 artifact-graph scalar resolver ("one loop body, per-practice via config"). Numeric fields clamp `>=0`, enum fields validate against their allowed set, unknown keys ignored; a bad/unreadable policy debug-logs and falls back to defaults (**never raises, never silent**).

Fields (the per-practice knobs): `source_staleness_days`, `unknown_triage_days`, `goal_auto_close`, `auto_delete`, `dedup`. Research keeps unknowns open longer; code closes evidence-backed goals fast; outreach watches link-rot.

## First consumer — `sources-check --staleness-days`
Only re-probes sources older than N days (default = policy's `source_staleness_days`, 30) — fresh ones are presumed live, keeping the sweep cheap. `0` probes everything; an unparseable/absent `discovered_at` probes anyway (never skip on missing data). Receipt gains `skipped_fresh` + `staleness_days`.

## Tests
9 for the resolver (defaults / override / clamp / enum-fallback / malformed-yaml / non-dict) + 2 for the staleness filter. **23 green** across hygiene + dispatch. ruff + pyright clean. Dogfooded live with the new flag.

Built **module-first then atomically wired** — applying the fleet-brick lesson (no reference-before-definition window). Part of goal `a729201b`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)