### PR TITLE
feat(sources): source-update — re-fetch + recompute content identity (lifecycle ACT half)

### DIFF
--- a/empirica/cli/cli_core.py
+++ b/empirica/cli/cli_core.py
@@ -392,6 +392,7 @@ _HELP_CATEGORIES = {
         "sources-reconcile",
         "sources-check",
         "source-archive",
+        "source-update",
         "act-log",
         "investigate-log",
         "log-artifacts",
@@ -900,6 +901,7 @@ def main(args=None):
             "sources-reconcile": handle_sources_reconcile_command,
             "sources-check": handle_sources_check_command,
             "source-archive": handle_source_archive_command,
+            "source-update": handle_source_update_command,
             "epp-activate": handle_epp_activate_command,
             # Training data export
             "training-export": handle_training_export_command,

--- a/empirica/cli/command_handlers/__init__.py
+++ b/empirica/cli/command_handlers/__init__.py
@@ -251,6 +251,7 @@ from .skill_commands import (
 )
 from .sources_check_commands import handle_sources_check_command
 from .sources_reconcile_commands import handle_sources_reconcile_command
+from .sources_update_commands import handle_source_update_command
 from .sync_commands import (
     handle_rebuild_command,
     handle_sync_config_command,
@@ -492,6 +493,7 @@ __all__ = [  # noqa: RUF022
     "handle_source_list_command",
     "handle_sources_map_command",
     "handle_sources_check_command",
+    "handle_source_update_command",
     "handle_sources_reconcile_command",
     # Sync commands (git notes synchronization)
     "handle_sync_config_command",

--- a/empirica/cli/command_handlers/sources_update_commands.py
+++ b/empirica/cli/command_handlers/sources_update_commands.py
@@ -1,0 +1,153 @@
+"""source-update — re-fetch a source, recompute its content identity, refresh it.
+
+The ACT half of David's source-lifecycle gap: ``sources-check`` DETECTS a stale /
+broken source; ``source-update`` RE-FETCHES it (local ``canonical_path`` first,
+else an http(s) ``source_url``), recomputes the content identity written by
+migration 050 (``content_hash`` / ``size_bytes`` / ``mime_type``), and appends an
+``updated`` event to ``lifecycle_audit_log`` (migration 044). A failed re-fetch
+updates NOTHING — an existing content_hash is never wiped by an unreachable
+source. Mirrors the source-archive handler's prefix-resolve + audit-append shape.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import mimetypes
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+from empirica.cli.cli_utils import handle_cli_error
+
+# Don't hash unbounded blobs — cap the re-fetch. A source over the cap keeps its
+# existing identity + reports the cap (rather than silently truncating a hash).
+_MAX_FETCH_BYTES = 25 * 1024 * 1024  # 25 MiB
+
+
+def _fetch_content(
+    source_url: str | None, canonical_path: str | None, timeout: float = 10.0
+) -> tuple[bytes | None, str | None]:
+    """Re-fetch a source's raw bytes. Returns ``(content, error)``.
+
+    Prefers a local ``canonical_path`` (fast, offline); falls back to an http(s)
+    ``source_url``. ``(None, reason)`` on any failure — the caller must NOT touch
+    the stored hash when the fetch fails.
+    """
+    for candidate in (canonical_path, source_url):
+        if candidate and not candidate.startswith(("http://", "https://")):
+            p = Path(candidate.replace("file://", ""))
+            try:
+                if p.is_file():
+                    data = p.read_bytes()
+                    if len(data) > _MAX_FETCH_BYTES:
+                        return None, f"file exceeds {_MAX_FETCH_BYTES}-byte cap"
+                    return data, None
+            except OSError as e:
+                return None, f"file read failed: {e}"
+    if source_url and source_url.startswith(("http://", "https://")):
+        try:
+            req = urllib.request.Request(source_url, method="GET", headers={"User-Agent": "empirica-source-update"})
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                data = resp.read(_MAX_FETCH_BYTES + 1)
+            if len(data) > _MAX_FETCH_BYTES:
+                return None, f"content exceeds {_MAX_FETCH_BYTES}-byte cap"
+            return data, None
+        except (urllib.error.URLError, urllib.error.HTTPError, OSError, TimeoutError, ValueError) as e:
+            return None, f"fetch failed: {e}"
+    return None, "no fetchable source_url or canonical_path"
+
+
+def _guess_mime(source_url: str | None, canonical_path: str | None) -> str | None:
+    for c in (canonical_path, source_url):
+        if c:
+            mt, _ = mimetypes.guess_type(c)
+            if mt:
+                return mt
+    return None
+
+
+def _content_hash(data: bytes) -> str:
+    """sha256-prefixed, matching migration 050's content_hash convention."""
+    return "sha256:" + hashlib.sha256(data).hexdigest()
+
+
+def handle_source_update_command(args):
+    """source-update --source-id <id> — re-fetch + recompute content identity + audit."""
+    db = None
+    try:
+        from empirica.data.session_database import SessionDatabase
+
+        source_id = args.source_id
+        output_format = getattr(args, "output", "human")
+
+        db = SessionDatabase()
+        cur = db.conn.cursor()
+        # Resolve full id from a prefix (matches source-archive / log-artifacts UX).
+        cur.execute(
+            "SELECT id, title, source_url, canonical_path, content_hash, lifecycle_audit_log "
+            "FROM epistemic_sources WHERE id = ? OR id LIKE ? LIMIT 2",
+            (source_id, f"{source_id}%"),
+        )
+        rows = cur.fetchall()
+        if not rows:
+            print(json.dumps({"ok": False, "error": f"Source not found: {source_id}"}))
+            return 1
+        if len(rows) > 1:
+            print(json.dumps({"ok": False, "error": f"Source ID '{source_id}' is ambiguous — use the full UUID."}))
+            return 1
+        full_id, title, source_url, canonical_path, old_hash, audit_json = rows[0]
+
+        content, err = _fetch_content(source_url, canonical_path)
+        if content is None:
+            # Never wipe an existing hash on a failed re-fetch.
+            print(json.dumps({"ok": False, "source_id": full_id, "error": err, "action": "unchanged_unreachable"}))
+            return 1
+
+        new_hash = _content_hash(content)
+        new_size = len(content)
+        mime = _guess_mime(source_url, canonical_path)
+        changed = new_hash != old_hash
+
+        audit = json.loads(audit_json) if audit_json else []
+        if not isinstance(audit, list):
+            audit = []
+        audit.append(
+            {
+                "event": "updated",
+                "at": time.time(),
+                "old_content_hash": old_hash,
+                "new_content_hash": new_hash,
+                "changed": changed,
+            }
+        )
+        cur.execute(
+            "UPDATE epistemic_sources SET content_hash = ?, size_bytes = ?, "
+            "mime_type = COALESCE(?, mime_type), lifecycle_audit_log = ? WHERE id = ?",
+            (new_hash, new_size, mime, json.dumps(audit), full_id),
+        )
+        db.conn.commit()
+
+        result = {
+            "ok": True,
+            "source_id": full_id,
+            "title": title,
+            "changed": changed,
+            "old_content_hash": old_hash,
+            "new_content_hash": new_hash,
+            "size_bytes": new_size,
+            "action": "updated" if changed else "refreshed_unchanged",
+        }
+        if output_format == "json":
+            print(json.dumps(result, indent=2))
+        else:
+            verb = "content CHANGED" if changed else "unchanged"
+            print(f"source-update: {full_id[:8]} '{title}' — {verb} ({new_hash[:19]}…, {new_size} bytes)")
+        return 0
+    except Exception as e:
+        handle_cli_error(e, "Source update", getattr(args, "verbose", False))
+        return 1
+    finally:
+        if db:
+            db.close()

--- a/empirica/cli/parsers/checkpoint_parsers.py
+++ b/empirica/cli/parsers/checkpoint_parsers.py
@@ -1423,6 +1423,22 @@ def add_checkpoint_parsers(subparsers):
     source_archive_parser.add_argument("--output", choices=["human", "json"], default="human", help="Output format")
     source_archive_parser.add_argument("--verbose", action="store_true", help="Verbose output")
 
+    # Source update (the ACT half of the lifecycle — re-fetch + recompute identity)
+    source_update_parser = subparsers.add_parser(
+        "source-update",
+        help=(
+            "Re-fetch a source and recompute its content identity "
+            "(content_hash / size / mime). The ACT half of the source "
+            "lifecycle: run it after sources-check flags a source stale or "
+            "broken. Prefers a local canonical_path, else the http(s) "
+            "source_url. A failed re-fetch updates nothing — an existing "
+            "content_hash is never wiped by an unreachable source."
+        ),
+    )
+    source_update_parser.add_argument("--source-id", required=True, help="Source UUID (or unique prefix) to re-fetch")
+    source_update_parser.add_argument("--output", choices=["human", "json"], default="human", help="Output format")
+    source_update_parser.add_argument("--verbose", action="store_true", help="Verbose output")
+
     # Sources reconcile (unified source identity — adopt catalogue uuids)
     sources_reconcile_parser = subparsers.add_parser(
         "sources-reconcile",

--- a/tests/test_source_update.py
+++ b/tests/test_source_update.py
@@ -1,0 +1,77 @@
+"""source-update — re-fetch + recompute content identity (source-lifecycle ACT half).
+
+The verb closes David's check->act gap: sources-check detects a stale/broken
+source, source-update re-fetches it (local canonical_path first, else http(s)
+source_url), recomputes content_hash/size/mime, and appends a lifecycle_audit_log
+event. A failed re-fetch must update NOTHING. These cover the fetch/hash helpers;
+the handler's DB path is covered by a live smoke in the PR.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+from empirica.cli.command_handlers.sources_update_commands import (
+    _content_hash,
+    _fetch_content,
+    _guess_mime,
+)
+
+
+def test_content_hash_is_sha256_prefixed_and_deterministic():
+    h = _content_hash(b"hello world")
+    assert h == "sha256:" + hashlib.sha256(b"hello world").hexdigest()
+    assert _content_hash(b"hello world") == h  # deterministic
+
+
+def test_fetch_reads_local_canonical_path(tmp_path):
+    f = tmp_path / "src.txt"
+    f.write_text("re-fetch me")
+    content, err = _fetch_content(source_url=None, canonical_path=str(f))
+    assert err is None
+    assert content == b"re-fetch me"
+
+
+def test_fetch_strips_file_uri_scheme(tmp_path):
+    f = tmp_path / "src.md"
+    f.write_bytes(b"body")
+    content, err = _fetch_content(source_url=f"file://{f}", canonical_path=None)
+    assert err is None and content == b"body"
+
+
+def test_fetch_prefers_local_path_over_url(tmp_path):
+    f = tmp_path / "local.txt"
+    f.write_bytes(b"local wins")
+    # source_url is http but a local canonical_path exists → no network, use file.
+    content, err = _fetch_content(source_url="https://example.com/x", canonical_path=str(f))
+    assert err is None and content == b"local wins"
+
+
+def test_fetch_missing_file_falls_through_to_no_source(tmp_path):
+    missing = tmp_path / "nope.txt"
+    content, err = _fetch_content(source_url=None, canonical_path=str(missing))
+    assert content is None
+    assert err is not None and "no fetchable" in err
+
+
+def test_fetch_no_source_at_all_errors():
+    content, err = _fetch_content(source_url=None, canonical_path=None)
+    assert content is None
+    assert err is not None
+
+
+def test_fetch_over_cap_refuses(tmp_path, monkeypatch):
+    import empirica.cli.command_handlers.sources_update_commands as m
+
+    monkeypatch.setattr(m, "_MAX_FETCH_BYTES", 8)
+    f = tmp_path / "big.bin"
+    f.write_bytes(b"x" * 100)
+    content, err = m._fetch_content(source_url=None, canonical_path=str(f))
+    assert content is None
+    assert err is not None and "cap" in err
+
+
+def test_guess_mime_from_extension():
+    assert _guess_mime("https://x/doc.html", None) == "text/html"
+    assert _guess_mime(None, "/path/notes.md") in ("text/markdown", "text/x-markdown")
+    assert _guess_mime(None, None) is None


### PR DESCRIPTION
Closes the **ACT half** of David's source-lifecycle gap (ingestion SER **prop_h2eux4al**, David-approved scope): `sources-check` **detects** a stale/broken source; `source-update` **re-fetches** it and refreshes its content identity — until now the loop could detect staleness but never act on it.

## What

`source-update --source-id <id|prefix>`:
- resolves the source (prefix-matched, like `source-archive`);
- re-fetches its bytes — **local `canonical_path` first** (offline), else an http(s) `source_url` (25 MiB cap, bounded timeout);
- recomputes `content_hash` (sha256) + `size_bytes` + `mime_type` (migration 050 columns);
- appends an `updated` event to `lifecycle_audit_log` (migration 044) with old/new hash + `changed` flag.

**No migration** — reuses the existing content-identity + audit columns. **Fail-soft**: an unreachable URL / missing file / over-cap updates **nothing** — an existing `content_hash` is never wiped by a transient failure.

`source-review` (verified/superseded/retire) is the follow-up PR; its terminal states already have machinery (the migration-044 archive lifecycle), so its net-new is small.

## Verification

Live-verified: added a file source, changed it, `source-update` recomputed the hash (`changed=true, action=updated`). `--help` + dispatch wired through cli_core.

`tests/test_source_update.py` (8): hash determinism, fetch (local / file-uri / prefer-local-over-url / missing / none / over-cap), mime guess. **pyright 0/0/0 full package**, ruff check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)