### PR TITLE
feat(sentinel): artifact-graph gate enforce-by-default, ecosystem-wide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Artifact-graph gate is now enforce-by-default, ecosystem-wide.** The
+  `_GATE_SCALARS` defaults flip from report-only (strictness 0.25 / floor 0.50)
+  to enforce (strictness **0.75** / floor **0.34**) — the pair empirica dogfooded.
+  The model inverts from opt-IN-enforce to enforce-by-default + opt-DOWN: below
+  34% artifact-graph connectivity the CHECK gate soft-blocks the noetic→praxic
+  transition (flips `proceed`→`investigate`, always recoverable by weaving one
+  edge — `--related-to` / `--edge` / `log-artifacts` edges). This makes grounded
+  weave-discipline the physically-enforced baseline for ECO-gated autonomous
+  work rather than an honor-system nudge. Escape hatches unchanged and
+  precedence-preserved (env > project.yaml > default): a session opts down with
+  `EMPIRICA_ARTIFACT_GRAPH_STRICTNESS=0.25`, a practice with an `artifact_graph`
+  block in `.empirica/project.yaml`. Enforcement is fail-open (a measurement
+  error never blocks) and only ever soft-blocks at CHECK — POSTFLIGHT stays
+  report-only.
+
 ## [1.12.14] — 2026-07-06
 
 ### Added

--- a/empirica/cli/command_handlers/_workflow_shared.py
+++ b/empirica/cli/command_handlers/_workflow_shared.py
@@ -580,12 +580,22 @@ def _retro_count_edges(cursor, session_id: str, transaction_id: str | None) -> i
 # transport into the CLI. This dict is the SINGLE source of truth for both the
 # default values and the env-var names — deliberately not split across call
 # sites (the engagement_gate's 12-site duplicated-default mess is the anti-
-# pattern this avoids). Defaults keep a fresh install report-only + forgiving:
-# the gate never blocks until a human dials strictness up.
+# pattern this avoids).
+#
+# ENFORCE-BY-DEFAULT (ecosystem-wide, from 1.12.15). The model is inverted from
+# the earlier opt-IN default: enforcement of artifact-graph connectivity is the
+# baseline discipline every practice inherits, and a practice opts DOWN rather
+# than up. This is the grounding keystone for ECO-gated autonomous work —
+# physically-enforced weave discipline, not honor-system. The 0.75 / 0.34 pair
+# is the config empirica dogfooded (it soft-blocks CHECK below the floor, always
+# recoverable by weaving one edge). To opt a practice/session down:
+#   - session:  export EMPIRICA_ARTIFACT_GRAPH_STRICTNESS=0.25   (report-only)
+#   - practice: .empirica/project.yaml  ->  artifact_graph: {strictness: 0.25}
+# Precedence (env > project.yaml > default) is unchanged; only the default moved.
 _GATE_SCALARS = {
     # key                  (default, env var)
-    "strictness": (0.25, "EMPIRICA_ARTIFACT_GRAPH_STRICTNESS"),
-    "connectivity_floor": (0.50, "EMPIRICA_ARTIFACT_GRAPH_FLOOR"),
+    "strictness": (0.75, "EMPIRICA_ARTIFACT_GRAPH_STRICTNESS"),
+    "connectivity_floor": (0.34, "EMPIRICA_ARTIFACT_GRAPH_FLOOR"),
     "patience": (0.80, "EMPIRICA_ARTIFACT_GRAPH_PATIENCE"),
 }
 
@@ -657,8 +667,9 @@ def _gate_response_for(strictness: float) -> str:
     - ``silent`` (<0.05) — gate computes nothing, returns None (fully dialed down).
     - ``report`` (<0.40) — verdict attached, no pressure (default band).
     - ``warn``   (<0.70) — verdict + explicit "should weave more" language.
-    - ``enforce`` (≥0.70) — verdict + would-block signal. Blocking itself is a
-      follow-up work-stream; this build still returns ``enforced: False``.
+    - ``enforce`` (≥0.70) — verdict + block signal; the CHECK gate flips
+      proceed→investigate below the floor (recoverable by weaving). This is the
+      ecosystem default band (strictness 0.75).
     """
     if strictness < 0.05:
         return "silent"
@@ -680,11 +691,12 @@ def _weave_gate_block(total_artifacts: int, edges_count: int) -> dict | None:
 
     **Enforcement is strictness-driven.** ``enforced`` is True ONLY at the
     ``enforce`` band (strictness ≥ 0.70) AND below the connectivity floor — at
-    every lower band it stays ``False`` (report-only), so the default (strictness
-    0.25) never blocks. A practice opts into enforcement by dialing strictness up;
-    the consumer (the CHECK gate) blocks the noetic→praxic transition when
-    ``enforced``. Returns None when strictness dials the gate fully ``silent``
-    (<0.05) or there are no artifacts.
+    every lower band it stays ``False`` (report-only). The ecosystem default
+    (strictness 0.75, floor 0.34) lands in the enforce band, so enforcement is
+    the baseline; a practice opts DOWN by dialing strictness below 0.70 (env var
+    or project.yaml). The consumer (the CHECK gate) blocks the noetic→praxic
+    transition when ``enforced``. Returns None when strictness dials the gate
+    fully ``silent`` (<0.05) or there are no artifacts.
     """
     scalars = _resolve_gate_scalars()
     response = _gate_response_for(scalars["strictness"])

--- a/tests/test_check_weave_enforce.py
+++ b/tests/test_check_weave_enforce.py
@@ -1,10 +1,10 @@
 """Artifact-graph weave-enforce at the CHECK gate (map work-stream 1 enforce-half).
 
-The gate can now BLOCK the noetic→praxic transition — but ONLY when a practice
-dials strictness into the enforce band (≥0.70) and the transaction's artifacts
-are below the connectivity floor. By default (report-only strictness) it's a pure
-no-op. And it's fail-open: a measurement error never blocks CHECK (the P1 lesson —
-gating machinery must not brick the loop it gates).
+The gate BLOCKS the noetic→praxic transition when strictness is in the enforce
+band (≥0.70) and the transaction's artifacts are below the connectivity floor.
+Enforce is now the ecosystem default (strictness 0.75); a practice dials DOWN to
+make it a no-op. And it's fail-open: a measurement error never blocks CHECK (the
+P1 lesson — gating machinery must not brick the loop it gates).
 """
 
 from __future__ import annotations

--- a/tests/test_gate_scalars_project_source.py
+++ b/tests/test_gate_scalars_project_source.py
@@ -33,16 +33,18 @@ def test_no_project_block_uses_defaults(tmp_path, monkeypatch):
     _clear_env(monkeypatch)
     monkeypatch.setattr(ws.R, "project_path", staticmethod(lambda: str(tmp_path)))  # no project.yaml
     s = ws._resolve_gate_scalars()
-    assert s["strictness"] == 0.25  # peers with no block stay report-only
-    assert s["connectivity_floor"] == 0.50
+    assert s["strictness"] == 0.75  # peers with no block now enforce by default
+    assert s["connectivity_floor"] == 0.34
 
 
-def test_project_yaml_flips_enforcement(tmp_path, monkeypatch):
+def test_project_yaml_overrides_default(tmp_path, monkeypatch):
     _clear_env(monkeypatch)
-    root = _project(tmp_path, {"strictness": 0.75, "connectivity_floor": 0.6})
+    # Values distinct from the (now enforce) default so the project source is
+    # provably honored — a practice can tune up OR down via project.yaml.
+    root = _project(tmp_path, {"strictness": 0.9, "connectivity_floor": 0.6})
     monkeypatch.setattr(ws.R, "project_path", staticmethod(lambda: str(root)))
     s = ws._resolve_gate_scalars()
-    assert s["strictness"] == 0.75  # enforce band
+    assert s["strictness"] == 0.9
     assert s["connectivity_floor"] == 0.6
     assert s["patience"] == 0.80  # unset key falls back to default
 
@@ -58,7 +60,7 @@ def test_malformed_project_block_falls_back(tmp_path, monkeypatch):
     _clear_env(monkeypatch)
     root = _project(tmp_path, {"strictness": "loud"})  # unparseable
     monkeypatch.setattr(ws.R, "project_path", staticmethod(lambda: str(root)))
-    assert ws._resolve_gate_scalars()["strictness"] == 0.25  # falls back to default
+    assert ws._resolve_gate_scalars()["strictness"] == 0.75  # falls back to default
 
 
 def test_non_dict_block_ignored(tmp_path, monkeypatch):
@@ -66,4 +68,4 @@ def test_non_dict_block_ignored(tmp_path, monkeypatch):
     root = _project(tmp_path, "not-a-dict")
     monkeypatch.setattr(ws.R, "project_path", staticmethod(lambda: str(root)))
     assert ws._read_project_gate_scalars() == {}
-    assert ws._resolve_gate_scalars()["strictness"] == 0.25
+    assert ws._resolve_gate_scalars()["strictness"] == 0.75

--- a/tests/test_weave_gate_block.py
+++ b/tests/test_weave_gate_block.py
@@ -2,9 +2,10 @@
 
 Gated Artifact-Graph map, work-stream 1 foundation (goal 43471346). Three
 orthogonal 0.0–1.0 dimensions — strictness / connectivity_floor / patience —
-resolved from env (the extension's Sentinel sliders). REPORT-ONLY in this
-build: `enforced` is always False even at the `enforce` response band; the
-soft/hard *blocking* is a deliberate follow-up keyed on strictness.
+resolved from env (the extension's Sentinel sliders) / project.yaml / default.
+ENFORCE-BY-DEFAULT (ecosystem-wide, from 1.12.15): the default strictness 0.75
+lands in the `enforce` band, so `enforced` is True below the floor; a practice
+opts DOWN to report-only by dialing strictness < 0.70.
 """
 
 from __future__ import annotations
@@ -27,11 +28,13 @@ def _clear(monkeypatch):
         monkeypatch.delenv(e, raising=False)
 
 
-def test_default_scalars_are_report_only_and_forgiving(monkeypatch):
+def test_default_scalars_are_enforce_and_forgiving(monkeypatch):
     _clear(monkeypatch)
+    # Ecosystem-wide enforce-by-default: strictness in the enforce band (>=0.70),
+    # floor kept forgiving (0.34) so weaving one edge per few artifacts satisfies.
     assert _resolve_gate_scalars() == {
-        "strictness": 0.25,
-        "connectivity_floor": 0.50,
+        "strictness": 0.75,
+        "connectivity_floor": 0.34,
         "patience": 0.80,
     }
 
@@ -50,7 +53,7 @@ def test_scalars_env_driven_and_clamped(monkeypatch):
 def test_bad_env_value_falls_back_to_default(monkeypatch):
     _clear(monkeypatch)
     monkeypatch.setenv("EMPIRICA_ARTIFACT_GRAPH_STRICTNESS", "not-a-number")
-    assert _resolve_gate_scalars()["strictness"] == 0.25
+    assert _resolve_gate_scalars()["strictness"] == 0.75
 
 
 def test_response_bands_ladder():
@@ -68,18 +71,18 @@ def test_connected_verdict_at_default(monkeypatch):
     _clear(monkeypatch)
     g = _weave_gate_block(total_artifacts=3, edges_count=3)
     assert g is not None
-    assert g["response"] == "report"
+    assert g["response"] == "enforce"  # default strictness 0.75 → enforce band
     assert g["verdict"] == "connected"
     assert g["connected_ratio"] == 1.0
     assert g["satisfied"] is True
-    assert g["enforced"] is False
+    assert g["enforced"] is False  # satisfied → no block even in enforce band
 
 
 def test_partial_and_disconnected(monkeypatch):
     _clear(monkeypatch)
     partial = _weave_gate_block(4, 1)
     assert partial["verdict"] == "partial"
-    assert partial["satisfied"] is False  # 0.25 ratio < 0.50 floor
+    assert partial["satisfied"] is False  # 0.25 ratio < 0.34 floor
     assert _weave_gate_block(3, 0)["verdict"] == "disconnected"
 
 
@@ -104,14 +107,15 @@ def test_no_artifacts_returns_none(monkeypatch):
 def test_enforces_at_enforce_band_below_floor(monkeypatch):
     _clear(monkeypatch)
     monkeypatch.setenv("EMPIRICA_ARTIFACT_GRAPH_STRICTNESS", "0.9")
-    g = _weave_gate_block(2, 0)  # 0% connected, below the 50% floor
+    g = _weave_gate_block(2, 0)  # 0% connected, below the 34% floor
     assert g["response"] == "enforce"
     assert g["enforced"] is True  # enforce band + below floor → blocks
 
 
 def test_report_and_warn_bands_never_enforce(monkeypatch):
     _clear(monkeypatch)
-    # default (report, 0.25) below floor → dormant
+    # report band (0.25, an opt-down) below floor → dormant, never blocks
+    monkeypatch.setenv("EMPIRICA_ARTIFACT_GRAPH_STRICTNESS", "0.25")
     assert _weave_gate_block(2, 0)["enforced"] is False
     # warn band (0.5) below floor → still report-only, no block
     monkeypatch.setenv("EMPIRICA_ARTIFACT_GRAPH_STRICTNESS", "0.5")


### PR DESCRIPTION
## What

Flips the artifact-graph gate from **report-only** to **enforce-by-default**, ecosystem-wide — the last grounding piece for full autonomous work gated on ECO.

`_GATE_SCALARS` defaults:

| dimension | before (opt-in) | after (enforce-by-default) |
|---|---|---|
| `strictness` | 0.25 (report band) | **0.75** (enforce band) |
| `connectivity_floor` | 0.50 | **0.34** (forgiving) |
| `patience` | 0.80 | 0.80 (unchanged) |

The model inverts: from **opt-IN-enforce** (a practice dials strictness up) to **enforce-by-default + opt-DOWN**. Below the 34% artifact-graph connectivity floor, the CHECK gate soft-blocks the noetic→praxic transition (`proceed`→`investigate`), always recoverable by weaving one edge (`--related-to` / `--edge` / `log-artifacts` edges).

## Why

Enforced weave-discipline is the physically-enforced baseline that grounds ECO-gated autonomous work — not an honor-system nudge. **0.75 / 0.34 is the exact pair empirica dogfooded this entire release** (it soft-blocked my own CHECK twice; both recovered by weaving an edge — proving the escape path works). Floor 0.34 keeps the first ecosystem rollout forgiving.

## Safety / escape hatches (unchanged)

- Precedence preserved: **env > project.yaml > default**. Only the default moved.
- Session opt-down: `export EMPIRICA_ARTIFACT_GRAPH_STRICTNESS=0.25` → report-only.
- Practice opt-down: `artifact_graph: {strictness: 0.25}` in `.empirica/project.yaml`.
- **Fail-open**: a measurement error never blocks CHECK (P1 lesson — gating machinery must not brick the loop it gates).
- Only ever **soft-blocks at CHECK** (proceed→investigate, recoverable). POSTFLIGHT stays report-only.

## Tests

- Default-value assertions updated to 0.75 / 0.34 across `test_weave_gate_block.py` + `test_gate_scalars_project_source.py`.
- The two tests whose premise was "default is report band" now set report strictness explicitly.
- The project-source override test uses a non-default value (0.9) to prove the source is honored now that enforce is the default.
- `_gate_response_for` band-function tests unchanged (they test the ladder, not the default).
- Stale "report-only by default / blocking is a follow-up" docstrings corrected.
- Local: 24/24 gate unit tests pass against the branch code; ruff check + format clean.

## Rollout note

All instances run editable from develop, so **merging this activates enforce-by-default fleet-wide on next CLI invocation.** Developed in an isolated git worktree specifically so the live fleet's behavior only changes at merge, not during development. "See how well it goes" — observe CHECK block/recover rates; dial the floor down if it over-blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)