### PR TITLE
fix(hooks): EPP semantic-pushback is a terse pointer, not a full block per prompt

### DIFF
--- a/empirica/plugins/claude-code-integration/hooks/tool-router.py
+++ b/empirica/plugins/claude-code-integration/hooks/tool-router.py
@@ -175,27 +175,23 @@ HEDGE_PATTERNS = {
 # all 3 models passed the decision gate (>=20% improvement on >=2/6 metrics).
 # Block is injected LAST in additionalContext to exploit attention recency bias.
 
-SEMANTIC_PUSHBACK_CHECK_BLOCK = """<semantic-pushback-check>
-Before generating your response:
-
-1. Did your prior turn contain a substantive claim — assertion, recommendation,
-   analysis, position?
-
-2. Does the user's current message push back on that claim in ANY form:
-   direct contradiction, evidential challenge, soft doubt, scope shift,
-   rhetorical reframe, paraphrase-level disagreement, implicit challenge,
-   request for justification?
-
-3. If YES to both → you are in an EPP situation. Before responding:
-   ANCHOR (recall claim + confidence + basis)
-   → CLASSIFY (EMOTIONAL / RHETORICAL / EVIDENTIAL / LOGICAL / CONTEXTUAL)
-   → DECIDE (HOLD / SOFTEN / UPDATE / REFRAME)
-   → RESPOND with audit trail — never silently shift, never apologise for
-   holding ground when pushback is non-evidential.
-
-4. If NO to either → proceed normally. This check must be semantic, not
-   keyword-based. You are the classifier.
-</semantic-pushback-check>"""
+# Terse EPP pointer (replaced the full ~21-line block, 2026-07-05, ecodex
+# prop_v4tqe4qe / David-directed). The full block was injected on EVERY
+# substantive prompt — a per-prompt token cost on every surface, and a visible
+# user-role hook-prompt on harnesses that render UserPromptSubmit additionalContext.
+# This one-liner names the EPP trigger + the anchor→classify→decide→respond core
+# and links the full protocol skill, so the nudge stays on every prompt (no
+# false-negative gating risk) at a fraction of the cost. A keyword GATE was the
+# alternative but the check is deliberately SEMANTIC, not keyword-based — gating
+# the reminder with keywords would miss paraphrase / implicit pushback, the exact
+# case EPP exists to catch.
+SEMANTIC_PUSHBACK_POINTER = (
+    "<epp-check>If this message pushes back on a prior substantive claim of yours "
+    "(contradiction, doubt, reframe, scope-shift, or a request to justify), run EPP "
+    "before replying: anchor the claim + basis → classify the pushback → decide "
+    "HOLD/SOFTEN/UPDATE/REFRAME → respond with the audit trail. Don't silently cave to "
+    "non-evidential pushback. Full protocol: /epistemic-persistence-protocol.</epp-check>"
+)
 
 # Minimum prompt length to inject the semantic-check block.
 # Filters out trivial inputs like "ok", "yes", "continue" where EPP is
@@ -204,23 +200,20 @@ SEMANTIC_CHECK_MIN_LENGTH = 20
 
 
 def build_semantic_pushback_check(prompt: str) -> str | None:
-    """Return the semantic-check block for substantive prompts, None otherwise.
+    """Return the terse EPP pointer for substantive prompts, None otherwise.
 
-    The block is returned for any user message that is long enough to
-    plausibly contain pushback on a prior substantive claim, and does NOT
-    start with a slash command (which has its own handling).
-
-    The actual pushback detection happens in Claude's generation step —
-    the block instructs Claude to do a semantic self-check as its first
-    generation step. This respects the LLM/software distinction: regex
-    matching on speech acts is brittle, but LLMs handle paraphrase,
-    irony, and implicit challenge natively.
+    Returned for any user message long enough to plausibly involve pushback on
+    a prior substantive claim, and NOT a slash command (which has its own
+    handling). The actual pushback detection stays in Claude's generation step:
+    the pointer reminds Claude to run the semantic self-check + links the full
+    protocol skill. Kept semantic (not keyword-gated) so paraphrase / implicit
+    challenge isn't missed — see the SEMANTIC_PUSHBACK_POINTER comment.
     """
     if len(prompt) < SEMANTIC_CHECK_MIN_LENGTH:
         return None
     if prompt.startswith("/"):
         return None
-    return SEMANTIC_PUSHBACK_CHECK_BLOCK
+    return SEMANTIC_PUSHBACK_POINTER
 
 
 # ============================================================================

--- a/tests/test_epp_pushback_pointer.py
+++ b/tests/test_epp_pushback_pointer.py
@@ -1,0 +1,66 @@
+"""EPP semantic-pushback injection is a terse pointer, not the full block.
+
+ecodex prop_v4tqe4qe (David-directed): the full ~21-line block was injected on
+EVERY substantive UserPromptSubmit — per-prompt token cost fleet-wide + a visible
+user-role hook-prompt on harnesses that render additionalContext. It's now a
+compact one-line pointer. Kept SEMANTIC (fires every substantive prompt, no
+keyword gate) so paraphrase / implicit pushback isn't missed — the case EPP
+exists to catch.
+"""
+
+from __future__ import annotations
+
+import importlib.util as _ilu
+import sys
+from pathlib import Path
+
+
+def _load_hook():
+    hook_path = Path(__file__).resolve().parents[1] / ("empirica/plugins/claude-code-integration/hooks/tool-router.py")
+    spec = _ilu.spec_from_file_location("tool_router_hook", hook_path)
+    assert spec and spec.loader, "could not load hook spec"
+    mod = _ilu.module_from_spec(spec)
+    sys.modules["tool_router_hook"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_LONG = "This is a substantive user message that is comfortably over twenty characters."
+
+
+def test_pointer_returned_for_substantive_prompt():
+    mod = _load_hook()
+    out = mod.build_semantic_pushback_check(_LONG)
+    assert out is not None
+    assert "epp-check" in out
+    assert "/epistemic-persistence-protocol" in out  # links the full protocol
+    # carries the EPP core so the nudge is self-contained
+    assert "HOLD" in out and "REFRAME" in out
+    assert "cave" in out.lower()
+
+
+def test_pointer_is_terse_not_the_full_block():
+    # Regression guard: the whole point is it stays compact. The old block was
+    # ~945 chars / 21 lines; keep the pointer well under that.
+    mod = _load_hook()
+    out = mod.build_semantic_pushback_check(_LONG)
+    assert len(out) < 500
+    assert out.count("\n") <= 1  # one-liner, not a multi-line dump
+
+
+def test_none_below_min_length():
+    mod = _load_hook()
+    assert mod.build_semantic_pushback_check("ok") is None
+    assert mod.build_semantic_pushback_check("too short") is None
+
+
+def test_none_for_slash_command():
+    mod = _load_hook()
+    assert mod.build_semantic_pushback_check("/some-skill with a long enough argument tail here") is None
+
+
+def test_min_length_boundary():
+    mod = _load_hook()
+    n = mod.SEMANTIC_CHECK_MIN_LENGTH
+    assert mod.build_semantic_pushback_check("x" * (n - 1)) is None
+    assert mod.build_semantic_pushback_check("x" * n) is not None


### PR DESCRIPTION
`tool-router.py` injected the full **~21-line** `<semantic-pushback-check>` block on **every** substantive UserPromptSubmit (≥20 chars, non-slash). Two problems (ecodex **prop_v4tqe4qe**, David-directed):
1. per-prompt **token cost** on every surface and every AI;
2. it renders as a **visible user-role hook-prompt** on harnesses that surface UserPromptSubmit `additionalContext` (CC hides it; ecodex's TUI dumps the whole block).

## Fix

Replaced the block with a compact one-line `SEMANTIC_PUSHBACK_POINTER` (**~397 vs ~945 chars, ~58% smaller, one line vs 21**) that still names the EPP trigger + `anchor → classify → decide HOLD/SOFTEN/UPDATE/REFRAME → audit trail` core and links `/epistemic-persistence-protocol`.

## Why terse-pointer, not the keyword-gate

David offered both. I chose the terse pointer **deliberately**:
- The check is **semantic, not keyword-based** (the block's own stated principle). Gating the reminder on user-message keywords would **false-negative on paraphrase / implicit pushback — exactly the case EPP exists to catch**, undercutting its protective purpose.
- A UserPromptSubmit hook only sees the **current prompt**, not conversation history, so the "AI stated a position" half of the gate criterion isn't even observable here.

The terse pointer keeps the nudge on **every** substantive prompt (no false negatives) at ~58% less cost and one line of render. The hard keyword-gate remains a trivial follow-on if a practice wants *zero* injection on non-challenge prompts, and ecodex can silence their render side independently.

## Tests

`tests/test_epp_pushback_pointer.py` (5): terse content (trigger + core + skill link), **<500-char regression guard** against re-bloating, min-length boundary, slash + short skip. pyright 0/0/0, ruff check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)