### PR TITLE
feat(sentinel): enforcement-report — artifact-graph enforce telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **`empirica enforcement-report` — artifact-graph enforce telemetry.** Reads
+  `weave_enforce_events` and reports block-rate and — the health metric —
+  **self-resolve-rate**: of the transactions the gate blocked, how many recovered
+  on their own (wove an edge → re-CHECK proceeded) vs stalled. High self-resolve =
+  the gate nudges and the system recovers autonomously (working as designed); low =
+  it's over-blocking (a low rate prints a floor-tuning hint). The empirical answer
+  to "how well is enforce-by-default going," and the first read of the ECO/novelty
+  frontier. Human + JSON; optional `--session-id` scope.
 - **Enforce-event persistence — `weave_enforce_events` (migration 052).** The
   artifact-graph gate's weave verdict at CHECK (connectivity vs floor, response
   band, whether it blocked and whether it overrode the decision) was computed

--- a/empirica/cli/cli_core.py
+++ b/empirica/cli/cli_core.py
@@ -393,6 +393,7 @@ _HELP_CATEGORIES = {
         "sources-check",
         "source-archive",
         "source-update",
+        "enforcement-report",
         "act-log",
         "investigate-log",
         "log-artifacts",
@@ -902,6 +903,7 @@ def main(args=None):
             "sources-check": handle_sources_check_command,
             "source-archive": handle_source_archive_command,
             "source-update": handle_source_update_command,
+            "enforcement-report": handle_enforcement_report_command,
             "epp-activate": handle_epp_activate_command,
             # Training data export
             "training-export": handle_training_export_command,

--- a/empirica/cli/command_handlers/__init__.py
+++ b/empirica/cli/command_handlers/__init__.py
@@ -78,6 +78,7 @@ from .doctor import handle_doctor_command
 from .ecosystem_commands import (
     handle_ecosystem_check_command,
 )
+from .enforcement_report_commands import handle_enforcement_report_command
 from .engagement_commands import (
     handle_engagement_create_command,
     handle_engagement_list_command,
@@ -250,7 +251,6 @@ from .skill_commands import (
     handle_skill_suggest_command,
 )
 from .sources_check_commands import handle_sources_check_command
-from .enforcement_report_commands import handle_enforcement_report_command
 from .sources_reconcile_commands import handle_sources_reconcile_command
 from .sources_update_commands import handle_source_update_command
 from .sync_commands import (

--- a/empirica/cli/command_handlers/__init__.py
+++ b/empirica/cli/command_handlers/__init__.py
@@ -250,6 +250,7 @@ from .skill_commands import (
     handle_skill_suggest_command,
 )
 from .sources_check_commands import handle_sources_check_command
+from .enforcement_report_commands import handle_enforcement_report_command
 from .sources_reconcile_commands import handle_sources_reconcile_command
 from .sources_update_commands import handle_source_update_command
 from .sync_commands import (
@@ -494,6 +495,7 @@ __all__ = [  # noqa: RUF022
     "handle_sources_map_command",
     "handle_sources_check_command",
     "handle_source_update_command",
+    "handle_enforcement_report_command",
     "handle_sources_reconcile_command",
     # Sync commands (git notes synchronization)
     "handle_sync_config_command",

--- a/empirica/cli/command_handlers/enforcement_report_commands.py
+++ b/empirica/cli/command_handlers/enforcement_report_commands.py
@@ -1,0 +1,143 @@
+"""`empirica enforcement-report` — artifact-graph enforce telemetry.
+
+Reads ``weave_enforce_events`` (migration 052) and reports how the enforce-by-default
+gate is behaving in practice: how often CHECK blocked the noetic→praxic transition,
+and — the health metric — how often a blocked transaction **self-resolved** (the
+practitioner wove an edge and reached a proceed) vs stalled.
+
+self-resolve-rate is the empirical answer to "how well is enforce going": high =
+the gate nudges and the system recovers on its own (working as designed); low =
+it's over-blocking (dial the floor down). Pure aggregation in
+``_aggregate_weave_events`` so the metric is unit-tested without a DB.
+"""
+
+from __future__ import annotations
+
+import json
+
+
+def _aggregate_weave_events(rows: list[dict]) -> dict:
+    """Aggregate weave_enforce_events rows into enforce telemetry.
+
+    ``rows`` — dicts with ``transaction_id``, ``created_timestamp``,
+    ``connectivity_ratio``, ``response_band``, ``enforced`` (0/1), ``decision_out``.
+
+    A transaction is **blocked** if any of its verdicts enforced. A blocked
+    transaction **self-resolved** if, at or after its first block, a later verdict
+    reached ``decision_out == 'proceed'`` (the practitioner wove an edge and the
+    re-CHECK passed). self-resolve-rate = self-resolved / blocked.
+    """
+    total_verdicts = len(rows)
+    bands: dict[str, int] = {}
+    conn_vals: list[float] = []
+    for r in rows:
+        band = r.get("response_band") or "unknown"
+        bands[band] = bands.get(band, 0) + 1
+        cv = r.get("connectivity_ratio")
+        if isinstance(cv, (int, float)):
+            conn_vals.append(float(cv))
+
+    # Group by transaction, ordered by time, to compute block + self-resolve.
+    by_txn: dict[str, list[dict]] = {}
+    for r in rows:
+        by_txn.setdefault(r.get("transaction_id"), []).append(r)
+
+    blocked_txns = 0
+    self_resolved_txns = 0
+    for verdicts in by_txn.values():
+        ordered = sorted(verdicts, key=lambda x: x.get("created_timestamp") or 0)
+        first_block_ts = next((v.get("created_timestamp") or 0 for v in ordered if v.get("enforced")), None)
+        if first_block_ts is None:
+            continue
+        blocked_txns += 1
+        if any(
+            (v.get("created_timestamp") or 0) >= first_block_ts and v.get("decision_out") == "proceed" for v in ordered
+        ):
+            self_resolved_txns += 1
+
+    total_txns = len(by_txn)
+    return {
+        "total_verdicts": total_verdicts,
+        "total_transactions": total_txns,
+        "blocked_transactions": blocked_txns,
+        "block_rate": round(blocked_txns / total_txns, 3) if total_txns else 0.0,
+        "self_resolved_transactions": self_resolved_txns,
+        "self_resolve_rate": round(self_resolved_txns / blocked_txns, 3) if blocked_txns else None,
+        "avg_connectivity_ratio": round(sum(conn_vals) / len(conn_vals), 3) if conn_vals else None,
+        "band_distribution": bands,
+    }
+
+
+def _read_weave_events(db, session_id: str | None) -> list[dict]:
+    """Read weave_enforce_events from the session DB. Returns [] if the table is
+    absent (un-migrated) or on any read error — the report degrades to 'no data'."""
+    cols = (
+        "transaction_id",
+        "created_timestamp",
+        "connectivity_ratio",
+        "connectivity_floor",
+        "strictness",
+        "response_band",
+        "enforced",
+        "decision_in",
+        "decision_out",
+    )
+    try:
+        sql = f"SELECT {', '.join(cols)} FROM weave_enforce_events"
+        params: tuple = ()
+        if session_id:
+            sql += " WHERE session_id = ?"
+            params = (session_id,)
+        cur = db.conn.execute(sql, params)
+        return [dict(zip(cols, row)) for row in cur.fetchall()]
+    except Exception:
+        return []
+
+
+def handle_enforcement_report_command(args) -> None:
+    """Render the enforce telemetry report (human or JSON)."""
+    from empirica.data.session_database import SessionDatabase
+
+    session_id = getattr(args, "session_id", None)
+    db = SessionDatabase()
+    try:
+        rows = _read_weave_events(db, session_id)
+    finally:
+        db.close()
+
+    summary = _aggregate_weave_events(rows)
+
+    if getattr(args, "output", "human") == "json":
+        print(json.dumps(summary, indent=2))
+        return
+
+    print("\n🛡️  Artifact-Graph Enforcement Report")
+    print("━" * 60)
+    if summary["total_verdicts"] == 0:
+        print("  (no weave verdicts recorded yet — enforce telemetry is empty)")
+        print("━" * 60)
+        return
+    srr = summary["self_resolve_rate"]
+    print(f"Weave verdicts:            {summary['total_verdicts']}")
+    print(f"Transactions:              {summary['total_transactions']}")
+    print(
+        f"Blocked (enforced):        {summary['blocked_transactions']} "
+        f"({summary['block_rate'] * 100:.0f}% of transactions)"
+    )
+    if srr is None:
+        print("Self-resolve rate:         — (nothing blocked)")
+    else:
+        print(
+            f"Self-resolve rate:         {srr * 100:.0f}% "
+            f"({summary['self_resolved_transactions']}/{summary['blocked_transactions']} blocked → wove → proceeded)"
+        )
+    if summary["avg_connectivity_ratio"] is not None:
+        print(f"Avg connectivity:          {summary['avg_connectivity_ratio'] * 100:.0f}%")
+    if summary["band_distribution"]:
+        bands = ", ".join(f"{k}={v}" for k, v in sorted(summary["band_distribution"].items()))
+        print(f"Response bands:            {bands}")
+    print("━" * 60)
+    if srr is not None and srr < 0.5:
+        print("⚠️  Low self-resolve rate — the floor may be over-blocking. Consider")
+        print("   EMPIRICA_ARTIFACT_GRAPH_FLOOR=0.25 or investigate stalled transactions.")
+        print("━" * 60)

--- a/empirica/cli/parsers/checkpoint_parsers.py
+++ b/empirica/cli/parsers/checkpoint_parsers.py
@@ -1449,12 +1449,8 @@ def add_checkpoint_parsers(subparsers):
             "recovers on its own; low means it may be over-blocking."
         ),
     )
-    enforcement_report_parser.add_argument(
-        "--session-id", help="Scope to one session (default: all recorded verdicts)"
-    )
-    enforcement_report_parser.add_argument(
-        "--output", choices=["human", "json"], default="human", help="Output format"
-    )
+    enforcement_report_parser.add_argument("--session-id", help="Scope to one session (default: all recorded verdicts)")
+    enforcement_report_parser.add_argument("--output", choices=["human", "json"], default="human", help="Output format")
 
     # Sources reconcile (unified source identity — adopt catalogue uuids)
     sources_reconcile_parser = subparsers.add_parser(

--- a/empirica/cli/parsers/checkpoint_parsers.py
+++ b/empirica/cli/parsers/checkpoint_parsers.py
@@ -1439,6 +1439,23 @@ def add_checkpoint_parsers(subparsers):
     source_update_parser.add_argument("--output", choices=["human", "json"], default="human", help="Output format")
     source_update_parser.add_argument("--verbose", action="store_true", help="Verbose output")
 
+    # Enforcement report (artifact-graph enforce telemetry — block/self-resolve rate)
+    enforcement_report_parser = subparsers.add_parser(
+        "enforcement-report",
+        help=(
+            "Artifact-graph enforce telemetry: block-rate and self-resolve-rate "
+            "from weave_enforce_events. self-resolve-rate is the health metric for "
+            "enforce-by-default — high means the gate nudges and the system "
+            "recovers on its own; low means it may be over-blocking."
+        ),
+    )
+    enforcement_report_parser.add_argument(
+        "--session-id", help="Scope to one session (default: all recorded verdicts)"
+    )
+    enforcement_report_parser.add_argument(
+        "--output", choices=["human", "json"], default="human", help="Output format"
+    )
+
     # Sources reconcile (unified source identity — adopt catalogue uuids)
     sources_reconcile_parser = subparsers.add_parser(
         "sources-reconcile",

--- a/tests/test_enforcement_report.py
+++ b/tests/test_enforcement_report.py
@@ -1,0 +1,115 @@
+"""enforcement-report — artifact-graph enforce telemetry aggregation.
+
+The health metric is self-resolve-rate: of the transactions the gate blocked, how
+many recovered on their own (wove an edge → re-CHECK proceeded). These pin the
+block-rate / self-resolve-rate math without a DB, plus the fail-open read.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import types
+
+from empirica.cli.command_handlers.enforcement_report_commands import (
+    _aggregate_weave_events,
+    _read_weave_events,
+)
+
+
+def _row(txn, ts, enforced, decision_out, band="enforce", conn=0.0):
+    return {
+        "transaction_id": txn,
+        "created_timestamp": ts,
+        "connectivity_ratio": conn,
+        "response_band": band,
+        "enforced": enforced,
+        "decision_out": decision_out,
+    }
+
+
+def test_empty_rows():
+    s = _aggregate_weave_events([])
+    assert s["total_verdicts"] == 0
+    assert s["total_transactions"] == 0
+    assert s["block_rate"] == 0.0
+    assert s["self_resolve_rate"] is None
+    assert s["avg_connectivity_ratio"] is None
+    assert s["band_distribution"] == {}
+
+
+def test_clean_transaction_never_blocks():
+    s = _aggregate_weave_events([_row("t1", 1, 0, "proceed", conn=1.0)])
+    assert s["blocked_transactions"] == 0
+    assert s["block_rate"] == 0.0
+    assert s["self_resolve_rate"] is None  # nothing blocked
+
+
+def test_blocked_then_self_resolved():
+    rows = [
+        _row("t1", 1, 1, "investigate", conn=0.0),  # blocked
+        _row("t1", 2, 0, "proceed", conn=0.5),  # wove → proceeded
+    ]
+    s = _aggregate_weave_events(rows)
+    assert s["blocked_transactions"] == 1
+    assert s["self_resolved_transactions"] == 1
+    assert s["block_rate"] == 1.0
+    assert s["self_resolve_rate"] == 1.0
+
+
+def test_blocked_and_stalled_is_not_self_resolved():
+    rows = [
+        _row("t1", 1, 1, "investigate"),
+        _row("t1", 2, 1, "investigate"),  # still blocked, never proceeded
+    ]
+    s = _aggregate_weave_events(rows)
+    assert s["blocked_transactions"] == 1
+    assert s["self_resolved_transactions"] == 0
+    assert s["self_resolve_rate"] == 0.0
+
+
+def test_mixed_two_transactions():
+    rows = [
+        _row("t1", 1, 1, "investigate"),
+        _row("t1", 2, 0, "proceed"),  # t1: blocked → resolved
+        _row("t2", 1, 0, "proceed"),  # t2: clean
+    ]
+    s = _aggregate_weave_events(rows)
+    assert s["total_transactions"] == 2
+    assert s["blocked_transactions"] == 1
+    assert s["block_rate"] == 0.5
+    assert s["self_resolve_rate"] == 1.0
+
+
+def test_band_distribution_and_avg_connectivity():
+    rows = [
+        _row("t1", 1, 0, "proceed", band="report", conn=0.4),
+        _row("t2", 1, 0, "proceed", band="enforce", conn=0.6),
+        _row("t3", 1, 1, "investigate", band="enforce", conn=0.0),
+    ]
+    s = _aggregate_weave_events(rows)
+    assert s["band_distribution"] == {"report": 1, "enforce": 2}
+    assert s["avg_connectivity_ratio"] == round((0.4 + 0.6 + 0.0) / 3, 3)
+
+
+def test_read_is_fail_open_on_missing_table():
+    conn = sqlite3.connect(":memory:")  # no weave_enforce_events table
+    db = types.SimpleNamespace(conn=conn)
+    assert _read_weave_events(db, None) == []
+
+
+def test_read_returns_rows_when_present():
+    conn = sqlite3.connect(":memory:")
+    from empirica.data.migrations.migrations import migration_052_weave_enforce_events
+
+    migration_052_weave_enforce_events(conn.cursor())
+    conn.execute(
+        "INSERT INTO weave_enforce_events (session_id, transaction_id, created_timestamp, "
+        "connectivity_ratio, response_band, enforced, decision_in, decision_out) "
+        "VALUES ('s1','t1',1.0,0.2,'enforce',1,'proceed','investigate')"
+    )
+    conn.commit()
+    db = types.SimpleNamespace(conn=conn)
+    rows = _read_weave_events(db, None)
+    assert len(rows) == 1 and rows[0]["transaction_id"] == "t1"
+    # session filter
+    assert _read_weave_events(db, "nope") == []


### PR DESCRIPTION
## What

`empirica enforcement-report` — reads `weave_enforce_events` (#277) and reports how the enforce-by-default gate is behaving:

- **block-rate** — % of transactions where CHECK blocked the noetic→praxic transition
- **self-resolve-rate** *(the health metric)* — of the blocked transactions, how many recovered on their own: wove an edge → re-CHECK proceeded
- band distribution + avg connectivity

```
🛡️  Artifact-Graph Enforcement Report
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Weave verdicts:            142
Transactions:              58
Blocked (enforced):        11 (19% of transactions)
Self-resolve rate:         91% (10/11 blocked → wove → proceeded)
Avg connectivity:          62%
Response bands:            enforce=142
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
```

## Why

This is item 2 of the post-enforce roadmap — the local "see how well it goes" telemetry. **self-resolve-rate is the signal that matters**: high = the gate nudges and the system recovers autonomously (working as designed, per the corrected model where the practitioner self-resolves weave blocks); low = it's over-blocking and the floor should come down (a low rate prints that hint). It's also the first empirical read of the ECO/novelty frontier.

## Design

- **Pure `_aggregate_weave_events(rows)`** — the block/self-resolve math is unit-tested without a DB.
- **Fail-open reader** — degrades to "no data" on an un-migrated DB (never raises).
- Human + JSON, optional `--session-id` scope. Verb + parser + export wired mirroring the `source-update` path.

## Tests

`tests/test_enforcement_report.py` — empty, clean-never-blocks, blocked→self-resolved, blocked-and-stalled, mixed two-transaction, band distribution, and the fail-open read. Local: report tests (8) + CLI-dispatch invariant tests (38) green; end-to-end smoke reads real recorded verdicts; ruff clean.

## Deferred

The **ECO-frontier half** (ECO-gate fire rate) is cross-system — the proposal/eco-decision data lives cortex-side — so it's a follow-up needing cortex integration, not part of this local-telemetry PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)