### PR TITLE
feat(sentinel): emit gating-state changes on pause/resume (immune-system Req 1)

### DIFF
--- a/empirica/cli/command_handlers/cockpit_commands.py
+++ b/empirica/cli/command_handlers/cockpit_commands.py
@@ -197,6 +197,46 @@ def _emit(args, payload: dict[str, Any], human_summary: str) -> int:
 # ─── empirica sentinel ──────────────────────────────────────────────────────
 
 
+def _emit_sentinel_state_event(event: str, status, *, _emit_fn=None) -> None:
+    """Best-effort: report a Sentinel gating-state change to cortex's system-event
+    surface (immune-system Req 1; autonomy ruling prop_72y3dqeb).
+
+    A silent pause that disarms gating is the most observable-worthy event in the
+    system — the fleet once ran ungated ~50min undetected. REPORTS flow UP here
+    (any practice, about itself, on /v1/system/event which it's entitled to);
+    guardians re-emit DIRECTIVES on the source-gated guardian_action channel after
+    judgment. ``emit_path=cli_verb`` marks this as verb-emitted so consumers can
+    tell it apart from the raw-file-touch blind spot the guardian's filesystem
+    watch covers.
+
+    NEVER raises, NEVER blocks — an emit failure must not affect gating.
+    """
+    try:
+        import time as _time
+
+        from empirica.cli.command_handlers.system_event import emit_system_event
+        from empirica.utils.session_resolver import InstanceResolver
+
+        emit = _emit_fn or emit_system_event
+        try:
+            practice = InstanceResolver.ai_id()  # best-available; canonical when resolvable
+        except Exception:
+            practice = None
+        envelope = {
+            "event": event,  # sentinel_pause | sentinel_resume
+            "scope": getattr(status, "scope", None),
+            "practice_ai_id": practice,
+            "instance_id": getattr(status, "instance_id", None),
+            "actor": "cli",
+            "created_at": _time.time(),
+            "reason": getattr(status, "reason", None),
+            "emit_path": "cli_verb",
+        }
+        emit(envelope)
+    except Exception as e:
+        logging.getLogger(__name__).debug("sentinel state-event emit failed (non-fatal): %s", e)
+
+
 def handle_sentinel_pause_command(args) -> int:
     try:
         targets = _resolve_sentinel_targets(args)
@@ -204,6 +244,8 @@ def handle_sentinel_pause_command(args) -> int:
         return _emit_sentinel_error(args, str(e))
     reason = getattr(args, "reason", None)
     statuses = [pause_sentinel(t, reason=reason) for t in targets]
+    for _st in statuses:
+        _emit_sentinel_state_event("sentinel_pause", _st)
     if len(statuses) == 1:
         status = statuses[0]
         payload = {
@@ -234,6 +276,8 @@ def handle_sentinel_resume_command(args) -> int:
     except SentinelResolveError as e:
         return _emit_sentinel_error(args, str(e))
     results = [(t, resume_sentinel(t)) for t in targets]
+    for _, _st in results:
+        _emit_sentinel_state_event("sentinel_resume", _st)
     if len(results) == 1:
         instance_id, status = results[0]
         payload = {

--- a/tests/test_sentinel_state_event.py
+++ b/tests/test_sentinel_state_event.py
@@ -1,0 +1,80 @@
+"""Tests for the Sentinel gating-state-change emit (immune-system Req 1).
+
+Autonomy ruling prop_72y3dqeb: a pause/resume that changes gating state must
+REPORT itself on cortex's system-event surface so a silent disarm of the fleet's
+gates is observable (the incident: fleet ran ungated ~50min undetected). Emit is
+best-effort — it must never raise or block the pause.
+"""
+
+from __future__ import annotations
+
+import types
+
+from empirica.cli.command_handlers.cockpit_commands import _emit_sentinel_state_event
+
+
+def _status(scope="global", instance_id="tmux_4", reason=None):
+    return types.SimpleNamespace(scope=scope, instance_id=instance_id, reason=reason)
+
+
+def test_envelope_matches_ruling_schema():
+    captured = {}
+    _emit_sentinel_state_event(
+        "sentinel_pause",
+        _status(scope="global", instance_id="tmux_4", reason="deadlock recovery"),
+        _emit_fn=lambda env: captured.update(env),
+    )
+    assert captured["event"] == "sentinel_pause"
+    assert captured["scope"] == "global"
+    assert captured["instance_id"] == "tmux_4"
+    assert captured["reason"] == "deadlock recovery"
+    assert captured["actor"] == "cli"
+    assert captured["emit_path"] == "cli_verb"  # marks verb-emitted vs raw-touch
+    assert "created_at" in captured
+    assert "practice_ai_id" in captured  # best-available (may be None off-project)
+
+
+def test_resume_event_name():
+    captured = {}
+    _emit_sentinel_state_event(
+        "sentinel_resume",
+        _status(scope="instance", instance_id="tmux_1"),
+        _emit_fn=lambda env: captured.update(env),
+    )
+    assert captured["event"] == "sentinel_resume"
+    assert captured["scope"] == "instance"
+
+
+def test_emit_failure_never_raises():
+    def boom(_env):
+        raise ConnectionError("cortex unreachable")
+
+    # Must swallow — a pause must not fail on an emit error.
+    _emit_sentinel_state_event("sentinel_pause", _status(), _emit_fn=boom)
+
+
+def test_handler_emits_on_pause(monkeypatch):
+    """The pause handler emits a state-change event per affected target — without
+    touching a real pause file (pause_sentinel + emit are stubbed)."""
+    from empirica.cli.command_handlers import cockpit_commands as cc
+
+    emitted = []
+    monkeypatch.setattr(cc, "_resolve_sentinel_targets", lambda args: ["tmux_9"])
+    monkeypatch.setattr(
+        cc,
+        "pause_sentinel",
+        lambda t, reason=None: types.SimpleNamespace(
+            paused=True, instance_id=t, scope="instance", since="now", reason=reason
+        ),
+    )
+    monkeypatch.setattr(
+        "empirica.cli.command_handlers.system_event.emit_system_event",
+        lambda env, **kw: emitted.append(env) or (200, {"ok": True}),
+    )
+    args = types.SimpleNamespace(reason="test", output="json")
+    rc = cc.handle_sentinel_pause_command(args)
+    assert rc == 0
+    assert len(emitted) == 1
+    assert emitted[0]["event"] == "sentinel_pause"
+    assert emitted[0]["instance_id"] == "tmux_9"
+    assert emitted[0]["emit_path"] == "cli_verb"


### PR DESCRIPTION
Sentinel `pause`/`resume` now **report the gating-state change** to cortex's system-event surface, so a silent disarm of the fleet's gates is observable — the failure the P1 exposed (fleet ran ungated ~50 min, detected only by David's eyeballs).

## Design (autonomy ruling `prop_72y3dqeb`)
The **affected practice reports on the surface it's entitled to** (`POST /v1/system/event` via `emit_system_event`), **not** the source-gated `guardian_action` channel. Crisp line: *reports flow up on system-event (any practice, about itself); directives flow out on guardian_action (guardians only, after judgment)*. Generalizes to any practice — empirica-core isn't special-cased.

## Schema
```json
{ "event": "sentinel_pause" | "sentinel_resume", "scope": "global|instance",
  "practice_ai_id": "...", "instance_id": "tmux_N", "actor": "cli",
  "created_at": <ts>, "reason": "...", "emit_path": "cli_verb" }
```
`emit_path=cli_verb` marks verb-emitted events so consumers distinguish them from the **raw-file-touch blind spot** the guardian's filesystem watch (autonomy Req 2) covers — **(a)+Req2 = full coverage**.

## Safety
Best-effort — **never raises, never blocks**; an emit failure cannot affect gating. Boundary: only the CLI verb path emits; a raw `touch sentinel_paused` runs no code and emits nothing (Req 2's job).

## Tests
4 — envelope-matches-schema, resume-event, emit-failure-never-raises, and a handler-integration proving pause emits per-target *without touching a real pause file*. ruff + pyright clean. (Note: I didn't live-run `sentinel pause` — that would disarm my own gate; the handler-integration test covers it with stubs.)

Closes the immune-system Req 1 from the P1 thread (goal `b494daff`). READ surface (GET+since for the watch-layer) is cortex's lane — flagged back to autonomy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)