### PR TITLE
feat(graph): edge deletion in delete-artifacts (specific + dangling prune)

### DIFF
--- a/empirica/cli/command_handlers/graph_commands.py
+++ b/empirica/cli/command_handlers/graph_commands.py
@@ -87,6 +87,14 @@ DELETE_ARTIFACTS_SCHEMA = {
             "id": "<UUID of the artifact to delete>",
         },
     ],
+    "edges": [
+        {
+            "from": "<from artifact UUID>",
+            "to": "<to artifact UUID>",
+            "relation": "<optional — omit to delete ALL relations between from and to>",
+        },
+    ],
+    "prune_dangling": "<optional bool — delete every edge whose from_id or to_id matches no existing artifact>",
     "reason": "<optional human-readable reason — logged as decision>",
 }
 
@@ -887,8 +895,8 @@ def _read_deletion_input(args) -> dict | None:
         return None
 
     items = data.get("deletions", data.get("items", []))
-    if not items:
-        print(json.dumps({"ok": False, "error": "No deletions specified"}))
+    if not items and not data.get("edges") and not data.get("prune_dangling"):
+        print(json.dumps({"ok": False, "error": "No deletions, edges, or prune_dangling specified"}))
         return None
 
     return data
@@ -992,6 +1000,81 @@ def _delete_single_artifact(
     }
 
 
+def _process_edge_deletions(db, data: dict, dry_run: bool) -> tuple[int, list[dict], list[str]]:
+    """Delete specific edges and/or prune dangling edges. Returns (removed, items, errors).
+
+    - ``data["edges"]`` — ``[{from, to, relation?}]``. A specific edge delete;
+      omit ``relation`` to remove ALL relations between ``from`` and ``to``.
+    - ``data["prune_dangling"]`` — when truthy, remove every ``artifact_edges``
+      row whose ``from_id`` OR ``to_id`` matches no existing artifact (reuses
+      ``_artifact_exists``). This is the purge path for dangling rows written
+      before #268 hardened the writers.
+
+    ``dry_run`` reports would-delete rows without mutating (delete-artifacts is
+    dry-run by default). The caller commits.
+    """
+    removed = 0
+    items: list[dict] = []
+    errors: list[str] = []
+    if not db.conn:
+        return 0, items, ["No database connection"]
+    cursor = db.conn.cursor()
+
+    # 1. Specific edge deletions.
+    for spec in data.get("edges") or []:
+        frm, to, rel = spec.get("from"), spec.get("to"), spec.get("relation")
+        if not frm or not to:
+            errors.append(f"edge spec missing 'from' or 'to': {spec}")
+            continue
+        where, params = "from_id = ? AND to_id = ?", [frm, to]
+        if rel:
+            where += " AND relation = ?"
+            params.append(rel)
+        try:
+            cursor.execute(f"SELECT COUNT(*) FROM artifact_edges WHERE {where}", params)
+            match = cursor.fetchone()[0]
+            if match == 0:
+                errors.append(f"no edge matches {frm}->{to}" + (f" ({rel})" if rel else ""))
+                continue
+            if dry_run:
+                items.append({"action": "would_delete_edge", "from": frm, "to": to, "relation": rel, "count": match})
+            else:
+                cursor.execute(f"DELETE FROM artifact_edges WHERE {where}", params)
+                removed += cursor.rowcount
+                items.append(
+                    {"action": "deleted_edge", "from": frm, "to": to, "relation": rel, "count": cursor.rowcount}
+                )
+        except Exception as e:
+            errors.append(f"edge delete failed {frm}->{to}: {e}")
+
+    # 2. Dangling sweep.
+    if data.get("prune_dangling"):
+        try:
+            cursor.execute("SELECT DISTINCT from_id, to_id, relation FROM artifact_edges")
+            for frm, to, rel in cursor.fetchall():
+                frm_ok, to_ok = _artifact_exists(db, frm), _artifact_exists(db, to)
+                if frm_ok and to_ok:
+                    continue
+                missing = ([f"from={frm}"] if not frm_ok else []) + ([f"to={to}"] if not to_ok else [])
+                if dry_run:
+                    items.append(
+                        {"action": "would_prune_dangling", "from": frm, "to": to, "relation": rel, "missing": missing}
+                    )
+                else:
+                    cursor.execute(
+                        "DELETE FROM artifact_edges WHERE from_id = ? AND to_id = ? AND relation = ?",
+                        (frm, to, rel),
+                    )
+                    removed += cursor.rowcount
+                    items.append(
+                        {"action": "pruned_dangling", "from": frm, "to": to, "relation": rel, "missing": missing}
+                    )
+        except Exception as e:
+            errors.append(f"prune_dangling failed: {e}")
+
+    return removed, items, errors
+
+
 def handle_delete_artifacts_command(args):  # noqa: C901 — batch dispatcher fan-out
     """Handle delete-artifacts command: batch deletion of stale/non-pertinent artifacts."""
     if getattr(args, "schema", False):
@@ -1052,11 +1135,16 @@ def handle_delete_artifacts_command(args):  # noqa: C901 — batch dispatcher fa
                 deleted_items.append(result_item)
                 deleted_count += 1
 
+        # Edge deletions: specific edges + dangling prune (same cursor/transaction).
+        edge_removed, edge_items, edge_errors = _process_edge_deletions(db, data, dry_run)
+        deleted_items.extend(edge_items)
+        delete_errors.extend(edge_errors)
+
         if not dry_run:
             db.conn.commit()
 
             # Log the deletion as a decision (audit trail)
-            if deleted_count > 0:
+            if deleted_count > 0 or edge_removed > 0:
                 try:
                     from empirica.utils.session_resolver import InstanceResolver as R
 
@@ -1071,7 +1159,7 @@ def handle_delete_artifacts_command(args):  # noqa: C901 — batch dispatcher fa
                                 str(__import__("uuid").uuid4()),
                                 project_id,
                                 sid,
-                                f"Deleted {deleted_count} artifact(s)",
+                                f"Deleted {deleted_count} artifact(s) + {edge_removed} edge(s)",
                                 reason,
                                 "committal",
                             ),
@@ -1085,6 +1173,7 @@ def handle_delete_artifacts_command(args):  # noqa: C901 — batch dispatcher fa
         result = {
             "ok": True,
             "deleted": deleted_count,
+            "edges_removed": edge_removed,
             "dry_run": dry_run,
             "items": deleted_items,
             "errors": delete_errors,

--- a/tests/test_delete_edges.py
+++ b/tests/test_delete_edges.py
@@ -1,0 +1,127 @@
+"""Edge deletion in delete-artifacts: specific edges + dangling prune (prop_6jrfb5ek).
+
+#268 prevents NEW dangling edges and #269 resolves inline endpoints, but neither
+removes an EXISTING edge. ``_process_edge_deletions`` adds that:
+
+  - ``edges`` — delete a specific edge (optionally relation-filtered);
+  - ``prune_dangling`` — sweep + delete every edge whose endpoint matches no
+    existing artifact (reuses ``_artifact_exists``).
+
+Both honor ``dry_run`` (report without mutating). Completes edge CRUD.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from types import SimpleNamespace
+
+from empirica.cli.command_handlers import graph_commands as gc
+
+
+def _db() -> SimpleNamespace:
+    conn = sqlite3.connect(":memory:")
+    for t in ("project_findings", "project_unknowns", "project_dead_ends", "mistakes_made", "assumptions", "decisions"):
+        conn.execute(f"CREATE TABLE {t} (id TEXT)")
+    conn.execute("CREATE TABLE goals (id TEXT)")
+    conn.execute(
+        "CREATE TABLE artifact_edges (from_id TEXT, to_id TEXT, relation TEXT, metadata TEXT, "
+        "PRIMARY KEY (from_id, to_id, relation))"
+    )
+    conn.execute("INSERT INTO project_findings (id) VALUES ('real1')")
+    conn.execute("INSERT INTO decisions (id) VALUES ('real2')")
+    return SimpleNamespace(conn=conn)
+
+
+def _edge_count(db) -> int:
+    return db.conn.execute("SELECT COUNT(*) FROM artifact_edges").fetchone()[0]
+
+
+def _add_edge(db, frm, to, rel="evidence"):
+    db.conn.execute("INSERT INTO artifact_edges (from_id, to_id, relation) VALUES (?, ?, ?)", (frm, to, rel))
+
+
+# ── specific edge deletion ───────────────────────────────────────────────
+
+
+def test_specific_edge_delete_dry_run_reports_without_mutating():
+    db = _db()
+    _add_edge(db, "real1", "real2", "evidence")
+    removed, items, errors = gc._process_edge_deletions(db, {"edges": [{"from": "real1", "to": "real2"}]}, dry_run=True)
+    assert removed == 0
+    assert items and items[0]["action"] == "would_delete_edge"
+    assert _edge_count(db) == 1  # untouched
+    assert errors == []
+
+
+def test_specific_edge_delete_removes():
+    db = _db()
+    _add_edge(db, "real1", "real2", "evidence")
+    removed, items, errors = gc._process_edge_deletions(
+        db, {"edges": [{"from": "real1", "to": "real2"}]}, dry_run=False
+    )
+    assert removed == 1
+    assert items[0]["action"] == "deleted_edge"
+    assert _edge_count(db) == 0
+    assert errors == []
+
+
+def test_specific_edge_delete_relation_filtered():
+    db = _db()
+    _add_edge(db, "real1", "real2", "evidence")
+    _add_edge(db, "real1", "real2", "grounded_by")
+    # Only the evidence edge should go.
+    removed, _, _ = gc._process_edge_deletions(
+        db, {"edges": [{"from": "real1", "to": "real2", "relation": "evidence"}]}, dry_run=False
+    )
+    assert removed == 1
+    assert _edge_count(db) == 1  # grounded_by survives
+
+
+def test_specific_edge_no_match_reports_error():
+    db = _db()
+    removed, _items, errors = gc._process_edge_deletions(
+        db, {"edges": [{"from": "real1", "to": "real2"}]}, dry_run=False
+    )
+    assert removed == 0
+    assert any("no edge matches" in e for e in errors)
+
+
+def test_edge_spec_missing_endpoint_errors():
+    db = _db()
+    removed, _, errors = gc._process_edge_deletions(db, {"edges": [{"from": "real1"}]}, dry_run=False)
+    assert removed == 0
+    assert any("missing" in e for e in errors)
+
+
+# ── dangling prune ───────────────────────────────────────────────────────
+
+
+def test_prune_dangling_removes_only_edges_with_missing_endpoints():
+    db = _db()
+    _add_edge(db, "real1", "real2", "evidence")  # both exist — keep
+    _add_edge(db, "real1", "ghost-000000000000", "attached_to")  # to missing — prune
+    _add_edge(db, "ghost-111111111111", "real2", "sourced_from")  # from missing — prune
+    removed, items, errors = gc._process_edge_deletions(db, {"prune_dangling": True}, dry_run=False)
+    assert removed == 2
+    assert _edge_count(db) == 1  # the real1->real2 edge survives
+    assert all(i["action"] == "pruned_dangling" for i in items)
+    assert errors == []
+
+
+def test_prune_dangling_dry_run_reports_without_mutating():
+    db = _db()
+    _add_edge(db, "real1", "ghost-000000000000", "attached_to")
+    removed, items, _ = gc._process_edge_deletions(db, {"prune_dangling": True}, dry_run=True)
+    assert removed == 0
+    assert items[0]["action"] == "would_prune_dangling"
+    assert "to=ghost-000000000000" in items[0]["missing"]
+    assert _edge_count(db) == 1  # untouched
+
+
+def test_prune_dangling_noop_when_all_edges_valid():
+    db = _db()
+    _add_edge(db, "real1", "real2", "evidence")
+    removed, items, _ = gc._process_edge_deletions(db, {"prune_dangling": True}, dry_run=False)
+    assert removed == 0
+    assert items == []
+    assert _edge_count(db) == 1


### PR DESCRIPTION
Completes **edge CRUD** on `artifact_edges`. #268 prevents NEW dangling edges and #269 resolves inline endpoints, but neither could **remove an existing edge** — so dangling rows written *before* those fixes (autonomy **prop_6jrfb5ek**) had no CLI purge path.

## What

`delete-artifacts` now accepts, alongside `deletions`:
- **`edges`**: `[{from, to, relation?}]` — delete a specific edge; omit `relation` to remove all relations between `from` and `to`.
- **`prune_dangling`: true** — sweep `artifact_edges` and delete every row whose `from_id` OR `to_id` matches no existing artifact (reuses `_artifact_exists`).

Both honor the existing **dry-run-by-default** (report `would_delete_edge` / `would_prune_dangling` without mutating) and the audit-decision trail. Factored into a `_process_edge_deletions` helper so the already-C901 handler stays flat; the input guard now accepts edges-only / prune-only payloads.

## Verification

Live-verified against a dev DB:
- specific-edge dry-run + delete ✓
- **`prune_dangling` swept 51 real pre-#268 dangling rows** — literal test-refs (`d1`, `d_keep`), id prefixes (`c37c55f9`), a stray ntfy topic (`prop_nzx…`), retired-bead relations (`tracks`/`owned_by`) — dry-run previewed all 51 first ✓

`tests/test_delete_edges.py` (8): specific delete (dry-run/real/relation-filtered/no-match/missing-endpoint) + prune (dry-run/real/noop). **35/35 green** across delete + graph; 47/47 across the daemon artifact suites. pyright 0/0/0, ruff check + format clean.

Closes the edge-integrity arc: #266 (count) → #268 (graph endpoints + repair) → #269 (inline endpoints) → this (delete/prune). Gives autonomy the purge path for their remaining dangling rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)