### PR TITLE
feat(postflight): per-practice project.yaml source for artifact-graph gate scalars

### DIFF
--- a/empirica/cli/command_handlers/_workflow_shared.py
+++ b/empirica/cli/command_handlers/_workflow_shared.py
@@ -579,8 +579,37 @@ _GATE_SCALARS = {
 }
 
 
+def _read_project_gate_scalars() -> dict:
+    """Per-practice ``artifact_graph`` gate-scalar block from .empirica/project.yaml.
+
+    The map's per-practice home for the gate config: a practice flips enforcement
+    on by setting ``artifact_graph: {strictness: 0.75, ...}`` in its project.yaml.
+    That file is gitignored + per-instance, so this is a LOCAL per-practice knob —
+    one practice enforcing does not touch the others. Returns {} on any error.
+    """
+    try:
+        from pathlib import Path
+
+        import yaml
+
+        pp = R.project_path()
+        if not pp:
+            return {}
+        pj = Path(pp) / ".empirica" / "project.yaml"
+        if not pj.exists():
+            return {}
+        data = yaml.safe_load(pj.read_text(encoding="utf-8")) or {}
+        block = data.get("artifact_graph")
+        return block if isinstance(block, dict) else {}
+    except Exception:
+        return {}
+
+
 def _resolve_gate_scalars() -> dict:
-    """Resolve the gate's three scalar dimensions from env (Sentinel sliders).
+    """Resolve the gate's three scalar dimensions.
+
+    Precedence: env var (session override) > .empirica/project.yaml
+    ``artifact_graph`` block (per-practice durable config) > single-source default.
 
     - **strictness** — response intensity (drives ``_gate_response_for``).
     - **connectivity_floor** — fraction of artifacts that must carry ≥1 edge to
@@ -593,9 +622,12 @@ def _resolve_gate_scalars() -> dict:
     back to its default. Never raises — a bad slider value must not break the
     retrospective.
     """
+    project_cfg = _read_project_gate_scalars()
     out: dict = {}
     for key, (default, env) in _GATE_SCALARS.items():
         raw = os.environ.get(env)
+        if raw is None and key in project_cfg:
+            raw = project_cfg[key]  # per-practice project.yaml source (env still wins)
         if raw is None:
             out[key] = default
             continue

--- a/tests/test_gate_scalars_project_source.py
+++ b/tests/test_gate_scalars_project_source.py
@@ -1,0 +1,69 @@
+"""Per-practice project.yaml source for the artifact-graph gate scalars.
+
+The map's "project.yaml home": a practice flips enforcement on by setting an
+``artifact_graph`` block in its (gitignored, per-instance) .empirica/project.yaml
+— so one practice enforcing doesn't touch the others. Precedence:
+env var (session override) > project.yaml > single-source default.
+"""
+
+from __future__ import annotations
+
+import yaml
+
+from empirica.cli.command_handlers import _workflow_shared as ws
+
+
+def _project(tmp_path, block):
+    empdir = tmp_path / ".empirica"
+    empdir.mkdir(parents=True, exist_ok=True)
+    (empdir / "project.yaml").write_text(yaml.dump({"project_id": "p", "artifact_graph": block}))
+    return tmp_path
+
+
+def _clear_env(monkeypatch):
+    for e in (
+        "EMPIRICA_ARTIFACT_GRAPH_STRICTNESS",
+        "EMPIRICA_ARTIFACT_GRAPH_FLOOR",
+        "EMPIRICA_ARTIFACT_GRAPH_PATIENCE",
+    ):
+        monkeypatch.delenv(e, raising=False)
+
+
+def test_no_project_block_uses_defaults(tmp_path, monkeypatch):
+    _clear_env(monkeypatch)
+    monkeypatch.setattr(ws.R, "project_path", staticmethod(lambda: str(tmp_path)))  # no project.yaml
+    s = ws._resolve_gate_scalars()
+    assert s["strictness"] == 0.25  # peers with no block stay report-only
+    assert s["connectivity_floor"] == 0.50
+
+
+def test_project_yaml_flips_enforcement(tmp_path, monkeypatch):
+    _clear_env(monkeypatch)
+    root = _project(tmp_path, {"strictness": 0.75, "connectivity_floor": 0.6})
+    monkeypatch.setattr(ws.R, "project_path", staticmethod(lambda: str(root)))
+    s = ws._resolve_gate_scalars()
+    assert s["strictness"] == 0.75  # enforce band
+    assert s["connectivity_floor"] == 0.6
+    assert s["patience"] == 0.80  # unset key falls back to default
+
+
+def test_env_wins_over_project_yaml(tmp_path, monkeypatch):
+    root = _project(tmp_path, {"strictness": 0.75})
+    monkeypatch.setattr(ws.R, "project_path", staticmethod(lambda: str(root)))
+    monkeypatch.setenv("EMPIRICA_ARTIFACT_GRAPH_STRICTNESS", "0.1")  # session override
+    assert ws._resolve_gate_scalars()["strictness"] == 0.1
+
+
+def test_malformed_project_block_falls_back(tmp_path, monkeypatch):
+    _clear_env(monkeypatch)
+    root = _project(tmp_path, {"strictness": "loud"})  # unparseable
+    monkeypatch.setattr(ws.R, "project_path", staticmethod(lambda: str(root)))
+    assert ws._resolve_gate_scalars()["strictness"] == 0.25  # falls back to default
+
+
+def test_non_dict_block_ignored(tmp_path, monkeypatch):
+    _clear_env(monkeypatch)
+    root = _project(tmp_path, "not-a-dict")
+    monkeypatch.setattr(ws.R, "project_path", staticmethod(lambda: str(root)))
+    assert ws._read_project_gate_scalars() == {}
+    assert ws._resolve_gate_scalars()["strictness"] == 0.25


### PR DESCRIPTION
## What

Adds a **per-practice durable source** for the artifact-graph gate's three scalar dimensions (`strictness` / `connectivity_floor` / `patience`). A practice flips enforcement on by setting an `artifact_graph` block in its (gitignored, per-instance) `.empirica/project.yaml`:

```yaml
artifact_graph:
  strictness: 0.75
  connectivity_floor: 0.34
```

## Precedence

`env var (session override)` > `project.yaml artifact_graph block` > `single-source default`.

- `_read_project_gate_scalars()` reads the block via `R.project_path()`, returns `{}` on any error — **never raises** (a bad block must not break the POSTFLIGHT retrospective).
- `_resolve_gate_scalars()` consults it between env and default.

## Why this shape

Because `project.yaml` is per-instance and gitignored, this is a **local per-practice knob**: one practice enforcing (strictness ≥ 0.70) does not touch the others — peers with no block keep the report-only default (0.25). This is the "project.yaml home" the gated-artifact-graph map (#247, #253, #264) called for — the last piece that lets a practice self-select into enforcement without a fleet-wide flag.

## Tests

`tests/test_gate_scalars_project_source.py` (5):
- defaults when no block present (peers stay report-only)
- project.yaml flips enforcement + unset key falls back to default
- env var wins over project.yaml
- malformed block value falls back to default
- non-dict block ignored

24/24 green across `test_gate_scalars_project_source` + `test_weave_gate_block` + `test_check_weave_enforce`. pyright 0/0/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)