### PR TITLE
fix(patterns): retrieve logged mistakes at PREFLIGHT + CHECK (epistemic-attention Component A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Logged mistakes now surface at PREFLIGHT + CHECK (they never did).** An audit
+  found the attention-nudge mechanism ran at half-mast: `mistake-log` embedded
+  mistakes for semantic search, but the retrieval (`retrieve_task_patterns` /
+  `check_against_patterns`) had no mistakes path at all — dead-ends surfaced,
+  mistakes were the orphan, so "log a mistake so it reminds you next time" was
+  structurally broken. Mistakes are now retrieved as a first-class anti-pattern
+  (base result `prior_mistakes` at PREFLIGHT, `mistake_matches` at CHECK), parsed
+  from the same embedded text and treated exactly like dead-ends
+  (know-gap-scaled adaptive limit, budget-protected from eviction). A logged
+  mistake now nudges attention on a semantically similar task.
+
 ### Added
 - **`empirica enforcement-report` — artifact-graph enforce telemetry.** Reads
   `weave_enforce_events` and reports block-rate and — the health metric —

--- a/empirica/cli/command_handlers/_workflow_preflight.py
+++ b/empirica/cli/command_handlers/_workflow_preflight.py
@@ -766,6 +766,7 @@ def _preflight_retrieve_patterns(db, session_id, project_id, task_context, reaso
             logger.debug(
                 f"Retrieved patterns ({gap_note}): {len(patterns.get('lessons', []))} lessons, "
                 f"{len(patterns.get('dead_ends', []))} dead_ends, "
+                f"{len(patterns.get('prior_mistakes', []))} mistakes, "
                 f"{len(patterns.get('relevant_findings', []))} findings, "
                 f"{len(patterns.get('eidetic_facts', []))} eidetic, "
                 f"{len(patterns.get('episodic_narratives', []))} episodic, "

--- a/empirica/core/qdrant/pattern_retrieval.py
+++ b/empirica/core/qdrant/pattern_retrieval.py
@@ -199,6 +199,7 @@ def _compute_adaptive_limits(vectors: dict | None, base_limit: int) -> dict[str,
             [
                 "lessons",
                 "dead_ends",
+                "mistakes",
                 "findings",
                 "eidetic",
                 "episodic",
@@ -233,6 +234,7 @@ def _compute_adaptive_limits(vectors: dict | None, base_limit: int) -> dict[str,
     return {
         "lessons": _limit(1.0, know_gap * 2),
         "dead_ends": _limit(1.0, know_gap * 2),
+        "mistakes": _limit(1.0, know_gap * 2),
         "findings": _limit(1.0),
         "eidetic": _limit(1.0, know_gap),
         "episodic": _limit(1.0, context_gap * 2),
@@ -507,6 +509,7 @@ _SECTION_TEXT_FIELDS = {
     "lessons": ["description", "name"],
     "dead_ends": ["why_failed", "approach"],
     "global_dead_ends": ["why_failed", "approach"],
+    "prior_mistakes": ["mistake", "prevention"],
     "relevant_findings": ["finding"],
     "eidetic_facts": ["content"],
     "episodic_narratives": ["narrative"],
@@ -516,6 +519,7 @@ _SECTION_TEXT_FIELDS = {
     "related_docs": ["description"],
     # CHECK (check_against_patterns)
     "dead_end_matches": ["why_failed", "approach"],
+    "mistake_matches": ["mistake", "prevention"],
     "related_findings": ["finding"],
     "eidetic_context": ["content"],
     "active_goals": ["objective"],
@@ -525,7 +529,7 @@ _SECTION_TEXT_FIELDS = {
 _NON_ITEM_KEYS = frozenset({"time_gap", "mistake_risk", "has_warnings", "_context_budget"})
 
 # Sections whose single top item is protected from budget eviction.
-_BUDGET_PROTECTED = frozenset({"lessons", "dead_ends", "relevant_findings"})
+_BUDGET_PROTECTED = frozenset({"lessons", "dead_ends", "prior_mistakes", "relevant_findings"})
 
 
 def _content_sig(text: str) -> str:
@@ -707,7 +711,13 @@ def retrieve_task_patterns(
     time_gap_info = compute_time_gap_info(last_session_timestamp)
 
     if not get_qdrant_url():
-        return {"lessons": [], "dead_ends": [], "relevant_findings": [], "time_gap": time_gap_info}
+        return {
+            "lessons": [],
+            "dead_ends": [],
+            "prior_mistakes": [],
+            "relevant_findings": [],
+            "time_gap": time_gap_info,
+        }
 
     # Adaptive limits: scale retrieval depth by vector state
     limits = _compute_adaptive_limits(vectors, limit)
@@ -746,6 +756,22 @@ def retrieve_task_patterns(
         for d in dead_ends_raw
     ]
 
+    # Search for prior mistakes (errors to not repeat). Sibling anti-pattern to
+    # dead_ends — embedded as "{mistake} Prevention: {prevention}" (type=mistake),
+    # parsed back out the same way. Always retrieved (not opt-in): a logged mistake
+    # must nudge attention on a similar task, else mistake-log is a write-only sink.
+    mistakes_raw = _search_memory_by_type(
+        project_id, f"Mistake or pitfall doing: {task_context}", "mistake", limits["mistakes"], threshold
+    )
+    prior_mistakes = [
+        {
+            "mistake": m.get("text", "").split(" Prevention:")[0] if m.get("text") else "",
+            "prevention": m.get("text", "").split("Prevention: ")[1] if "Prevention:" in m.get("text", "") else "",
+            "score": m.get("score", 0.0),
+        }
+        for m in mistakes_raw
+    ]
+
     # Search for relevant findings (high-impact facts). Over-fetch, then re-rank
     # by recency at read-time so stale findings sink below fresh relevant ones.
     findings_raw = _search_memory_by_type(
@@ -774,6 +800,7 @@ def retrieve_task_patterns(
     result = {
         "lessons": lessons,
         "dead_ends": dead_ends,
+        "prior_mistakes": prior_mistakes,
         "relevant_findings": relevant_findings,
         "time_gap": time_gap_info,
     }
@@ -905,9 +932,9 @@ def check_against_patterns(
         include_assumptions: Include unverified assumptions as risk signal
     """
     if not get_qdrant_url():
-        return {"dead_end_matches": [], "mistake_risk": None, "has_warnings": False}
+        return {"dead_end_matches": [], "mistake_matches": [], "mistake_risk": None, "has_warnings": False}
 
-    warnings = {"dead_end_matches": [], "mistake_risk": None, "has_warnings": False}
+    warnings = {"dead_end_matches": [], "mistake_matches": [], "mistake_risk": None, "has_warnings": False}
 
     # Check if current approach matches known dead ends
     if current_approach:
@@ -922,6 +949,20 @@ def check_against_patterns(
                 "similarity": d.get("score", 0.0),
             }
             for d in dead_ends
+        ]
+
+        # Check if the current approach matches known MISTAKES (sibling anti-pattern
+        # to dead_ends — surfaced here at the point of action, not just PREFLIGHT).
+        mistakes = _search_memory_by_type(
+            project_id, f"Mistake or pitfall: {current_approach}", "mistake", limit, threshold
+        )
+        warnings["mistake_matches"] = [
+            {
+                "mistake": m.get("text", "").split(" Prevention:")[0] if m.get("text") else "",
+                "prevention": m.get("text", "").split("Prevention: ")[1] if "Prevention:" in m.get("text", "") else "",
+                "similarity": m.get("score", 0.0),
+            }
+            for m in mistakes
         ]
 
     # Check vector patterns for mistake risk
@@ -965,6 +1006,7 @@ def check_against_patterns(
     # Set has_warnings flag
     warnings["has_warnings"] = (
         bool(warnings["dead_end_matches"])
+        or bool(warnings["mistake_matches"])
         or bool(warnings["mistake_risk"])
         or bool(warnings.get("unverified_assumptions"))
     )

--- a/tests/test_retrieve_mistakes.py
+++ b/tests/test_retrieve_mistakes.py
@@ -1,0 +1,65 @@
+"""Mistake retrieval — logged mistakes surface at PREFLIGHT + CHECK.
+
+The audit found mistakes were embedded (type='mistake') but never retrieved — the
+attention-nudge orphan (dead_ends surfaced, mistakes didn't). These pin the fix:
+retrieve_task_patterns returns `prior_mistakes`, check_against_patterns returns
+`mistake_matches`, both parsed from the embedded "{mistake} Prevention: {prevention}"
+text exactly like dead_ends parse "DEAD END: ... Why failed: ...".
+"""
+
+from __future__ import annotations
+
+import empirica.core.qdrant.pattern_retrieval as pr
+
+
+def test_adaptive_limits_include_mistakes():
+    assert "mistakes" in pr._compute_adaptive_limits(None, 3)  # no-vectors path
+    limits = pr._compute_adaptive_limits({"know": 0.3, "uncertainty": 0.7, "context": 0.5}, 3)
+    assert "mistakes" in limits and limits["mistakes"] >= 1  # vectors path, scaled by know_gap
+
+
+def _fake_search(mistake_items):
+    def _f(project_id, query_text, memory_type, limit=3, min_score=0.5):
+        return mistake_items if memory_type == "mistake" else []
+
+    return _f
+
+
+def test_retrieve_task_patterns_surfaces_prior_mistakes(monkeypatch):
+    monkeypatch.setattr(pr, "get_qdrant_url", lambda: "http://fake")
+    monkeypatch.setattr(
+        pr,
+        "_search_memory_by_type",
+        _fake_search([{"text": "Ran narrow ruff Prevention: run full-tree ruff before push", "score": 0.9}]),
+    )
+    result = pr.retrieve_task_patterns("proj", "pushing a PR", vectors={"know": 0.5, "uncertainty": 0.5})
+    pm = result.get("prior_mistakes")
+    assert pm and len(pm) == 1
+    assert pm[0]["mistake"] == "Ran narrow ruff"
+    assert pm[0]["prevention"] == "run full-tree ruff before push"
+
+
+def test_check_against_patterns_surfaces_mistake_matches(monkeypatch):
+    monkeypatch.setattr(pr, "get_qdrant_url", lambda: "http://fake")
+    monkeypatch.setattr(
+        pr,
+        "_search_memory_by_type",
+        _fake_search([{"text": "Skipped CI check Prevention: always check CI after push", "score": 0.85}]),
+    )
+    w = pr.check_against_patterns("proj", current_approach="push without checking CI", vectors=None)
+    assert w["mistake_matches"] and len(w["mistake_matches"]) == 1
+    assert w["mistake_matches"][0]["mistake"] == "Skipped CI check"
+    assert w["mistake_matches"][0]["prevention"] == "always check CI after push"
+    assert w["has_warnings"] is True  # mistake_matches alone flips has_warnings
+
+
+def test_absent_mistakes_are_empty_lists_not_missing(monkeypatch):
+    monkeypatch.setattr(pr, "get_qdrant_url", lambda: "http://fake")
+    monkeypatch.setattr(pr, "_search_memory_by_type", _fake_search([]))
+    assert pr.retrieve_task_patterns("proj", "some task", vectors=None).get("prior_mistakes") == []
+    assert pr.check_against_patterns("proj", current_approach="x", vectors=None)["mistake_matches"] == []
+
+
+def test_no_qdrant_still_returns_prior_mistakes_key(monkeypatch):
+    monkeypatch.setattr(pr, "get_qdrant_url", lambda: None)  # qdrant unavailable
+    assert "prior_mistakes" in pr.retrieve_task_patterns("proj", "task")


### PR DESCRIPTION
## The gap (audit finding)

The attention-nudge mechanism was running **at half-mast**: `mistake-log` embeds mistakes for semantic search ("Auto-embedded…"), but **nothing ever retrieved them**. `retrieve_task_patterns` (PREFLIGHT) and `check_against_patterns` (CHECK) had no mistakes path at all:

| anti-pattern | logged | embedded | **surfaced at PREFLIGHT/CHECK?** |
|---|---|---|---|
| dead-end | ✅ | ✅ | ✅ |
| **mistake** | ✅ | ✅ | ❌ **never** |

So "log a mistake so it reminds you next time" was structurally broken — a write-only sink.

## The fix (Component A)

Retrieve mistakes as a **first-class anti-pattern, mirroring dead-ends exactly**:
- `retrieve_task_patterns` → **`prior_mistakes`** in the base result (always retrieved, not behind an opt-in flag — dead-ends aren't either), parsed from the embedded `"{mistake} Prevention: {prevention}"` text
- `check_against_patterns` → **`mistake_matches`** at the point of action; flips `has_warnings`
- `_compute_adaptive_limits`: `mistakes` section scaled by `know_gap` (low knowledge → more warnings)
- `_SECTION_TEXT_FIELDS` mapping + `_BUDGET_PROTECTED` (an anti-pattern shouldn't be evicted before it can nudge)

**Purely additive** — the mistakes collection, embeddings, and `_search_memory_by_type(type='mistake')` all already existed; this wires the retrieval that never asked. No storage changes.

## Tests

`tests/test_retrieve_mistakes.py` — adaptive-limits include mistakes, PREFLIGHT `prior_mistakes` parsing, CHECK `mistake_matches` + `has_warnings`, empty-list consistency, no-qdrant path. Regression: recency-ranking tests still green. Full CI lint gate (ruff check + ruff format --check, full-tree) + pyright verified locally.

## Context

Component **A** of the epistemic-attention gap (goal `fb845b12`). Follow-ups: **B** — bring the blindspot predictor in-repo as a first-class citizen (currently an absent external sibling package); **C** — cross-artifact-set blindspot detection (the new relational layer). The mistake corpus this PR unlocks is exactly what C's relational analysis reasons over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)