### PR TITLE
fix(listener): relay allowlisted non-proposal wake shapes from the push body (part A)

### DIFF
--- a/empirica/core/loop_scheduler/listener.py
+++ b/empirica/core/loop_scheduler/listener.py
@@ -246,6 +246,55 @@ def _is_real_event(ntfy_message: dict[str, Any]) -> bool:
     return ntfy_message.get("event") == "message"
 
 
+# Non-proposal wake shapes relayed directly from the push body. These have NO
+# proposal-store row, so the proposal-only catch-up (content_poll) can never
+# reconstruct them — the doorbell body is the only possible LIVE delivery.
+# Extensible allowlist: each shape added here also needs a durable store the
+# catch-up can reconcile from on a dropped doorbell (ser_escalation → /v1/sers).
+_NON_PROPOSAL_WAKE_SHAPES = frozenset({"ser_escalation"})
+
+
+def _relay_non_proposal_wake(msg: dict, instance_id: str, loop_name: str, canonical, output_stream, err_stream) -> bool:
+    """Relay an allowlisted non-proposal wake shape from the ntfy push body.
+
+    Returns True if a fires line was written. Recipient gating is already done by
+    the ntfy tag-filter subscription (``?tags=<canonical>``); we additionally
+    honor an explicit ``target_claudes`` in the body when present. The AI's
+    documented reaction protocol re-pulls the durable state (the SER projection)
+    before acting, so relaying the doorbell body is a wake TRIGGER, not authority
+    — the ECO-gated-autonomy property is preserved.
+    """
+    import datetime as _dt
+
+    try:
+        raw = msg.get("message")
+        body = json.loads(raw) if isinstance(raw, str) and raw.lstrip().startswith("{") else None
+    except (json.JSONDecodeError, TypeError):
+        body = None
+    if not isinstance(body, dict) or body.get("event") not in _NON_PROPOSAL_WAKE_SHAPES:
+        return False
+    targets = body.get("target_claudes")
+    if isinstance(targets, list) and canonical and canonical not in targets:
+        return False  # defense-in-depth: body names targets and we're not one
+    shape = body["event"]
+    line = json.dumps(
+        {
+            "ts": _dt.datetime.now(_dt.timezone.utc).isoformat(),
+            "instance_id": instance_id,
+            "loop": loop_name,
+            "event_type": shape,
+            **{k: v for k, v in body.items() if k != "event"},
+        }
+    )
+    try:
+        output_stream.write(line + "\n")
+        output_stream.flush()
+    except Exception:
+        return False
+    err_stream.write(f"listener: relayed non-proposal wake '{shape}' from push body\n")
+    return True
+
+
 def _listener_health_path(instance_id: str) -> Path:
     return Path.home() / ".empirica" / f"listener_health_{instance_id}.json"
 
@@ -737,6 +786,10 @@ def run_listener(  # noqa: C901 — held-connection loop; clarity beats decompos
                     err_stream.write(
                         f"listener: ntfy event arrived (id={msg.get('id', '?')[:12]}) → running catch-up\n"
                     )
+                    # Relay allowlisted non-proposal wake shapes (ser_escalation)
+                    # from the push body FIRST — they have no proposal-store row,
+                    # so the proposal-only catch-up below can't reconstruct them.
+                    _relay_non_proposal_wake(msg, instance_id, loop_name, tag_filter, output_stream, err_stream)
                     _emit_catchup_events(instance_id, loop_name, output_stream)
                     # Catch-up can take a few seconds; refresh activity stamp
                     # so the watchdog doesn't fire on a slow-but-healthy poll.

--- a/tests/test_listener_relay.py
+++ b/tests/test_listener_relay.py
@@ -1,0 +1,102 @@
+"""Listener relays allowlisted non-proposal wake shapes from the push body.
+
+autonomy prop_tr4dbwcf: ser_escalation (and any non-proposal wake) has no
+proposal-store row, so the proposal-only catch-up can never reconstruct it — it
+was structurally undeliverable, all-time-zero at every receiver. The listener now
+relays allowlisted shapes directly from the doorbell body BEFORE running catch-up.
+"""
+
+from __future__ import annotations
+
+import importlib.util as _ilu
+import io
+import json
+import sys
+from pathlib import Path
+
+
+def _load():
+    p = Path(__file__).resolve().parents[1] / "empirica/core/loop_scheduler/listener.py"
+    spec = _ilu.spec_from_file_location("listener_mod", p)
+    assert spec and spec.loader
+    mod = _ilu.module_from_spec(spec)
+    sys.modules["listener_mod"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_CANON = "empirica.david.empirica"
+
+
+def _msg(body: dict) -> dict:
+    return {"event": "message", "message": json.dumps(body)}
+
+
+def _relay(mod, msg, canonical=_CANON):
+    out, err = io.StringIO(), io.StringIO()
+    relayed = mod._relay_non_proposal_wake(msg, "empirica", "cortex-mailbox-poll", canonical, out, err)
+    return relayed, out.getvalue()
+
+
+def test_relays_ser_escalation_with_fields():
+    mod = _load()
+    relayed, out = _relay(
+        mod, _msg({"event": "ser_escalation", "ser_id": "ser_abc", "coordination_state": "in_progress"})
+    )
+    assert relayed is True
+    line = json.loads(out.strip())
+    assert line["event_type"] == "ser_escalation"
+    assert line["ser_id"] == "ser_abc"
+    assert line["coordination_state"] == "in_progress"
+    assert line["instance_id"] == "empirica"
+    assert "event" not in line  # collapsed into event_type
+
+
+def test_proposal_shaped_body_not_relayed():
+    # proposals are reconstructed by catch-up — the relay must NOT double-emit them.
+    mod = _load()
+    relayed, out = _relay(mod, _msg({"event": "proposal_event", "proposal_id": "p1"}))
+    assert relayed is False
+    assert out == ""
+
+
+def test_wrong_target_not_relayed():
+    mod = _load()
+    relayed, _ = _relay(
+        mod, _msg({"event": "ser_escalation", "ser_id": "x", "target_claudes": ["empirica.philipp.other"]})
+    )
+    assert relayed is False
+
+
+def test_matching_target_in_body_relayed():
+    mod = _load()
+    relayed, _ = _relay(mod, _msg({"event": "ser_escalation", "ser_id": "x", "target_claudes": [_CANON]}))
+    assert relayed is True
+
+
+def test_no_target_in_body_relayed_tag_filter_gated():
+    # No body target_claudes → rely on the ntfy tag-filter subscription (already
+    # recipient-gated). Relay.
+    mod = _load()
+    relayed, _ = _relay(mod, _msg({"event": "ser_escalation", "ser_id": "x"}))
+    assert relayed is True
+
+
+def test_non_json_body_is_safe_noop():
+    mod = _load()
+    relayed, out = _relay(mod, {"event": "message", "message": "keepalive-not-json"})
+    assert relayed is False
+    assert out == ""
+
+
+def test_missing_message_field_is_safe_noop():
+    mod = _load()
+    relayed, out = _relay(mod, {"event": "message"})
+    assert relayed is False
+    assert out == ""
+
+
+def test_unknown_event_shape_not_relayed():
+    mod = _load()
+    relayed, _ = _relay(mod, _msg({"event": "some_future_shape", "x": 1}))
+    assert relayed is False  # only allowlisted shapes relay


### PR DESCRIPTION
`ser_escalation` (and any non-proposal wake) has **no proposal-store row**, so the proposal-only catch-up (`content_poll` hardcodes `event_type='proposal_event'`) can never reconstruct it — and the listener parsed the ntfy arrival only for `_is_real_event()` then **discarded the body**, just running catch-up. Result: `ser_escalation` was **structurally undeliverable, all-time-zero** at every receiver since it shipped.

Diagnosed three-practice (autonomy **prop_tr4dbwcf**); I **verified it real, not stale** — git-dated both sites, confirmed the discard + the hardcoded `proposal_event`, and `rg ser_escalation` in the listener layer returns nothing.

## What (part A — the push doorbell)

The arrival loop now relays allowlisted non-proposal shapes (`_NON_PROPOSAL_WAKE_SHAPES = {ser_escalation}`) directly from the doorbell body to the fires log **before** catch-up:
- parse the body, match the allowlist;
- honor an explicit `target_claudes` when present (the ntfy `?tags=<canonical>` subscription already recipient-gates — this is defense-in-depth);
- pass the body fields through as `event_type=<shape>`.

The AI's reaction protocol re-pulls the durable SER projection before acting, so this is a wake **trigger, not authority** — the ECO-gated-autonomy property holds.

## Two-path scope (mesh-agreed)

This is **part A**. **Part B** — catch-up SER reconcile against `/v1/sers` so a *dropped* doorbell is still recoverable (mesh-support **prop_dzbmmlri**, autonomy authorial call **prop_mj3jmqmv**) — follows next. The `/cortex-mailbox-poll` skill's "ser_escalation LIVE" claim stays deferred until **both** land. mesh-support + autonomy will run the 3-receiver test SER on ship.

## Tests

`tests/test_listener_relay.py` (8): relay + field-collapse, proposal-not-double-emitted, target-gating (match/mismatch/absent), unknown-shape skip, non-JSON / missing-field safe no-op. pyright 0/0/0, ruff check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)