### PR TITLE
feat(hooks): SessionStart leads with pending mesh inbox + arm-by-replacement

### DIFF
--- a/empirica/plugins/claude-code-integration/hooks/ewm-protocol-loader.py
+++ b/empirica/plugins/claude-code-integration/hooks/ewm-protocol-loader.py
@@ -331,6 +331,109 @@ def format_unknown_user_prompt(protocol: dict) -> str:
     return "\n".join(parts)
 
 
+def _resolve_ai_id_for_poll() -> str | None:
+    """This practice's ai_id from .empirica/project.yaml (git root or cwd).
+
+    Prefer the basename ``ai_id`` — the mailbox-poll CLI resolves it to the
+    canonical 3-form internally; fall back to ``canonical_seat``. Returns None
+    when there's no project.yaml or no id, so the caller skips the inbox lead.
+    """
+    if not HAS_YAML:
+        return None
+    import yaml
+
+    candidates = [Path.cwd() / ".empirica" / "project.yaml"]
+    try:
+        import subprocess
+
+        r = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if r.returncode == 0:
+            candidates.insert(0, Path(r.stdout.strip()) / ".empirica" / "project.yaml")
+    except Exception:
+        pass
+    for p in candidates:
+        try:
+            if not p.exists():
+                continue
+            data = yaml.safe_load(p.read_text(encoding="utf-8")) or {}
+            ai_id = data.get("ai_id") or data.get("canonical_seat")
+            if ai_id:
+                return str(ai_id)
+        except Exception:
+            continue
+    return None
+
+
+def _build_pending_inbox_lead() -> str:
+    """Render a 'handle these FIRST' lead block of pending mesh inbox messages.
+
+    The SessionStart greet-prime (the EWM block below) dominates injected wake
+    context so hard that models greet + cite the user's goals instead of
+    reacting to a pending mesh message — even when the wake CONTENT was inlined
+    (verified across GLM-5.2 / Kimi-K2.6 / MiniMax-M2.7). Leading with the inbox
+    — prepended BEFORE the EWM block — puts the pending messages first in the
+    session's context so they aren't buried under the greeting.
+
+    Best-effort: a bounded 6s poll (well inside the hook's 10s allowFailure
+    budget, shared with find_protocol's git call). Fails open to "" on missing
+    CLI / timeout / bad JSON / empty inbox / any error — never delays or breaks
+    SessionStart.
+    """
+    ai_id = _resolve_ai_id_for_poll()
+    if not ai_id:
+        return ""
+    try:
+        import subprocess
+
+        r = subprocess.run(
+            ["empirica", "mailbox", "poll", "--ai-id", ai_id, "--status", "accepted", "--output", "json"],
+            capture_output=True,
+            text=True,
+            timeout=6,
+            check=False,
+        )
+        if r.returncode != 0 or not r.stdout.strip():
+            return ""
+        proposals = (json.loads(r.stdout) or {}).get("proposals") or []
+    except Exception:
+        return ""
+    if not proposals:
+        return ""
+
+    total = len(proposals)
+    shown = proposals[:8]
+    lines = [f"## 📬 Pending mesh messages ({total}) — handle these FIRST", ""]
+    for p in shown:
+        pid = str(p.get("id") or "")[:26]
+        src = p.get("source_claude") or "?"
+        status = p.get("status") or "?"
+        ptype = p.get("type") or "?"
+        title = (p.get("title") or "").strip()
+        summary = " ".join((p.get("summary") or "").split())
+        if len(summary) > 300:
+            summary = summary[:300] + "…"
+        lines.append(f"- **[{pid}]** from `{src}` ({status}, {ptype}) — {title}")
+        if summary:
+            lines.append(f"  {summary}")
+    if total > len(shown):
+        lines.append("")
+        lines.append(
+            f"…and {total - len(shown)} more — run `empirica mailbox poll --status accepted` for the full list."
+        )
+    lines.append("")
+    lines.append(
+        "React per the mailbox protocol (`empirica mailbox show <id>`, "
+        "`empirica mailbox reply`) before orienting or asking what to work on."
+    )
+    lines.append("")
+    return "\n".join(lines)
+
+
 def main():
     try:
         json.loads(sys.stdin.read())
@@ -384,8 +487,15 @@ def main():
     # Identify user
     current_user = get_current_user()
 
-    # Build context injection
-    context_parts = ["## EWM Protocol Active", ""]
+    # Build context injection. LEAD with the pending mesh inbox (prop_pu4xrog):
+    # the greet-prime below otherwise dominates so hard the model never checks
+    # the inbox, so pending peer messages get ignored even when inlined. The
+    # inbox block is best-effort and prepends only when non-empty.
+    context_parts: list[str] = []
+    inbox_lead = _build_pending_inbox_lead()
+    if inbox_lead:
+        context_parts.append(inbox_lead)
+    context_parts.extend(["## EWM Protocol Active", ""])
     context_parts.append(f"*Protocol: `{protocol_path}`*")
 
     # Surface security warnings if any

--- a/empirica/plugins/claude-code-integration/hooks/session-monitor-arm.py
+++ b/empirica/plugins/claude-code-integration/hooks/session-monitor-arm.py
@@ -337,8 +337,17 @@ ntfy stream were compromised, your status re-verification against Cortex
 by `proposal_id` is the auth boundary.
 
 If you do not arm this Monitor, events will accumulate at Cortex but no
-work will trigger in this session. Arming is idempotent (Monitor with
-identical command is a no-op the second time).
+work will trigger in this session.
+
+**Arm exactly once per ai_id — replace, don't stack.** Before arming, if you
+already armed a loop_fires Monitor for `{instance_id}` earlier in THIS session,
+do NOT arm a second one: TaskStop the prior Monitor first (or skip arming
+entirely). Duplicate Monitors tailing the same log deliver every wake event
+N times — once per stacked tail. Harnesses that dedupe identical Monitor
+commands make a re-arm a no-op; those that don't (and every re-fired
+SessionStart) accumulate duplicates unless you reap first. `empirica listener
+off` TaskStops the recorded Monitor; re-arm, then `empirica listener arm
+<new_monitor_task_id>` to replace the record.
 {_build_orphan_warning()}"""
 
 

--- a/tests/test_ewm_inbox_lead.py
+++ b/tests/test_ewm_inbox_lead.py
@@ -1,0 +1,149 @@
+"""Tests for the EWM loader's SessionStart inbox-lead block (prop_pu4xrog).
+
+The SessionStart greet-prime dominates injected wakes, so pending mesh messages
+must be PREPENDED before the EWM Protocol block. ``_build_pending_inbox_lead``
+polls the mailbox (best-effort, bounded 6s) and renders a "handle these FIRST"
+block. It MUST fail open to "" on any error — a poll hiccup can never delay or
+break SessionStart.
+"""
+
+from __future__ import annotations
+
+import importlib.util as _ilu
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _load_hook():
+    hook_path = Path(__file__).resolve().parents[1] / (
+        "empirica/plugins/claude-code-integration/hooks/ewm-protocol-loader.py"
+    )
+    spec = _ilu.spec_from_file_location("ewm_protocol_loader_hook", hook_path)
+    assert spec and spec.loader, "could not load hook spec"
+    mod = _ilu.module_from_spec(spec)
+    sys.modules["ewm_protocol_loader_hook"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _fake_run(stdout: str = "", returncode: int = 0):
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr="")
+
+
+def _poll_json(proposals):
+    return json.dumps(
+        {"ok": True, "ai_id": "empirica", "count": len(proposals), "proposals": proposals}
+    )
+
+
+def _prop(i):
+    return {
+        "id": f"prop_{i:02d}",
+        "source_claude": "empirica.david.ecodex",
+        "status": "accepted",
+        "type": "collab_brief",
+        "title": f"Message {i}",
+        "summary": f"summary body {i}",
+    }
+
+
+def test_renders_pending_messages(monkeypatch):
+    mod = _load_hook()
+    monkeypatch.setattr(mod, "_resolve_ai_id_for_poll", lambda: "empirica")
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: _fake_run(_poll_json([_prop(1)])))
+    out = mod._build_pending_inbox_lead()
+    assert "Pending mesh messages (1)" in out
+    assert "handle these FIRST" in out
+    assert "prop_01" in out
+    assert "empirica.david.ecodex" in out
+    assert "Message 1" in out
+    assert "summary body 1" in out
+    # leads before nothing here, but must carry the react-protocol footer
+    assert "empirica mailbox reply" in out
+
+
+def test_caps_at_eight_with_overflow_pointer(monkeypatch):
+    mod = _load_hook()
+    monkeypatch.setattr(mod, "_resolve_ai_id_for_poll", lambda: "empirica")
+    proposals = [_prop(i) for i in range(1, 21)]  # 20 pending
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: _fake_run(_poll_json(proposals)))
+    out = mod._build_pending_inbox_lead()
+    assert "Pending mesh messages (20)" in out
+    assert "prop_08" in out  # 8th shown
+    assert "prop_09" not in out  # 9th elided
+    assert "and 12 more" in out
+
+
+def test_truncates_long_summaries(monkeypatch):
+    mod = _load_hook()
+    monkeypatch.setattr(mod, "_resolve_ai_id_for_poll", lambda: "empirica")
+    p = _prop(1)
+    p["summary"] = "x" * 500
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: _fake_run(_poll_json([p])))
+    out = mod._build_pending_inbox_lead()
+    assert "…" in out
+    assert "x" * 500 not in out  # not the full 500-char body
+
+
+def test_empty_inbox_returns_blank(monkeypatch):
+    mod = _load_hook()
+    monkeypatch.setattr(mod, "_resolve_ai_id_for_poll", lambda: "empirica")
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: _fake_run(_poll_json([])))
+    assert mod._build_pending_inbox_lead() == ""
+
+
+def test_cli_nonzero_returns_blank(monkeypatch):
+    mod = _load_hook()
+    monkeypatch.setattr(mod, "_resolve_ai_id_for_poll", lambda: "empirica")
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: _fake_run("boom", returncode=1))
+    assert mod._build_pending_inbox_lead() == ""
+
+
+def test_timeout_is_fail_open(monkeypatch):
+    mod = _load_hook()
+    monkeypatch.setattr(mod, "_resolve_ai_id_for_poll", lambda: "empirica")
+
+    def _boom(*a, **k):
+        raise subprocess.TimeoutExpired(cmd="empirica", timeout=6)
+
+    monkeypatch.setattr(subprocess, "run", _boom)
+    assert mod._build_pending_inbox_lead() == ""  # a slow poll never breaks SessionStart
+
+
+def test_missing_cli_is_fail_open(monkeypatch):
+    mod = _load_hook()
+    monkeypatch.setattr(mod, "_resolve_ai_id_for_poll", lambda: "empirica")
+
+    def _boom(*a, **k):
+        raise FileNotFoundError("empirica not on PATH")
+
+    monkeypatch.setattr(subprocess, "run", _boom)
+    assert mod._build_pending_inbox_lead() == ""
+
+
+def test_no_ai_id_skips_poll(monkeypatch):
+    mod = _load_hook()
+    monkeypatch.setattr(mod, "_resolve_ai_id_for_poll", lambda: None)
+
+    called = {"ran": False}
+
+    def _track(*a, **k):
+        called["ran"] = True
+        return _fake_run(_poll_json([_prop(1)]))
+
+    monkeypatch.setattr(subprocess, "run", _track)
+    assert mod._build_pending_inbox_lead() == ""
+    assert called["ran"] is False  # no ai_id → never even polls
+
+
+def test_resolve_ai_id_reads_project_yaml(monkeypatch, tmp_path):
+    mod = _load_hook()
+    empdir = tmp_path / ".empirica"
+    empdir.mkdir()
+    (empdir / "project.yaml").write_text("ai_id: empirica\ncanonical_seat: empirica.david.empirica\n")
+    monkeypatch.setattr(mod.Path, "cwd", staticmethod(lambda: tmp_path))
+    # Force the git-root probe to fail so it falls through to cwd.
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: _fake_run("", returncode=128))
+    assert mod._resolve_ai_id_for_poll() == "empirica"  # basename preferred

--- a/tests/test_ewm_inbox_lead.py
+++ b/tests/test_ewm_inbox_lead.py
@@ -33,9 +33,7 @@ def _fake_run(stdout: str = "", returncode: int = 0):
 
 
 def _poll_json(proposals):
-    return json.dumps(
-        {"ok": True, "ai_id": "empirica", "count": len(proposals), "proposals": proposals}
-    )
+    return json.dumps({"ok": True, "ai_id": "empirica", "count": len(proposals), "proposals": proposals})
 
 
 def _prop(i):


### PR DESCRIPTION
Two SessionStart wake-delivery fixes from the ecodex wake work (**prop_pu4xrog** + **prop_x3jlnivl #2**), verified across GLM-5.2 / Kimi-K2.6 / MiniMax-M2.7. This is PR A of the mesh-delivery @core leg.

## 1. `ewm-protocol-loader.py` — LEAD with the inbox (prop_pu4xrog, David-directed)

Root cause of the wake→act failure is **one layer up from the wake mechanism**: the EWM loader injects the "greet / here are your goals" context and never checks the mesh inbox. It dominates so hard that models greet + cite the user's goals instead of reacting to a pending mesh message — **even when the wake CONTENT was inlined** into the wake item (ecodex measured this directly). Content-injection is necessary but not sufficient while the greet-prime leads.

**Fix:** `_build_pending_inbox_lead()` polls `empirica mailbox poll --status accepted` (bounded **6s**, well inside the hook's 10s `allowFailure` budget shared with `find_protocol`'s git call) and **PREPENDS** a `📬 Pending mesh messages (N) — handle these FIRST` block (cap 8 + overflow pointer, ~300-char summaries, react-protocol footer) **BEFORE** the `## EWM Protocol Active` block.

- Fails open to `""` on missing CLI / timeout / bad JSON / empty inbox / any error — never delays or breaks SessionStart.
- `ai_id` resolved from `.empirica/project.yaml` (basename, which the poll CLI resolves to canonical).

## 2. `session-monitor-arm.py` — arm-by-replacement (prop_x3jlnivl #2)

The hook only emits arm *instructions*; its old "arming is idempotent" claim rode on **harness dedup**, which non-CC harnesses lack — so re-fired SessionStarts stacked duplicate `loop_fires` monitors and delivered every wake **N times**. Replaced with explicit *"arm exactly once per ai_id — reap the prior monitor before arming"* guidance, making the AI the dedup point regardless of harness behavior.

## Verification

- **Live end-to-end**: ran the loader hook against a real 20-item inbox → renders the lead block (8 shown + "and 12 more") ahead of the EWM block. ✓
- `tests/test_ewm_inbox_lead.py` (9): render / cap-8 / overflow / truncate + fail-open on empty / CLI-nonzero / timeout / missing-CLI / no-ai_id + project.yaml ai_id resolution.
- 33/33 green (incl. existing `test_session_monitor_arm_hook.py`). pyright 0/0/0, ruff clean.

## Mesh context

Acks ecodex prop_pu4xrog + prop_x3jlnivl #2 + the aligned prop_ti5i3qnm ("treat them as one"). PR B (canonical_loops opt-in + catch-up-timeout) follows, sequenced after catch-up robustness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)