### PR TITLE
fix(hooks): inbox-lead surfaces the full proposal id (not [:26]) (#267 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **SessionStart inbox-lead truncated proposal IDs, breaking `mailbox reply`.**
+  The pending-mesh-messages block sliced the proposal id to 26 chars (`[:26]`),
+  but real ids are `prop_` + 26 = 31 chars — so the surfaced id lost its last 5
+  and failed the `mailbox show <id>` / `reply --parent-id <id>` commands the block
+  itself instructs you to run. Now shows the full id. Regression test added with a
+  real-length id (prior fixtures used short ids that never hit the cut). (#267 follow-up.)
 - **Logged mistakes now surface at PREFLIGHT + CHECK (they never did).** An audit
   found the attention-nudge mechanism ran at half-mast: `mistake-log` embedded
   mistakes for semantic search, but the retrieval (`retrieve_task_patterns` /

--- a/empirica/plugins/claude-code-integration/hooks/ewm-protocol-loader.py
+++ b/empirica/plugins/claude-code-integration/hooks/ewm-protocol-loader.py
@@ -409,7 +409,10 @@ def _build_pending_inbox_lead() -> str:
     shown = proposals[:8]
     lines = [f"## 📬 Pending mesh messages ({total}) — handle these FIRST", ""]
     for p in shown:
-        pid = str(p.get("id") or "")[:26]
+        # Full id, NOT truncated: it's copied verbatim into `mailbox show <id>` /
+        # `reply --parent-id <id>`. Real ids are "prop_" + 26 chars (31); a [:26]
+        # slice dropped the last 5 and broke those commands (#267 regression).
+        pid = str(p.get("id") or "")
         src = p.get("source_claude") or "?"
         status = p.get("status") or "?"
         ptype = p.get("type") or "?"

--- a/tests/test_ewm_inbox_lead.py
+++ b/tests/test_ewm_inbox_lead.py
@@ -62,6 +62,21 @@ def test_renders_pending_messages(monkeypatch):
     assert "empirica mailbox reply" in out
 
 
+def test_full_length_proposal_id_is_not_truncated(monkeypatch):
+    # Regression (#267): real ids are "prop_" + 26 chars (31 total). A [:26] slice
+    # dropped the last 5, so the surfaced id failed the `mailbox show/reply` commands
+    # the block tells you to run. Prior fixtures used short ids (prop_01) and missed it.
+    mod = _load_hook()
+    monkeypatch.setattr(mod, "_resolve_ai_id_for_poll", lambda: "empirica")
+    full_id = "prop_6g73eoci7ngz3kcvd7aw6ktdqu"  # 31 chars
+    assert len(full_id) == 31
+    p = _prop(1)
+    p["id"] = full_id
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: _fake_run(_poll_json([p])))
+    out = mod._build_pending_inbox_lead()
+    assert full_id in out  # complete id, copyable into `mailbox reply --parent-id`
+
+
 def test_caps_at_eight_with_overflow_pointer(monkeypatch):
     mod = _load_hook()
     monkeypatch.setattr(mod, "_resolve_ai_id_for_poll", lambda: "empirica")


### PR DESCRIPTION
## Bug (mesh-reported, confirmed)

The SessionStart inbox-lead (#267) sliced each proposal id to 26 chars:
```python
pid = str(p.get("id") or "")[:26]
```
Real ids are `prop_` + 26 = **31 chars**, so `[:26]` dropped the last 5. The block then renders `**[<truncated-id>]**` and instructs you to run `mailbox show <id>` / `reply --parent-id <id>` with it — which **fail**, because the id is wrong.

## Fix

Show the full id (the title and summary are already width-managed; the id sits alone in `[...]`).

## Why it shipped

`tests/test_ewm_inbox_lead.py` fixtures used short ids (`prop_01`, 8 chars) that never reached the 26-char cut. Added a regression test with a real-length 31-char id asserting it survives intact. Full CI lint gate (ruff check + format) + pyright verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)