### PR TITLE
fix(postflight): weave connectivity is degree-based, not out-degree only

### DIFF
--- a/empirica/cli/command_handlers/_workflow_shared.py
+++ b/empirica/cli/command_handlers/_workflow_shared.py
@@ -528,13 +528,23 @@ def _retro_count_sources(cursor, session_id: str, transaction_id: str | None) ->
 
 def _retro_count_edges(cursor, session_id: str, transaction_id: str | None) -> int:
     """Count artifacts in this transaction that have ≥1 edge in the canonical
-    ``artifact_edges`` table (migration 041) — i.e. appear as an edge's ``from_id``.
+    ``artifact_edges`` table (migration 041) — i.e. participate as EITHER endpoint
+    (``from_id`` OR ``to_id``) of at least one edge.
 
     Reads ``artifact_edges``, the source BOTH ``log-artifacts`` and the POSTFLIGHT
     auto-edge writer persist to — NOT the legacy inline ``<type>_data.edges`` JSON,
     which neither actually writes, so it chronically reported a false ``0`` even
     when edges existed. Best-effort: a pre-041 DB with no ``artifact_edges``
     degrades to 0 (each table query raises and is skipped).
+
+    Connectivity is DEGREE-based (any incident edge), not out-degree only. An
+    earlier form counted ``from_id`` alone, which under-counted the idiomatic
+    hub/star weave — one decision ``grounded_by`` N findings makes only the
+    decision a ``from_id``; the N findings are ``to_id``-only and were wrongly
+    read as unconnected. That over-blocked well-woven transactions at enforce
+    strictness and made the count depend on which way the human happened to
+    orient an edge. A finding woven INTO a decision's reasoning is connected
+    regardless of arrow direction.
     """
     by_table = (
         "project_findings",
@@ -550,7 +560,8 @@ def _retro_count_edges(cursor, session_id: str, transaction_id: str | None) -> i
             sql = (
                 f"SELECT COUNT(*) FROM {table} t "
                 "WHERE t.session_id = ? "
-                "AND EXISTS (SELECT 1 FROM artifact_edges e WHERE e.from_id = t.id)"
+                "AND EXISTS (SELECT 1 FROM artifact_edges e "
+                "WHERE e.from_id = t.id OR e.to_id = t.id)"
             )
             params: tuple = (session_id,)
             if transaction_id:

--- a/tests/test_retro_count_edges_canonical.py
+++ b/tests/test_retro_count_edges_canonical.py
@@ -3,7 +3,9 @@
 Regression guard for the chronic false "0 edges": the counter used to read the
 inline `<type>_data.edges` JSON (which neither log-artifacts nor the auto-edge
 writer populate), so real edges in the canonical `artifact_edges` table (mig 041)
-were invisible. It now counts artifacts that appear as an edge `from_id`.
+were invisible. It now counts artifacts that participate as EITHER endpoint
+(`from_id` OR `to_id`) — degree-based connectivity, so hub/star weaves aren't
+under-counted.
 """
 
 from __future__ import annotations
@@ -45,3 +47,25 @@ def test_pre_041_db_without_artifact_edges_is_zero_not_error():
     conn = _db(with_edges_table=False)
     conn.execute("INSERT INTO project_findings VALUES ('a1', 's1', 'tx1')")
     assert _retro_count_edges(conn.cursor(), "s1", "tx1") == 0
+
+
+def test_counts_artifact_that_is_only_an_edge_target():
+    # Degree-based connectivity: a finding pointed AT by a decision
+    # (edge d1 -> f1, `grounded_by`) is to_id-only but still connected.
+    # Pre-fix this returned 0 (from_id-only count); the arrow direction
+    # must not decide whether the finding reads as woven.
+    conn = _db()
+    conn.execute("INSERT INTO project_findings VALUES ('f1', 's1', 'tx1')")  # only a to_id
+    conn.execute("INSERT INTO artifact_edges VALUES ('d1', 'f1', 'grounded_by')")
+    assert _retro_count_edges(conn.cursor(), "s1", "tx1") == 1
+
+
+def test_hub_weave_counts_all_findings_targeted_by_one_decision():
+    # The live over-block scenario: one decision `grounded_by` three findings.
+    # All three findings are to_id-only; degree-based connectivity counts all 3.
+    # Pre-fix: 0 (over-blocks the transaction at enforce strictness).
+    conn = _db()
+    for fid in ("f1", "f2", "f3"):
+        conn.execute("INSERT INTO project_findings VALUES (?, 's1', 'tx1')", (fid,))
+        conn.execute("INSERT INTO artifact_edges VALUES ('d1', ?, 'grounded_by')", (fid,))
+    assert _retro_count_edges(conn.cursor(), "s1", "tx1") == 3


### PR DESCRIPTION
## The bug (caught live by dogfooding enforce)

`_retro_count_edges` counted an artifact as *connected* only if it appeared as an edge's `from_id` (an **outgoing** edge). That under-counts the idiomatic **hub/star weave**: one decision `grounded_by` N findings writes edges `decision -> finding`, so only the decision is a `from_id` — the N findings are `to_id`-only and were wrongly read as **unconnected**.

Consequences at enforce strictness (≥ 0.70):
- **Over-blocks well-woven transactions** at the CHECK gate.
- Connectivity depended on **which way the human oriented an edge** — a `finding -> decision` (`evidence`) edge counted the finding; the reciprocal `decision -> finding` (`grounded_by`) edge did not.

A finding woven *into* a decision's reasoning is connected regardless of arrow direction.

## How it surfaced

Flipping the artifact-graph gate to **enforce** on empirica (strictness 0.75, floor 0.34 — #265) immediately caught this: a real transaction logging one decision `grounded_by` 3 findings reported **1/4 connected (25%)** and **blocked CHECK**, when true degree-based connectivity is **4/4**. This is exactly the class of defect flipping enforce ON was meant to expose — the mechanism found a bug in itself.

## Fix

Count artifacts participating as **EITHER endpoint** (`from_id` OR `to_id`) — standard degree-based connectivity.

```sql
-- before: AND EXISTS (SELECT 1 FROM artifact_edges e WHERE e.from_id = t.id)
-- after:  AND EXISTS (SELECT 1 FROM artifact_edges e WHERE e.from_id = t.id OR e.to_id = t.id)
```

Live-verified on the discovering transaction: **2/6 → 5/6 connected, satisfied True**.

## Tests

Two regressions in `test_retro_count_edges_canonical.py` (both returned 0 pre-fix):
- a `to_id`-only target counts as connected
- the 3-finding hub weave counts all 3

24/24 green across the counter + weave-gate + check-enforce suites. pyright 0/0/0.

## Note

Companion to #265 (the enforce flip). This is a correctness fix to the enforce mechanism's connectivity semantics — without it, enforce over-blocks common weave shapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)