### PR TITLE
feat(graph): repair-before-prune — rewire recoverable dangling edges

### DIFF
--- a/empirica/cli/command_handlers/graph_commands.py
+++ b/empirica/cli/command_handlers/graph_commands.py
@@ -94,7 +94,8 @@ DELETE_ARTIFACTS_SCHEMA = {
             "relation": "<optional — omit to delete ALL relations between from and to>",
         },
     ],
-    "prune_dangling": "<optional bool — delete every edge whose from_id or to_id matches no existing artifact>",
+    "prune_dangling": "<optional bool — act on every edge whose from_id or to_id matches no existing artifact>",
+    "repair": "<optional bool (default true) — with prune_dangling, REWIRE a dangling endpoint that resolves to a real artifact (e.g. a short prefix) instead of deleting it; only truly-unrecoverable edges are pruned. false = pure prune (delete all dangling)>",
     "reason": "<optional human-readable reason — logged as decision>",
 }
 
@@ -1000,24 +1001,120 @@ def _delete_single_artifact(
     }
 
 
-def _process_edge_deletions(db, data: dict, dry_run: bool) -> tuple[int, list[dict], list[str]]:
-    """Delete specific edges and/or prune dangling edges. Returns (removed, items, errors).
+def _resolve_dangling_endpoints(db, frm, to, frm_ok, to_ok, resolver):
+    """Resolve a dangling edge's missing endpoints. Returns (new_frm, new_to, recoverable).
+
+    ``recoverable`` is True only when a resolver is available AND every missing
+    endpoint resolved to a real artifact id. An endpoint already present (``*_ok``)
+    is kept as-is.
+    """
+    new_frm, new_to, recoverable = frm, to, bool(resolver)
+    if resolver:
+        if not frm_ok:
+            r, _ = resolver(db, frm)
+            new_frm = r if r else frm
+            recoverable = recoverable and bool(r)
+        if not to_ok:
+            r, _ = resolver(db, to)
+            new_to = r if r else to
+            recoverable = recoverable and bool(r)
+    return new_frm, new_to, recoverable
+
+
+def _sweep_dangling_edges(db, cursor, repair: bool, dry_run: bool) -> tuple[int, int, list[dict], list[str]]:
+    """Repair-before-prune sweep of ``artifact_edges``. Returns (removed, repaired, items, errors).
+
+    Reuses the inline path's resolver (#269) via lazy import — both cross-module
+    imports are lazy, so there's no circular import at load, and it keeps ONE
+    prefix resolver rather than a second, drift-prone copy.
+    """
+    removed = repaired = 0
+    items: list[dict] = []
+    errors: list[str] = []
+    resolver = None
+    if repair:
+        try:
+            from empirica.cli.command_handlers.artifact_log_commands import _resolve_edge_target as resolver
+        except Exception:
+            resolver = None
+    try:
+        cursor.execute("SELECT DISTINCT from_id, to_id, relation FROM artifact_edges")
+        for frm, to, rel in cursor.fetchall():
+            frm_ok, to_ok = _artifact_exists(db, frm), _artifact_exists(db, to)
+            if frm_ok and to_ok:
+                continue
+            missing = ([f"from={frm}"] if not frm_ok else []) + ([f"to={to}"] if not to_ok else [])
+            new_frm, new_to, recoverable = _resolve_dangling_endpoints(db, frm, to, frm_ok, to_ok, resolver)
+
+            if recoverable and (new_frm != frm or new_to != to):
+                if dry_run:
+                    items.append(
+                        {
+                            "action": "would_repair_dangling",
+                            "from": frm,
+                            "to": to,
+                            "relation": rel,
+                            "rewire_to": {"from": new_frm, "to": new_to},
+                        }
+                    )
+                else:
+                    cursor.execute(
+                        "DELETE FROM artifact_edges WHERE from_id = ? AND to_id = ? AND relation = ?", (frm, to, rel)
+                    )
+                    cursor.execute(
+                        "INSERT OR IGNORE INTO artifact_edges (from_id, to_id, relation) VALUES (?, ?, ?)",
+                        (new_frm, new_to, rel),
+                    )
+                    repaired += 1
+                    items.append(
+                        {
+                            "action": "repaired_dangling",
+                            "from": frm,
+                            "to": to,
+                            "relation": rel,
+                            "rewired_to": {"from": new_frm, "to": new_to},
+                        }
+                    )
+                continue
+
+            if dry_run:
+                items.append(
+                    {"action": "would_prune_dangling", "from": frm, "to": to, "relation": rel, "missing": missing}
+                )
+            else:
+                cursor.execute(
+                    "DELETE FROM artifact_edges WHERE from_id = ? AND to_id = ? AND relation = ?", (frm, to, rel)
+                )
+                removed += cursor.rowcount
+                items.append({"action": "pruned_dangling", "from": frm, "to": to, "relation": rel, "missing": missing})
+    except Exception as e:
+        errors.append(f"prune_dangling failed: {e}")
+    return removed, repaired, items, errors
+
+
+def _process_edge_deletions(db, data: dict, dry_run: bool) -> tuple[int, int, list[dict], list[str]]:
+    """Delete specific edges and/or prune/repair dangling edges.
+
+    Returns ``(removed, repaired, items, errors)``.
 
     - ``data["edges"]`` — ``[{from, to, relation?}]``. A specific edge delete;
       omit ``relation`` to remove ALL relations between ``from`` and ``to``.
-    - ``data["prune_dangling"]`` — when truthy, remove every ``artifact_edges``
-      row whose ``from_id`` OR ``to_id`` matches no existing artifact (reuses
-      ``_artifact_exists``). This is the purge path for dangling rows written
-      before #268 hardened the writers.
+    - ``data["prune_dangling"]`` — when truthy, act on every ``artifact_edges``
+      row whose ``from_id`` OR ``to_id`` matches no existing artifact. Default is
+      REPAIR-BEFORE-PRUNE: a dangling endpoint that resolves to a real artifact
+      (e.g. a short prefix) is REWIRED to the full id; only the truly
+      unrecoverable is deleted. Pass ``data["repair"] = false`` to force pure
+      prune (delete every dangling row — the raw #270 behavior).
 
-    ``dry_run`` reports would-delete rows without mutating (delete-artifacts is
+    ``dry_run`` reports would-* rows without mutating (delete-artifacts is
     dry-run by default). The caller commits.
     """
     removed = 0
+    repaired = 0
     items: list[dict] = []
     errors: list[str] = []
     if not db.conn:
-        return 0, items, ["No database connection"]
+        return 0, 0, items, ["No database connection"]
     cursor = db.conn.cursor()
 
     # 1. Specific edge deletions.
@@ -1047,32 +1144,15 @@ def _process_edge_deletions(db, data: dict, dry_run: bool) -> tuple[int, list[di
         except Exception as e:
             errors.append(f"edge delete failed {frm}->{to}: {e}")
 
-    # 2. Dangling sweep.
+    # 2. Dangling sweep — repair-before-prune (safe default).
     if data.get("prune_dangling"):
-        try:
-            cursor.execute("SELECT DISTINCT from_id, to_id, relation FROM artifact_edges")
-            for frm, to, rel in cursor.fetchall():
-                frm_ok, to_ok = _artifact_exists(db, frm), _artifact_exists(db, to)
-                if frm_ok and to_ok:
-                    continue
-                missing = ([f"from={frm}"] if not frm_ok else []) + ([f"to={to}"] if not to_ok else [])
-                if dry_run:
-                    items.append(
-                        {"action": "would_prune_dangling", "from": frm, "to": to, "relation": rel, "missing": missing}
-                    )
-                else:
-                    cursor.execute(
-                        "DELETE FROM artifact_edges WHERE from_id = ? AND to_id = ? AND relation = ?",
-                        (frm, to, rel),
-                    )
-                    removed += cursor.rowcount
-                    items.append(
-                        {"action": "pruned_dangling", "from": frm, "to": to, "relation": rel, "missing": missing}
-                    )
-        except Exception as e:
-            errors.append(f"prune_dangling failed: {e}")
+        d_removed, d_repaired, d_items, d_errors = _sweep_dangling_edges(db, cursor, data.get("repair", True), dry_run)
+        removed += d_removed
+        repaired += d_repaired
+        items.extend(d_items)
+        errors.extend(d_errors)
 
-    return removed, items, errors
+    return removed, repaired, items, errors
 
 
 def handle_delete_artifacts_command(args):  # noqa: C901 — batch dispatcher fan-out
@@ -1135,8 +1215,8 @@ def handle_delete_artifacts_command(args):  # noqa: C901 — batch dispatcher fa
                 deleted_items.append(result_item)
                 deleted_count += 1
 
-        # Edge deletions: specific edges + dangling prune (same cursor/transaction).
-        edge_removed, edge_items, edge_errors = _process_edge_deletions(db, data, dry_run)
+        # Edge deletions: specific edges + dangling repair/prune (same cursor/transaction).
+        edge_removed, edge_repaired, edge_items, edge_errors = _process_edge_deletions(db, data, dry_run)
         deleted_items.extend(edge_items)
         delete_errors.extend(edge_errors)
 
@@ -1144,7 +1224,7 @@ def handle_delete_artifacts_command(args):  # noqa: C901 — batch dispatcher fa
             db.conn.commit()
 
             # Log the deletion as a decision (audit trail)
-            if deleted_count > 0 or edge_removed > 0:
+            if deleted_count > 0 or edge_removed > 0 or edge_repaired > 0:
                 try:
                     from empirica.utils.session_resolver import InstanceResolver as R
 
@@ -1159,7 +1239,7 @@ def handle_delete_artifacts_command(args):  # noqa: C901 — batch dispatcher fa
                                 str(__import__("uuid").uuid4()),
                                 project_id,
                                 sid,
-                                f"Deleted {deleted_count} artifact(s) + {edge_removed} edge(s)",
+                                f"Deleted {deleted_count} artifact(s) + {edge_removed} edge(s) + repaired {edge_repaired}",
                                 reason,
                                 "committal",
                             ),
@@ -1174,6 +1254,7 @@ def handle_delete_artifacts_command(args):  # noqa: C901 — batch dispatcher fa
             "ok": True,
             "deleted": deleted_count,
             "edges_removed": edge_removed,
+            "edges_repaired": edge_repaired,
             "dry_run": dry_run,
             "items": deleted_items,
             "errors": delete_errors,

--- a/tests/test_delete_edges.py
+++ b/tests/test_delete_edges.py
@@ -1,13 +1,12 @@
-"""Edge deletion in delete-artifacts: specific edges + dangling prune (prop_6jrfb5ek).
+"""Edge deletion in delete-artifacts: specific + dangling prune/repair (prop_6jrfb5ek).
 
-#268 prevents NEW dangling edges and #269 resolves inline endpoints, but neither
-removes an EXISTING edge. ``_process_edge_deletions`` adds that:
+#268 prevents NEW dangling edges and #269 resolves inline endpoints; #270 added
+delete + prune. This adds REPAIR-BEFORE-PRUNE (autonomy prop_ovf7iday): a dangling
+endpoint that resolves to a real artifact (e.g. a short prefix) is rewired to the
+full id rather than deleted — only the truly-unrecoverable is pruned. Safe by
+default; ``repair: false`` forces pure prune.
 
-  - ``edges`` — delete a specific edge (optionally relation-filtered);
-  - ``prune_dangling`` — sweep + delete every edge whose endpoint matches no
-    existing artifact (reuses ``_artifact_exists``).
-
-Both honor ``dry_run`` (report without mutating). Completes edge CRUD.
+``_process_edge_deletions`` returns ``(removed, repaired, items, errors)``.
 """
 
 from __future__ import annotations
@@ -16,6 +15,8 @@ import sqlite3
 from types import SimpleNamespace
 
 from empirica.cli.command_handlers import graph_commands as gc
+
+_FULL = "abcdef12-3456-7890-abcd-ef1234567890"  # a real artifact with a hex id
 
 
 def _db() -> SimpleNamespace:
@@ -36,6 +37,10 @@ def _edge_count(db) -> int:
     return db.conn.execute("SELECT COUNT(*) FROM artifact_edges").fetchone()[0]
 
 
+def _edges(db):
+    return [tuple(r) for r in db.conn.execute("SELECT from_id, to_id FROM artifact_edges").fetchall()]
+
+
 def _add_edge(db, frm, to, rel="evidence"):
     db.conn.execute("INSERT INTO artifact_edges (from_id, to_id, relation) VALUES (?, ?, ?)", (frm, to, rel))
 
@@ -46,8 +51,10 @@ def _add_edge(db, frm, to, rel="evidence"):
 def test_specific_edge_delete_dry_run_reports_without_mutating():
     db = _db()
     _add_edge(db, "real1", "real2", "evidence")
-    removed, items, errors = gc._process_edge_deletions(db, {"edges": [{"from": "real1", "to": "real2"}]}, dry_run=True)
-    assert removed == 0
+    removed, repaired, items, errors = gc._process_edge_deletions(
+        db, {"edges": [{"from": "real1", "to": "real2"}]}, dry_run=True
+    )
+    assert removed == 0 and repaired == 0
     assert items and items[0]["action"] == "would_delete_edge"
     assert _edge_count(db) == 1  # untouched
     assert errors == []
@@ -56,7 +63,7 @@ def test_specific_edge_delete_dry_run_reports_without_mutating():
 def test_specific_edge_delete_removes():
     db = _db()
     _add_edge(db, "real1", "real2", "evidence")
-    removed, items, errors = gc._process_edge_deletions(
+    removed, _repaired, items, errors = gc._process_edge_deletions(
         db, {"edges": [{"from": "real1", "to": "real2"}]}, dry_run=False
     )
     assert removed == 1
@@ -69,8 +76,7 @@ def test_specific_edge_delete_relation_filtered():
     db = _db()
     _add_edge(db, "real1", "real2", "evidence")
     _add_edge(db, "real1", "real2", "grounded_by")
-    # Only the evidence edge should go.
-    removed, _, _ = gc._process_edge_deletions(
+    removed, _repaired, _items, _errors = gc._process_edge_deletions(
         db, {"edges": [{"from": "real1", "to": "real2", "relation": "evidence"}]}, dry_run=False
     )
     assert removed == 1
@@ -79,7 +85,7 @@ def test_specific_edge_delete_relation_filtered():
 
 def test_specific_edge_no_match_reports_error():
     db = _db()
-    removed, _items, errors = gc._process_edge_deletions(
+    removed, _repaired, _items, errors = gc._process_edge_deletions(
         db, {"edges": [{"from": "real1", "to": "real2"}]}, dry_run=False
     )
     assert removed == 0
@@ -88,21 +94,21 @@ def test_specific_edge_no_match_reports_error():
 
 def test_edge_spec_missing_endpoint_errors():
     db = _db()
-    removed, _, errors = gc._process_edge_deletions(db, {"edges": [{"from": "real1"}]}, dry_run=False)
+    removed, _repaired, _items, errors = gc._process_edge_deletions(db, {"edges": [{"from": "real1"}]}, dry_run=False)
     assert removed == 0
     assert any("missing" in e for e in errors)
 
 
-# ── dangling prune ───────────────────────────────────────────────────────
+# ── dangling prune (unrecoverable) ───────────────────────────────────────
 
 
-def test_prune_dangling_removes_only_edges_with_missing_endpoints():
+def test_prune_dangling_removes_unrecoverable_edges():
     db = _db()
     _add_edge(db, "real1", "real2", "evidence")  # both exist — keep
-    _add_edge(db, "real1", "ghost-000000000000", "attached_to")  # to missing — prune
-    _add_edge(db, "ghost-111111111111", "real2", "sourced_from")  # from missing — prune
-    removed, items, errors = gc._process_edge_deletions(db, {"prune_dangling": True}, dry_run=False)
-    assert removed == 2
+    _add_edge(db, "real1", "ghost-000000000000", "attached_to")  # non-hex-resolvable — prune
+    _add_edge(db, "ghost-111111111111", "real2", "sourced_from")  # non-resolvable — prune
+    removed, repaired, items, errors = gc._process_edge_deletions(db, {"prune_dangling": True}, dry_run=False)
+    assert removed == 2 and repaired == 0
     assert _edge_count(db) == 1  # the real1->real2 edge survives
     assert all(i["action"] == "pruned_dangling" for i in items)
     assert errors == []
@@ -111,8 +117,8 @@ def test_prune_dangling_removes_only_edges_with_missing_endpoints():
 def test_prune_dangling_dry_run_reports_without_mutating():
     db = _db()
     _add_edge(db, "real1", "ghost-000000000000", "attached_to")
-    removed, items, _ = gc._process_edge_deletions(db, {"prune_dangling": True}, dry_run=True)
-    assert removed == 0
+    removed, repaired, items, _errors = gc._process_edge_deletions(db, {"prune_dangling": True}, dry_run=True)
+    assert removed == 0 and repaired == 0
     assert items[0]["action"] == "would_prune_dangling"
     assert "to=ghost-000000000000" in items[0]["missing"]
     assert _edge_count(db) == 1  # untouched
@@ -121,7 +127,47 @@ def test_prune_dangling_dry_run_reports_without_mutating():
 def test_prune_dangling_noop_when_all_edges_valid():
     db = _db()
     _add_edge(db, "real1", "real2", "evidence")
-    removed, items, _ = gc._process_edge_deletions(db, {"prune_dangling": True}, dry_run=False)
-    assert removed == 0
+    removed, repaired, items, _errors = gc._process_edge_deletions(db, {"prune_dangling": True}, dry_run=False)
+    assert removed == 0 and repaired == 0
     assert items == []
     assert _edge_count(db) == 1
+
+
+# ── repair-before-prune (recoverable) ────────────────────────────────────
+
+
+def test_prune_repairs_resolvable_prefix():
+    db = _db()
+    db.conn.execute("INSERT INTO project_findings (id) VALUES (?)", (_FULL,))
+    _add_edge(db, "real1", "abcdef12", "evidence")  # `to` is an 8-char hex prefix of _FULL
+    removed, repaired, items, errors = gc._process_edge_deletions(db, {"prune_dangling": True}, dry_run=False)
+    assert repaired == 1
+    assert removed == 0  # rewired, not deleted
+    assert ("real1", _FULL) in _edges(db)  # corrected edge exists
+    assert ("real1", "abcdef12") not in _edges(db)  # dangling row gone
+    assert items[0]["action"] == "repaired_dangling"
+    assert items[0]["rewired_to"]["to"] == _FULL
+    assert errors == []
+
+
+def test_repair_false_forces_pure_prune():
+    db = _db()
+    db.conn.execute("INSERT INTO project_findings (id) VALUES (?)", (_FULL,))
+    _add_edge(db, "real1", "abcdef12", "evidence")  # recoverable, but repair disabled
+    removed, repaired, items, _errors = gc._process_edge_deletions(
+        db, {"prune_dangling": True, "repair": False}, dry_run=False
+    )
+    assert repaired == 0
+    assert removed == 1  # pure prune deletes it despite being recoverable
+    assert items[0]["action"] == "pruned_dangling"
+
+
+def test_prune_dry_run_reports_would_repair():
+    db = _db()
+    db.conn.execute("INSERT INTO project_findings (id) VALUES (?)", (_FULL,))
+    _add_edge(db, "real1", "abcdef12", "evidence")
+    removed, repaired, items, _errors = gc._process_edge_deletions(db, {"prune_dangling": True}, dry_run=True)
+    assert removed == 0 and repaired == 0
+    assert items[0]["action"] == "would_repair_dangling"
+    assert items[0]["rewire_to"]["to"] == _FULL
+    assert _edge_count(db) == 1  # untouched in dry-run


### PR DESCRIPTION
#270's `prune_dangling` deleted **every** dangling edge. But some are dangling only because an endpoint is a **resolvable prefix** — autonomy (**prop_ovf7iday**) found **9 of their 11** were recoverable. Blindly pruning silently loses real intent.

## What

`prune_dangling` is now **repair-before-prune, safe by default**: for each dangling edge, resolve each missing endpoint via the inline path's resolver (#269, **reused by lazy import** — no circular import, one resolver not two). If *every* missing endpoint resolves to a real artifact → **rewire** the edge to the full id (`repaired_dangling`); only the truly-unrecoverable is deleted (`pruned_dangling`). Pass `repair: false` to force pure prune (the raw #270 behavior). Response carries `edges_repaired` alongside `edges_removed`.

Factored the sweep into `_sweep_dangling_edges` + `_resolve_dangling_endpoints` to keep `_process_edge_deletions` under the C901 ceiling.

## Verification

Live-verified against a dev DB:
```
prune (repair default) → edges_repaired=1, edges_removed=0; the prefix edge 000938d9
                          rewired to 000938d9-7d87-4e82-b885-db2354c80bce (full UUID)
prune repair:false     → pruned it instead (edges_removed=1)
```
`tests/test_delete_edges.py` (11): specific delete, unrecoverable prune, **repair / repair:false / dry-run-would-repair**. 28/28 green across the edge suites. pyright 0/0/0, ruff check + format clean.

Completes the safety story of the edge-CRUD arc: #266 count → #268 guard+repair → #269 inline → #270 delete/prune → **this (prune no longer loses recoverable edges)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)