### PR TITLE
fix(edges): resolve inline --related-to/--edge endpoints (prefix + existence)

### DIFF
--- a/empirica/cli/command_handlers/artifact_log_commands.py
+++ b/empirica/cli/command_handlers/artifact_log_commands.py
@@ -172,16 +172,75 @@ def _collect_edges_from_args(args, evidence_relation: str | None = None) -> list
     return edges
 
 
+def _resolve_edge_target(db, to_id: str) -> tuple[str | None, str | None]:
+    """Resolve an edge ``to`` endpoint to a full artifact id, or explain why not.
+
+    Returns ``(resolved_id, None)`` on success; ``(None, reason)`` when the
+    endpoint matches no existing artifact (dangling) or a prefix is ambiguous.
+
+    - **Exact** id match against any artifact table (or ``goals``) → use as-is.
+    - Otherwise, if ``to_id`` is a hex-ish prefix (≥6 chars), **unique-prefix
+      resolve** to the full id — prefixes are the natural paste form, so a short
+      id becomes usable rather than a literal dangling row. Ambiguous (>1 match)
+      → refuse rather than guess.
+
+    This closes the inline ``--related-to`` / ``--edge`` path's endpoint gap: it
+    used to store the raw ``to`` (a prefix or a non-existent UUID) verbatim, the
+    same silent-success class #268 fixed on the graph-batch path. Best-effort:
+    a query error on one table is skipped.
+    """
+    if not db.conn or not to_id:
+        return None, "empty endpoint"
+    cursor = db.conn.cursor()
+    lookups = [(t[1], t[2]) for t in _ARTIFACT_EDGE_TARGETS.values()]  # (table, id_col)
+    lookups.append(("goals", "id"))
+
+    # 1. Exact match — the common case (AIs paste full UUIDs).
+    for table, id_col in lookups:
+        try:
+            cursor.execute(f"SELECT 1 FROM {table} WHERE {id_col} = ? LIMIT 1", (to_id,))
+            if cursor.fetchone():
+                return to_id, None
+        except Exception:
+            continue
+
+    # 2. Unique-prefix resolution — only for hex-ish ids, so junk can't match.
+    import re as _re
+
+    if len(to_id) >= 6 and _re.fullmatch(r"[0-9a-fA-F-]{6,}", to_id):
+        matches: list[str] = []
+        for table, id_col in lookups:
+            try:
+                cursor.execute(f"SELECT {id_col} FROM {table} WHERE {id_col} LIKE ?", (to_id + "%",))
+                matches.extend(r[0] for r in cursor.fetchall())
+                if len(matches) > 1:
+                    break
+            except Exception:
+                continue
+        if len(matches) == 1:
+            return matches[0], None
+        if len(matches) > 1:
+            return None, f"ambiguous prefix '{to_id}' ({len(matches)}+ artifacts match)"
+
+    return None, f"no artifact matches '{to_id}'"
+
+
 def _persist_edges(artifact_type: str, artifact_id: str, edges: list[dict]) -> int:
     """Persist edges to SQLite data column AND patch git note JSON. Non-fatal.
 
     Returns count successfully wired. Order: SQLite first (graph_commands._store_edge),
     then git-note patch via read-modify-write. Idempotent — re-running with the same
     edges is a no-op since they're keyed by (artifact_id, to_id, relation) in JSON.
+
+    Each ``to`` endpoint is resolved via ``_resolve_edge_target`` first: a prefix
+    is resolved to its full UUID, and a dangling / ambiguous endpoint is SKIPPED
+    (logged, not counted, and not written to either SQLite or the git note) —
+    "accepted must mean applied-or-loudly-failed", the inline-flag twin of #268.
     """
     if not edges or artifact_type not in _ARTIFACT_EDGE_TARGETS:
         return 0
     wired = 0
+    wired_edges: list[dict] = []  # only successfully-resolved edges reach the git note
     # 1. SQLite
     try:
         from empirica.cli.command_handlers.graph_commands import _store_edge
@@ -190,9 +249,14 @@ def _persist_edges(artifact_type: str, artifact_id: str, edges: list[dict]) -> i
         db = SessionDatabase()
         try:
             for edge in edges:
+                resolved, reason = _resolve_edge_target(db, edge["to"])
+                if resolved is None:
+                    logger.warning(f"inline edge skipped {artifact_id}->{edge['to']} ({edge['relation']}): {reason}")
+                    continue
                 try:
-                    _store_edge(db, artifact_id, edge["to"], edge["relation"])
+                    _store_edge(db, artifact_id, resolved, edge["relation"])
                     wired += 1
+                    wired_edges.append({"to": resolved, "relation": edge["relation"]})
                 except Exception as e:
                     logger.warning(f"SQLite edge persist failed: {e}")
         finally:
@@ -200,11 +264,12 @@ def _persist_edges(artifact_type: str, artifact_id: str, edges: list[dict]) -> i
     except Exception as e:
         logger.warning(f"_persist_edges SQLite phase failed: {e}")
         return 0
-    # 2. Git note: read existing, merge edges into <type>_data, rewrite via `git notes add -f -m`.
-    try:
-        _patch_git_note_with_edges(artifact_type, artifact_id, edges)
-    except Exception as e:
-        logger.warning(f"_persist_edges git-note phase failed: {e}")
+    # 2. Git note: read existing, merge the WIRED edges into <type>_data, rewrite.
+    if wired_edges:
+        try:
+            _patch_git_note_with_edges(artifact_type, artifact_id, wired_edges)
+        except Exception as e:
+            logger.warning(f"_persist_edges git-note phase failed: {e}")
     return wired
 
 

--- a/tests/test_inline_edge_resolution.py
+++ b/tests/test_inline_edge_resolution.py
@@ -1,0 +1,84 @@
+"""Inline --related-to / --edge endpoint resolution (autonomy prop_nejysxsl).
+
+The inline edge path used to store the raw ``to`` verbatim — a short prefix
+(``--related-to 32933cda``) landed as a literal 8-char dangling row, and a
+non-existent UUID stored silently. ``_resolve_edge_target`` now:
+
+  - exact-matches a full id,
+  - unique-prefix-resolves a short hex id to its full UUID (the ergonomic win),
+  - refuses an ambiguous prefix or a no-match endpoint (→ skipped, not stored).
+
+This is the inline-flag twin of #268's graph-path endpoint validation.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from types import SimpleNamespace
+
+from empirica.cli.command_handlers import artifact_log_commands as alc
+
+_FULL = "1bfb481c-e70c-4948-b7db-4d30e64176a5"
+
+
+def _db() -> SimpleNamespace:
+    conn = sqlite3.connect(":memory:")
+    for t in ("project_findings", "project_unknowns", "project_dead_ends", "mistakes_made", "assumptions", "decisions"):
+        conn.execute(f"CREATE TABLE {t} (id TEXT)")
+    conn.execute("CREATE TABLE goals (id TEXT)")
+    conn.execute("INSERT INTO project_findings (id) VALUES (?)", (_FULL,))
+    conn.execute("INSERT INTO decisions (id) VALUES ('dddddddd-1111-2222-3333-444444444444')")
+    return SimpleNamespace(conn=conn)
+
+
+def test_exact_match_returns_id_unchanged():
+    resolved, reason = alc._resolve_edge_target(_db(), _FULL)
+    assert resolved == _FULL
+    assert reason is None
+
+
+def test_exact_match_across_tables():
+    resolved, _ = alc._resolve_edge_target(_db(), "dddddddd-1111-2222-3333-444444444444")
+    assert resolved == "dddddddd-1111-2222-3333-444444444444"  # decisions table too
+
+
+def test_unique_prefix_resolves_to_full_uuid():
+    # autonomy's exact case: an 8-char prefix of a real artifact.
+    resolved, reason = alc._resolve_edge_target(_db(), "1bfb481c")
+    assert resolved == _FULL  # not the literal prefix
+    assert reason is None
+
+
+def test_ambiguous_prefix_refuses():
+    db = _db()
+    # A second finding sharing the "1bfb481c" prefix makes it ambiguous.
+    db.conn.execute("INSERT INTO project_unknowns (id) VALUES ('1bfb481c-ffff-ffff-ffff-ffffffffffff')")
+    resolved, reason = alc._resolve_edge_target(db, "1bfb481c")
+    assert resolved is None
+    assert reason is not None and "ambiguous" in reason
+
+
+def test_no_match_dangling_uuid_refused():
+    resolved, reason = alc._resolve_edge_target(_db(), "cafebabe-9999-9999-9999-999999999999")
+    assert resolved is None
+    assert reason is not None and "no artifact matches" in reason
+
+
+def test_non_hex_junk_refused():
+    resolved, reason = alc._resolve_edge_target(_db(), "not-an-id")
+    assert resolved is None
+    assert reason is not None
+
+
+def test_empty_endpoint_refused():
+    resolved, reason = alc._resolve_edge_target(_db(), "")
+    assert resolved is None
+    assert reason is not None
+
+
+def test_short_prefix_below_threshold_not_prefix_resolved():
+    # Guard: a <6-char string never prefix-resolves (too broad); it must be
+    # an exact match or nothing.
+    resolved, reason = alc._resolve_edge_target(_db(), "1bfb")
+    assert resolved is None
+    assert reason is not None


### PR DESCRIPTION
The inline edge path (`--related-to` / `--edge` on the `*-log` verbs) is **separate** from the graph-batch path #268 hardened: `_persist_edges` called `_store_edge` directly with the raw `to`, so a short prefix (`--related-to 32933cda`) landed as a **literal 8-char dangling row**, and a non-existent UUID stored silently, counted as `edges_wired`. Autonomy caught this (**prop_nejysxsl**) while verifying #268 — the inline twin of the same silent-success class.

## Fix

`_resolve_edge_target` resolves each `to` endpoint before storing:
- **exact** id match (the common AI-pastes-full-UUID case) → use as-is;
- else **unique-prefix resolve** a hex-ish id (≥6 chars) to its full UUID — prefixes are the natural paste form, so the short id becomes *usable* instead of a dangling literal;
- **ambiguous** prefix or **no-match** → skipped (logged, not counted, kept out of **both** the SQLite edge table and the git-note JSON).

The `related` default relation is **deliberately untouched** — it's an established default across `checkpoint_parsers` / `project_update` and the commit-context walker (`commit_context_commands.py:345`) expects it. The inline-vs-graph `VALID_RELATIONS` mismatch is a separate, broader schema question, out of scope here.

## Verification

Live-verified against the real DB:
```
--related-to 1bfb481c (8-char prefix)  → edges_wired=1, stored to_id = 1bfb481c-e70c-4948-b7db-4d30e64176a5 (full 36-char UUID)
--related-to cafebabe-9999-…(fake)     → edges_wired=0 + "inline edge skipped … no artifact matches" (stderr), clean JSON on stdout
```
`tests/test_inline_edge_resolution.py` (8): exact / cross-table / unique-prefix / ambiguous-refuse / no-match / non-hex / empty / below-threshold. **17/17 green.** pyright 0/0/0, ruff check + format clean.

Completes the log-artifacts edge-integrity arc: #266 (connectivity count) → #268 (graph-path endpoints + repair) → this (inline-path endpoints).

🤖 Generated with [Claude Code](https://claude.com/claude-code)