### PR TITLE
feat(postflight): artifact-graph gate enforce mechanism (dormant, strictness-keyed)

### DIFF
--- a/empirica/cli/command_handlers/_workflow_check.py
+++ b/empirica/cli/command_handlers/_workflow_check.py
@@ -674,6 +674,40 @@ def _check_gate_decision(vectors, ready_uncertainty_threshold, diminishing_retur
     return decision, computed_decision, autopilot_mode, decision_binding
 
 
+def _check_apply_weave_enforce(result, decision, session_id, transaction_id):
+    """Artifact-graph weave-gate enforce-half (map work-stream 1).
+
+    Attaches the weave-gate verdict to the CHECK result (report) and, when the
+    gate is ENFORCED — strictness in the ``enforce`` band (≥0.70) AND the
+    transaction's artifacts below the connectivity floor — overrides a
+    ``proceed`` to ``investigate``, blocking the noetic→praxic transition until
+    the artifacts are woven.
+
+    DORMANT BY DEFAULT: the report-only strictness (0.25) never sets
+    ``enforced``, so this is a pure no-op until a practice dials strictness up.
+    Best-effort and fail-open — a measurement error never blocks CHECK (mirrors
+    the P1 lesson: gating machinery must not brick the loop it gates).
+    """
+    try:
+        from ._workflow_shared import _weave_enforcement_block
+
+        block = _weave_enforcement_block(session_id, transaction_id)
+        if not block:
+            return decision
+        result["weave_gate"] = block
+        if block.get("enforced") and decision == "proceed":
+            decision = "investigate"
+            result["decision"] = decision
+            result["weave_enforce"] = {
+                "blocked": True,
+                "reason": block.get("note", "weave more artifacts before proceeding to praxic"),
+            }
+            logger.info("CHECK weave-enforce override: proceed → investigate (artifact-graph gate enforced)")
+    except Exception as e:
+        logger.debug(f"weave-enforce check skipped (non-fatal): {e}")
+    return decision
+
+
 def _check_store_and_publish(session_id, round_num, vectors, decision, reasoning, cycle):
     """Store CHECK checkpoint (3-layer) and publish bus event.
 
@@ -1207,6 +1241,11 @@ def handle_check_submit_command(args):
 
             # Stage 13: Blindspot scan (may override decision)
             decision = _check_run_blindspot_scan(result, decision, session_id, bootstrap_result, bootstrap_status)
+
+            # Stage 13.5: Artifact-graph weave-enforce (may override decision).
+            # Dormant by default (report-only strictness) — only blocks when a
+            # practice dials strictness into the enforce band. Map work-stream 1.
+            decision = _check_apply_weave_enforce(result, decision, session_id, check_transaction_id)
 
             # Stage 14: Pattern retrieval + codebase context
             _check_enrich_context(result, bootstrap_result, bootstrap_status, vectors, reasoning)

--- a/empirica/cli/command_handlers/_workflow_shared.py
+++ b/empirica/cli/command_handlers/_workflow_shared.py
@@ -39,6 +39,7 @@ __all__ = [
     "_retro_count_edges",
     "_retro_count_sources",
     "_soft_run",
+    "_weave_enforcement_block",
 ]
 
 # Investigation-heavy work_types where noetic_batch is most useful.
@@ -634,11 +635,13 @@ def _weave_gate_block(total_artifacts: int, edges_count: int) -> dict | None:
     is measured against ``connectivity_floor``; the loudness of the ``note`` is
     scaled by the ``strictness``-derived response band.
 
-    **REPORT-ONLY in this build** — ``enforced`` is always ``False``, even at the
-    ``enforce`` band. The actual soft/hard *blocking* is a deliberate follow-up
-    keyed on ``strictness`` (and ``patience`` for the adaptive escalation).
-    Returns None when strictness dials the gate fully ``silent`` (<0.05) or there
-    are no artifacts.
+    **Enforcement is strictness-driven.** ``enforced`` is True ONLY at the
+    ``enforce`` band (strictness ≥ 0.70) AND below the connectivity floor — at
+    every lower band it stays ``False`` (report-only), so the default (strictness
+    0.25) never blocks. A practice opts into enforcement by dialing strictness up;
+    the consumer (the CHECK gate) blocks the noetic→praxic transition when
+    ``enforced``. Returns None when strictness dials the gate fully ``silent``
+    (<0.05) or there are no artifacts.
     """
     scalars = _resolve_gate_scalars()
     response = _gate_response_for(scalars["strictness"])
@@ -647,6 +650,9 @@ def _weave_gate_block(total_artifacts: int, edges_count: int) -> dict | None:
     connected = min(edges_count, total_artifacts)
     connected_ratio = connected / total_artifacts if total_artifacts else 0.0
     satisfied = connected_ratio >= scalars["connectivity_floor"]
+    # The block signal: only the enforce band, only below the floor. Everything
+    # else is report-only — the whole point of the ramp (#253 scalar surface).
+    enforced = response == "enforce" and not satisfied
     if connected >= total_artifacts:
         verdict = "connected"
     elif connected > 0:
@@ -655,20 +661,26 @@ def _weave_gate_block(total_artifacts: int, edges_count: int) -> dict | None:
         verdict = "disconnected"
     pct = round(connected_ratio * 100)
     floor_pct = round(scalars["connectivity_floor"] * 100)
+    mode = "ENFORCED — blocks" if enforced else f"{response}, report-only"
     if satisfied:
         note = (
-            f"artifact-graph gate [{response}, report-only]: "
+            f"artifact-graph gate [{mode}]: "
             f"{connected}/{total_artifacts} artifacts connected ({pct}%) — "
             f"meets the {floor_pct}% floor."
         )
     else:
-        lead = "SHOULD weave more" if response in ("warn", "enforce") else "consider weaving"
+        lead = (
+            "MUST weave more (transition blocked)"
+            if enforced
+            else ("SHOULD weave more" if response == "warn" else "consider weaving")
+        )
+        tail = "" if enforced else " Blocking activates only at strictness ≥ 0.70."
         note = (
-            f"artifact-graph gate [{response}, report-only]: "
+            f"artifact-graph gate [{mode}]: "
             f"{connected}/{total_artifacts} artifacts connected ({pct}%), below the "
             f"{floor_pct}% floor — {lead}. Structural goal-edges are automatic; add "
             "semantic edges (log-artifacts nodes+edges, or --related-to / --edge on "
-            "any *-log) to raise connectivity. Blocking not yet active."
+            f"any *-log) to raise connectivity.{tail}"
         )
     return {
         "scalars": scalars,
@@ -678,9 +690,29 @@ def _weave_gate_block(total_artifacts: int, edges_count: int) -> dict | None:
         "connected_artifacts": connected,
         "total_artifacts": total_artifacts,
         "satisfied": satisfied,
-        "enforced": False,  # report-only build; blocking keyed on strictness is a follow-up
+        "enforced": enforced,  # strictness-driven: True only at enforce band + below floor
         "note": note,
     }
+
+
+def _weave_enforcement_block(session_id: str, transaction_id: str | None) -> dict | None:
+    """Compute the artifact-graph weave-gate for THIS transaction, for the CHECK
+    gate's enforce-half (map work-stream 1). Reuses the same artifact/edge
+    counters the POSTFLIGHT retrospective uses. Returns the gate block (carrying
+    the ``enforced`` flag) or None. Best-effort — any measurement error returns
+    None, so a counting failure never blocks CHECK.
+    """
+    try:
+        db = _get_db_for_session(session_id)
+        cursor = db.conn.cursor()
+        counts = _retro_count_artifacts(cursor, session_id, transaction_id)
+        total_artifacts = sum(counts.values()) if isinstance(counts, dict) else int(counts)
+        if total_artifacts < 1:
+            return None
+        edges = _retro_count_edges(cursor, session_id, transaction_id)
+        return _weave_gate_block(total_artifacts, edges)
+    except Exception:
+        return None
 
 
 def _maybe_add_weave_gate(cursor, session_id, transaction_id, retro: dict, total_artifacts: int) -> None:

--- a/tests/test_check_weave_enforce.py
+++ b/tests/test_check_weave_enforce.py
@@ -1,0 +1,80 @@
+"""Artifact-graph weave-enforce at the CHECK gate (map work-stream 1 enforce-half).
+
+The gate can now BLOCK the noetic→praxic transition — but ONLY when a practice
+dials strictness into the enforce band (≥0.70) and the transaction's artifacts
+are below the connectivity floor. By default (report-only strictness) it's a pure
+no-op. And it's fail-open: a measurement error never blocks CHECK (the P1 lesson —
+gating machinery must not brick the loop it gates).
+"""
+
+from __future__ import annotations
+
+from empirica.cli.command_handlers._workflow_check import _check_apply_weave_enforce
+
+_BLOCK_MOD = "empirica.cli.command_handlers._workflow_shared._weave_enforcement_block"
+
+
+def test_dormant_when_not_enforced(monkeypatch):
+    monkeypatch.setattr(_BLOCK_MOD, lambda sid, tx: {"enforced": False, "note": "report-only"})
+    result = {"decision": "proceed"}
+    d = _check_apply_weave_enforce(result, "proceed", "s1", "tx1")
+    assert d == "proceed"  # dormant — no override
+    assert result["weave_gate"]["enforced"] is False  # still attached (report)
+    assert "weave_enforce" not in result
+
+
+def test_blocks_proceed_when_enforced(monkeypatch):
+    monkeypatch.setattr(_BLOCK_MOD, lambda sid, tx: {"enforced": True, "note": "MUST weave more"})
+    result = {"decision": "proceed"}
+    d = _check_apply_weave_enforce(result, "proceed", "s1", "tx1")
+    assert d == "investigate"  # blocked
+    assert result["decision"] == "investigate"  # result updated too
+    assert result["weave_enforce"]["blocked"] is True
+    assert "MUST weave" in result["weave_enforce"]["reason"]
+
+
+def test_investigate_unchanged_when_enforced(monkeypatch):
+    # enforce only overrides a proceed — an already-investigate decision is untouched.
+    monkeypatch.setattr(_BLOCK_MOD, lambda sid, tx: {"enforced": True, "note": "x"})
+    result = {"decision": "investigate"}
+    d = _check_apply_weave_enforce(result, "investigate", "s1", "tx1")
+    assert d == "investigate"
+
+
+def test_none_block_leaves_everything_alone(monkeypatch):
+    monkeypatch.setattr(_BLOCK_MOD, lambda sid, tx: None)  # no artifacts / silent
+    result = {"decision": "proceed"}
+    d = _check_apply_weave_enforce(result, "proceed", "s1", "tx1")
+    assert d == "proceed"
+    assert "weave_gate" not in result
+
+
+def test_measurement_failure_is_fail_open(monkeypatch):
+    def boom(sid, tx):
+        raise RuntimeError("db locked")
+
+    monkeypatch.setattr(_BLOCK_MOD, boom)
+    result = {"decision": "proceed"}
+    d = _check_apply_weave_enforce(result, "proceed", "s1", "tx1")
+    assert d == "proceed"  # fail-open — a counting error never blocks CHECK
+
+
+# ── _weave_enforcement_block (the DB-reading wrapper) ────────────────────
+
+
+def test_enforcement_block_none_on_db_error(monkeypatch):
+    from empirica.cli.command_handlers import _workflow_shared as ws
+
+    monkeypatch.setattr(ws, "_get_db_for_session", lambda sid: (_ for _ in ()).throw(RuntimeError("boom")))
+    assert ws._weave_enforcement_block("s1", "tx1") is None
+
+
+def test_enforcement_block_none_when_no_artifacts(monkeypatch):
+    import types
+
+    from empirica.cli.command_handlers import _workflow_shared as ws
+
+    fake_db = types.SimpleNamespace(conn=types.SimpleNamespace(cursor=lambda: None))
+    monkeypatch.setattr(ws, "_get_db_for_session", lambda sid: fake_db)
+    monkeypatch.setattr(ws, "_retro_count_artifacts", lambda cur, sid, tx: {"finding": 0})
+    assert ws._weave_enforcement_block("s1", "tx1") is None  # 0 artifacts → None

--- a/tests/test_weave_gate_block.py
+++ b/tests/test_weave_gate_block.py
@@ -101,9 +101,29 @@ def test_no_artifacts_returns_none(monkeypatch):
     assert _weave_gate_block(0, 0) is None
 
 
-def test_never_enforces_even_at_enforce_band(monkeypatch):
+def test_enforces_at_enforce_band_below_floor(monkeypatch):
     _clear(monkeypatch)
     monkeypatch.setenv("EMPIRICA_ARTIFACT_GRAPH_STRICTNESS", "0.9")
-    g = _weave_gate_block(2, 0)
+    g = _weave_gate_block(2, 0)  # 0% connected, below the 50% floor
     assert g["response"] == "enforce"
-    assert g["enforced"] is False  # report-only build — blocking is a follow-up
+    assert g["enforced"] is True  # enforce band + below floor → blocks
+
+
+def test_report_and_warn_bands_never_enforce(monkeypatch):
+    _clear(monkeypatch)
+    # default (report, 0.25) below floor → dormant
+    assert _weave_gate_block(2, 0)["enforced"] is False
+    # warn band (0.5) below floor → still report-only, no block
+    monkeypatch.setenv("EMPIRICA_ARTIFACT_GRAPH_STRICTNESS", "0.5")
+    g = _weave_gate_block(2, 0)
+    assert g["response"] == "warn"
+    assert g["enforced"] is False
+
+
+def test_enforce_band_satisfied_does_not_enforce(monkeypatch):
+    _clear(monkeypatch)
+    monkeypatch.setenv("EMPIRICA_ARTIFACT_GRAPH_STRICTNESS", "0.9")
+    g = _weave_gate_block(2, 2)  # fully connected → satisfied → no block even at enforce
+    assert g["response"] == "enforce"
+    assert g["satisfied"] is True
+    assert g["enforced"] is False


### PR DESCRIPTION
The artifact-graph gate can now **block** the noetic→praxic transition — but stays **report-only until a practice dials strictness up** ("build the mechanism, we enforce after"). Map work-stream 1's enforce-half, riding the #253 scalar control surface.

## What changed
- **`_weave_gate_block`** — `enforced` is now **strictness-driven**: True only at the `enforce` band (strictness ≥ 0.70) **and** below the connectivity floor. Every lower band stays report-only, so the default (0.25) never blocks. (Was hardcoded `False`.)
- **`_weave_enforcement_block(session_id, tx)`** — computes the gate for the live transaction, reusing the POSTFLIGHT retrospective's artifact/edge counters. Best-effort → `None` on any error.
- **CHECK Stage 13.5 (`_check_apply_weave_enforce`)** — attaches `weave_gate` to the result (report) and, when **enforced**, overrides `proceed → investigate`, blocking until artifacts are woven. Mirrors the existing sentinel (Stage 9) / blindspot (Stage 13) override pattern.

## Safety
- **Fail-open**: a measurement error never blocks CHECK — gating machinery must not brick the loop it gates (the P1 lesson, applied to the *core* gate this time).
- **Dormant**: default strictness (0.25) = zero behavior change. **Verified live** — default → `proceed`; strictness 0.9 with satisfied artifacts → `proceed` (no over-block). The block fires only below the floor at the enforce band.

## Tests
`_weave_gate_block` enforce cases (enforce-band-below-floor blocks · report/warn never enforce · enforce-band-satisfied doesn't) + 7 for the CHECK integration (dormant / blocks-proceed / investigate-unchanged / none / fail-open / db-error / no-artifacts). **389 CHECK+workflow tests green; pyright 0/0/0.**

This is the flip from *nudge* to a real *gate* — you enforce by dialing strictness, per practice, when ready. Part of goal `43471346` (the GATED_ARTIFACT_GRAPH map).

🤖 Generated with [Claude Code](https://claude.com/claude-code)