### PR TITLE
feat(sentinel): persist weave-enforce events (migration 052) — telemetry foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Enforce-event persistence — `weave_enforce_events` (migration 052).** The
+  artifact-graph gate's weave verdict at CHECK (connectivity vs floor, response
+  band, whether it blocked and whether it overrode the decision) was computed
+  transiently and never stored. It's now recorded one row per CHECK, **fail-open**
+  (a persistence error never affects the CHECK decision — the path is fleet-critical
+  since enforce-by-default shipped). This is the durable source for the
+  forthcoming enforcement telemetry (block-rate / self-resolve-rate) and the
+  adaptive-enforcement (`patience`) consecutive-miss history — the instrumentation
+  for observing the ECO/novelty frontier as it recedes.
+
 ### Changed
 - **Artifact-graph gate is now enforce-by-default, ecosystem-wide.** The
   `_GATE_SCALARS` defaults flip from report-only (strictness 0.25 / floor 0.50)

--- a/empirica/cli/command_handlers/_workflow_check.py
+++ b/empirica/cli/command_handlers/_workflow_check.py
@@ -674,6 +674,47 @@ def _check_gate_decision(vectors, ready_uncertainty_threshold, diminishing_retur
     return decision, computed_decision, autopilot_mode, decision_binding
 
 
+def _persist_weave_event(session_id, transaction_id, block, decision_in, decision_out):
+    """Record the weave-enforce verdict to ``weave_enforce_events`` (migration 052).
+
+    Durable telemetry: one row per CHECK that produced a weave verdict — the
+    source for enforcement-report block-rate / self-resolve-rate and the
+    consecutive-miss history adaptive ``patience`` consumes. FAIL-OPEN: a
+    persistence error must never affect the CHECK decision (the CHECK path is
+    fleet-critical since enforce-by-default shipped), so every error is swallowed.
+    A missing table (un-migrated DB) simply drops the row.
+    """
+    try:
+        import time
+
+        from ._workflow_shared import _get_db_for_session
+
+        scalars = block.get("scalars") or {}
+        db = _get_db_for_session(session_id)
+        db.conn.execute(
+            """INSERT INTO weave_enforce_events
+               (session_id, transaction_id, created_timestamp, connectivity_ratio,
+                connectivity_floor, strictness, response_band, enforced,
+                decision_in, decision_out)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                session_id,
+                transaction_id,
+                time.time(),
+                block.get("connected_ratio"),
+                scalars.get("connectivity_floor"),
+                scalars.get("strictness"),
+                block.get("response"),
+                1 if block.get("enforced") else 0,
+                decision_in,
+                decision_out,
+            ),
+        )
+        db.conn.commit()
+    except Exception as e:
+        logger.debug(f"weave-event persist skipped (non-fatal): {e}")
+
+
 def _check_apply_weave_enforce(result, decision, session_id, transaction_id):
     """Artifact-graph weave-gate enforce-half (map work-stream 1).
 
@@ -683,8 +724,10 @@ def _check_apply_weave_enforce(result, decision, session_id, transaction_id):
     ``proceed`` to ``investigate``, blocking the noetic→praxic transition until
     the artifacts are woven.
 
-    DORMANT BY DEFAULT: the report-only strictness (0.25) never sets
-    ``enforced``, so this is a pure no-op until a practice dials strictness up.
+    ENFORCE BY DEFAULT (since #276): the ecosystem default strictness (0.75)
+    lands in the enforce band, so a below-floor transaction blocks unless a
+    practice dials strictness down. Every verdict is persisted to
+    ``weave_enforce_events`` (fail-open) for telemetry + adaptive patience.
     Best-effort and fail-open — a measurement error never blocks CHECK (mirrors
     the P1 lesson: gating machinery must not brick the loop it gates).
     """
@@ -694,6 +737,7 @@ def _check_apply_weave_enforce(result, decision, session_id, transaction_id):
         block = _weave_enforcement_block(session_id, transaction_id)
         if not block:
             return decision
+        decision_in = decision
         result["weave_gate"] = block
         if block.get("enforced") and decision == "proceed":
             decision = "investigate"
@@ -703,6 +747,7 @@ def _check_apply_weave_enforce(result, decision, session_id, transaction_id):
                 "reason": block.get("note", "weave more artifacts before proceeding to praxic"),
             }
             logger.info("CHECK weave-enforce override: proceed → investigate (artifact-graph gate enforced)")
+        _persist_weave_event(session_id, transaction_id, block, decision_in, decision)
     except Exception as e:
         logger.debug(f"weave-enforce check skipped (non-fatal): {e}")
     return decision

--- a/empirica/data/migrations/migrations.py
+++ b/empirica/data/migrations/migrations.py
@@ -1471,6 +1471,11 @@ ALL_MIGRATIONS: list[tuple[str, str, Callable]] = [
         "Add nullable engagement_id column to goals — scopes a goal to an engagement (the artifact → goal → engagement linkage of the engagement substrate). Cross-db by-id reference (goals in sessions.db, engagements in workspace.db); no FK, enforced at the API layer.",
         lambda cursor: migration_051_goals_engagement_id(cursor),
     ),
+    (
+        "052_weave_enforce_events",
+        "Create weave_enforce_events — durable telemetry for the artifact-graph gate. The weave-enforce verdict at CHECK (connectivity vs floor, band, block/override) was computed transiently and never persisted; this table is the durable record one row per CHECK, written fail-open. Feeds enforcement-report telemetry and the adaptive-enforcement (patience) consecutive-miss history.",
+        lambda cursor: migration_052_weave_enforce_events(cursor),
+    ),
 ]
 
 
@@ -2025,6 +2030,42 @@ def migration_051_goals_engagement_id(cursor: sqlite3.Cursor):
     add_column_if_missing(cursor, "goals", "engagement_id", "TEXT")
     cursor.execute("CREATE INDEX IF NOT EXISTS idx_goals_engagement_id ON goals(engagement_id)")
     logger.info("✅ Migration 051 complete: engagement_id column added to goals")
+
+
+def migration_052_weave_enforce_events(cursor: sqlite3.Cursor):
+    """Create `weave_enforce_events` — durable telemetry for the artifact-graph gate.
+
+    The weave-enforce verdict at CHECK (connectivity vs the floor, response band,
+    whether it blocked and whether it overrode the decision) was computed
+    transiently in `_check_apply_weave_enforce` and returned to the caller, but
+    never persisted — so there was no durable source for enforce block-rate /
+    self-resolve-rate telemetry, nor the consecutive-miss history that adaptive
+    `patience` needs. This table is that record: one row per CHECK that produced a
+    weave verdict.
+
+    Written fail-open — a persistence failure must never affect the CHECK decision
+    (the CHECK path is fleet-critical since enforce-by-default shipped). Both the
+    enforcement-report telemetry and the adaptive-enforcement work-stream read it.
+    Idempotent via CREATE TABLE IF NOT EXISTS.
+    """
+    cursor.execute("""
+        CREATE TABLE IF NOT EXISTS weave_enforce_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT,
+            transaction_id TEXT,
+            created_timestamp REAL NOT NULL,
+            connectivity_ratio REAL,
+            connectivity_floor REAL,
+            strictness REAL,
+            response_band TEXT,
+            enforced INTEGER NOT NULL DEFAULT 0,
+            decision_in TEXT,
+            decision_out TEXT
+        )
+    """)
+    cursor.execute("CREATE INDEX IF NOT EXISTS idx_weave_events_txn ON weave_enforce_events(transaction_id)")
+    cursor.execute("CREATE INDEX IF NOT EXISTS idx_weave_events_session ON weave_enforce_events(session_id)")
+    logger.info("✅ Migration 052 complete: weave_enforce_events table created")
 
 
 def migration_044_source_lifecycle(cursor: sqlite3.Cursor):

--- a/tests/test_weave_enforce_persist.py
+++ b/tests/test_weave_enforce_persist.py
@@ -1,0 +1,101 @@
+"""weave_enforce_events persistence (migration 052).
+
+Durable telemetry for the artifact-graph gate: every CHECK weave verdict is
+recorded — the source for enforcement-report block-rate / self-resolve-rate and
+the consecutive-miss history adaptive `patience` consumes. Writes are FAIL-OPEN:
+a persistence error must never affect the CHECK decision (the CHECK path is
+fleet-critical since enforce-by-default shipped).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import types
+
+from empirica.cli.command_handlers import _workflow_check as wc
+from empirica.cli.command_handlers import _workflow_shared as ws
+from empirica.data.migrations.migrations import migration_052_weave_enforce_events
+
+
+def _migrated_conn():
+    conn = sqlite3.connect(":memory:")
+    migration_052_weave_enforce_events(conn.cursor())
+    conn.commit()
+    return conn
+
+
+def test_migration_creates_table_with_expected_columns():
+    conn = _migrated_conn()
+    cols = {r[1] for r in conn.execute("PRAGMA table_info(weave_enforce_events)")}
+    assert {
+        "session_id",
+        "transaction_id",
+        "created_timestamp",
+        "connectivity_ratio",
+        "connectivity_floor",
+        "strictness",
+        "response_band",
+        "enforced",
+        "decision_in",
+        "decision_out",
+    } <= cols
+
+
+def test_migration_is_idempotent():
+    conn = _migrated_conn()
+    migration_052_weave_enforce_events(conn.cursor())  # second run must not raise
+    conn.commit()
+
+
+def test_persist_weave_event_inserts_row(monkeypatch):
+    conn = _migrated_conn()
+    monkeypatch.setattr(ws, "_get_db_for_session", lambda sid: types.SimpleNamespace(conn=conn))
+    block = {
+        "connected_ratio": 0.2,
+        "response": "enforce",
+        "enforced": True,
+        "scalars": {"connectivity_floor": 0.34, "strictness": 0.75},
+    }
+    wc._persist_weave_event("s1", "tx1", block, "proceed", "investigate")
+    rows = list(
+        conn.execute(
+            "SELECT session_id, transaction_id, connectivity_ratio, connectivity_floor, "
+            "strictness, response_band, enforced, decision_in, decision_out FROM weave_enforce_events"
+        )
+    )
+    assert rows == [("s1", "tx1", 0.2, 0.34, 0.75, "enforce", 1, "proceed", "investigate")]
+
+
+def test_persist_is_fail_open_on_missing_table(monkeypatch):
+    conn = sqlite3.connect(":memory:")  # un-migrated → table absent
+    monkeypatch.setattr(ws, "_get_db_for_session", lambda sid: types.SimpleNamespace(conn=conn))
+    wc._persist_weave_event("s1", "tx1", {"scalars": {}}, "proceed", "proceed")  # must not raise
+
+
+def test_persist_is_fail_open_on_db_error(monkeypatch):
+    def boom(sid):
+        raise RuntimeError("db locked")
+
+    monkeypatch.setattr(ws, "_get_db_for_session", boom)
+    wc._persist_weave_event("s1", "tx1", {"scalars": {}}, "proceed", "proceed")  # must not raise
+
+
+def test_apply_weave_enforce_persists_the_verdict(monkeypatch):
+    conn = _migrated_conn()
+    monkeypatch.setattr(ws, "_get_db_for_session", lambda sid: types.SimpleNamespace(conn=conn))
+    monkeypatch.setattr(
+        ws,
+        "_weave_enforcement_block",
+        lambda sid, tx: {
+            "connected_ratio": 0.0,
+            "response": "enforce",
+            "enforced": True,
+            "scalars": {"connectivity_floor": 0.34, "strictness": 0.75},
+            "note": "MUST weave more",
+        },
+    )
+    result = {"decision": "proceed"}
+    d = wc._check_apply_weave_enforce(result, "proceed", "s1", "tx1")
+    assert d == "investigate"  # enforce override
+    rows = list(conn.execute("SELECT decision_in, decision_out, enforced FROM weave_enforce_events"))
+    assert rows == [("proceed", "investigate", 1)]


### PR DESCRIPTION
## What

Adds **`weave_enforce_events`** (migration 052): a durable record of the artifact-graph gate's weave verdict at every CHECK — one row per verdict, carrying `connectivity_ratio` / `connectivity_floor` / `strictness` / `response_band` / `enforced` / `decision_in` / `decision_out`.

## Why

Foundation for **items 1–3** of the post-enforce roadmap. The weave verdict was computed transiently in `_check_apply_weave_enforce` and returned to the caller, but **never persisted** — so there's no source for:
- **enforcement telemetry** (block-rate, self-resolve-rate) — "see how well enforce-by-default is going"
- **adaptive `patience`** (consecutive-miss escalation needs the miss history)

Both the forthcoming enforcement-report and the adaptive-enforcement work-stream read this table. It's the instrumentation for watching the **ECO/novelty frontier recede** as grounding accumulates.

## Safety

- **Fail-open.** The write is wrapped so any error (including a missing table on an un-migrated DB) is swallowed and **never affects the CHECK decision** — the CHECK path is fleet-critical since enforce-by-default (#276) shipped.
- Migration is idempotent (`CREATE TABLE IF NOT EXISTS` + `IF NOT EXISTS` indexes).
- No reorder of the CHECK flow — the write is additive inside the existing Stage 13.5.

## Also

- Corrects the now-stale "dormant by default (report-only)" docstring on `_check_apply_weave_enforce` (enforce is the default post-#276).

## Tests

`tests/test_weave_enforce_persist.py` — migration table shape + idempotency, row insert, fail-open on missing table, fail-open on DB error, and the override-path write. Local: migration suite (84) + weave tests (25) green; ruff check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)