### PR TITLE
feat(blindspots): scaffold + intent-gap detector (blindspot-scan dry-run) — T1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Blindspot detection — scaffold + intent-gap signal (`empirica blindspot-scan`,
+  dry-run).** First step toward inferring unknown-unknowns from the artifact corpus.
+  A blindspot is *absent + unacknowledged + inferred* — and the least-noisy signal
+  is against **stated intent**: an open goal/task with no covering finding, no
+  acknowledging `unknown`, and no attempt (the per-task finding/unknown/dead_end
+  lists are the mask). New `empirica/core/blindspots/` module with a pure,
+  unit-tested `detect_intent_gaps()`. `blindspot-scan` reports candidates for a
+  session (human/JSON) — **dry-run only**: wired to nobody (no CHECK nudge, no
+  persistence) until later transactions. Explicitly **not** keyword/ontology based.
+
 ### Fixed
 - **Logged mistakes now surface at PREFLIGHT + CHECK (they never did).** An audit
   found the attention-nudge mechanism ran at half-mast: `mistake-log` embedded

--- a/empirica/cli/cli_core.py
+++ b/empirica/cli/cli_core.py
@@ -394,6 +394,7 @@ _HELP_CATEGORIES = {
         "source-archive",
         "source-update",
         "enforcement-report",
+        "blindspot-scan",
         "act-log",
         "investigate-log",
         "log-artifacts",
@@ -904,6 +905,7 @@ def main(args=None):
             "source-archive": handle_source_archive_command,
             "source-update": handle_source_update_command,
             "enforcement-report": handle_enforcement_report_command,
+            "blindspot-scan": handle_blindspot_scan_command,
             "epp-activate": handle_epp_activate_command,
             # Training data export
             "training-export": handle_training_export_command,

--- a/empirica/cli/command_handlers/__init__.py
+++ b/empirica/cli/command_handlers/__init__.py
@@ -25,6 +25,7 @@ from .artifact_log_commands import (
     handle_unknown_resolve_command,
 )
 from .artifacts_commands import handle_artifacts_generate_command
+from .blindspot_commands import handle_blindspot_scan_command
 from .checkpoint_commands import (
     handle_checkpoint_create_command,
     handle_checkpoint_diff_command,
@@ -496,6 +497,7 @@ __all__ = [  # noqa: RUF022
     "handle_sources_check_command",
     "handle_source_update_command",
     "handle_enforcement_report_command",
+    "handle_blindspot_scan_command",
     "handle_sources_reconcile_command",
     # Sync commands (git notes synchronization)
     "handle_sync_config_command",

--- a/empirica/cli/command_handlers/blindspot_commands.py
+++ b/empirica/cli/command_handlers/blindspot_commands.py
@@ -1,0 +1,60 @@
+"""`empirica blindspot-scan` — dry-run blindspot detection.
+
+Surfaces predicted unknown-unknowns for a session: stated goals/tasks with no
+covering artifact and no acknowledging unknown (the intent-gap signal). DRY-RUN —
+reports only, wired to nobody (no CHECK nudge, no persistence) until the surfacing
+transactions. Human + JSON. Defaults to the current session.
+"""
+
+from __future__ import annotations
+
+import json
+
+
+def _read_intent_gaps(db, session_id: str) -> list[dict]:
+    """Read the session's goal tree and detect intent-gap candidates. Degrades to
+    [] on any read error — a scan must never raise."""
+    try:
+        from empirica.core.blindspots import detect_intent_gaps
+
+        tree = db.goals.get_goal_tree(session_id)
+        return detect_intent_gaps(tree)
+    except Exception:
+        return []
+
+
+def handle_blindspot_scan_command(args) -> None:
+    """Render the dry-run blindspot scan (human or JSON)."""
+    from empirica.data.session_database import SessionDatabase
+    from empirica.utils.session_resolver import InstanceResolver as R
+
+    session_id = getattr(args, "session_id", None) or R.session_id()
+    if not session_id:
+        msg = {"ok": False, "error": "no session_id (pass --session-id or run inside an active session)"}
+        print(json.dumps(msg) if getattr(args, "output", "human") == "json" else f"⚠️  {msg['error']}")
+        return
+
+    db = SessionDatabase()
+    try:
+        gaps = _read_intent_gaps(db, session_id)
+    finally:
+        db.close()
+
+    if getattr(args, "output", "human") == "json":
+        print(json.dumps({"session_id": session_id, "intent_gaps": gaps, "count": len(gaps)}, indent=2))
+        return
+
+    print("\n🔦 Blindspot Scan — intent gaps (dry-run)")
+    print("━" * 60)
+    if not gaps:
+        print("  no intent gaps — every open task carries a finding, unknown, or attempt")
+        print("━" * 60)
+        return
+    print(f"{len(gaps)} predicted blindspot(s) — stated intent with no coverage and no acknowledged unknown:\n")
+    for g in gaps:
+        print(f"  • {g['intent']}")
+        print(f"      under goal: {g['objective']}")
+        print(f"      {g['reason']}")
+    print("━" * 60)
+    print("Dry-run only — surface an `unknown` to acknowledge one, or dismiss it.")
+    print("━" * 60)

--- a/empirica/cli/parsers/checkpoint_parsers.py
+++ b/empirica/cli/parsers/checkpoint_parsers.py
@@ -1452,6 +1452,18 @@ def add_checkpoint_parsers(subparsers):
     enforcement_report_parser.add_argument("--session-id", help="Scope to one session (default: all recorded verdicts)")
     enforcement_report_parser.add_argument("--output", choices=["human", "json"], default="human", help="Output format")
 
+    # Blindspot scan (dry-run unknown-unknown detection — intent-gap signal)
+    blindspot_scan_parser = subparsers.add_parser(
+        "blindspot-scan",
+        help=(
+            "Dry-run blindspot detection: predicted unknown-unknowns for a session — "
+            "stated goals/tasks with no covering artifact and no acknowledging unknown "
+            "(the intent-gap signal). Reports only; wired to nobody yet."
+        ),
+    )
+    blindspot_scan_parser.add_argument("--session-id", help="Session to scan (default: current session)")
+    blindspot_scan_parser.add_argument("--output", choices=["human", "json"], default="human", help="Output format")
+
     # Sources reconcile (unified source identity — adopt catalogue uuids)
     sources_reconcile_parser = subparsers.add_parser(
         "sources-reconcile",

--- a/empirica/core/blindspots/__init__.py
+++ b/empirica/core/blindspots/__init__.py
@@ -1,0 +1,25 @@
+"""Blindspot detection — inferring unknown-unknowns from the artifact corpus.
+
+A blindspot is a **predicted-necessary assessment that is absent, unacknowledged,
+and inferred from the artifacts themselves** — the negative space of what the
+practice has logged. Unlike an ``unknown`` (a known-unknown: an acknowledged gap),
+a blindspot is an UNacknowledged gap the corpus predicts should be filled.
+
+Candidate generation is deliberately NOT keyword/ontology based (brittle, fires on
+vocabulary coincidence). It is inferred from the corpus, cheapest-and-least-noisy
+signal first:
+
+1. **intent-gap** (this module) — a stated goal/task with no covering artifact and
+   no acknowledging unknown. Measured against the practice's own declared intent,
+   so it is the highest-confidence signal. Ships first, dry-run.
+2. co-occurrence — what work shaped like this usually assessed that this hasn't (T5).
+3. fossils — where mistakes/dead-ends historically materialized (T6).
+
+See ``docs`` / the blindspot goal for the full transaction plan.
+"""
+
+from __future__ import annotations
+
+from .intent_gap import detect_intent_gaps
+
+__all__ = ["detect_intent_gaps"]

--- a/empirica/core/blindspots/intent_gap.py
+++ b/empirica/core/blindspots/intent_gap.py
@@ -1,0 +1,63 @@
+"""Intent-gap blindspot detection — the least-noisy signal.
+
+A blindspot is *absent + unacknowledged + inferred*. The strongest, lowest-noise
+inference is against **stated intent**: a goal/task the practice declared it would
+address, that has no covering artifact AND no acknowledging unknown. You said
+you'd assess X; nothing shows you did; you never flagged X as open.
+
+Pure function over ``GoalDataRepository.get_goal_tree(session_id)`` — no DB, no
+embeddings, unit-testable. The per-subtask ``findings`` / ``unknowns`` /
+``dead_ends`` lists ARE the mask:
+
+- a **finding** means it's covered → not a blindspot
+- an **unknown** means it's acknowledged → a known-unknown, not a blindspot
+- a **dead_end** means it was attempted → not an untouched gap
+
+so a candidate is an *open* subtask, under a *non-terminal* goal, with all three
+empty.
+"""
+
+from __future__ import annotations
+
+# Terminal states — no intent-gap possible (the work is done or abandoned).
+_TERMINAL_GOAL_STATUS = frozenset({"completed", "complete", "done", "abandoned", "cancelled", "stale"})
+_TERMINAL_TASK_STATUS = frozenset({"completed", "complete", "done", "cancelled", "abandoned"})
+
+
+def detect_intent_gaps(goal_tree: list[dict] | None) -> list[dict]:
+    """Return intent-gap blindspot candidates from a session's goal tree.
+
+    ``goal_tree`` — the output of ``GoalDataRepository.get_goal_tree(session_id)``:
+    a list of goal dicts, each with a nested ``subtasks`` list whose items carry
+    ``description`` / ``status`` / ``findings`` / ``unknowns`` / ``dead_ends``.
+
+    A candidate is an open subtask (non-terminal status) under a non-terminal goal
+    whose findings, unknowns, and dead_ends are all empty — stated intent with no
+    coverage, no acknowledgment, and no attempt. Conservative by design: any of the
+    three lists being non-empty masks the subtask out.
+    """
+    candidates: list[dict] = []
+    for goal in goal_tree or []:
+        if (goal.get("status") or "").strip().lower() in _TERMINAL_GOAL_STATUS:
+            continue
+        objective = goal.get("objective") or ""
+        for st in goal.get("subtasks") or []:
+            if (st.get("status") or "").strip().lower() in _TERMINAL_TASK_STATUS:
+                continue
+            # The mask: covered (finding) / acknowledged (unknown) / attempted (dead_end).
+            if st.get("findings") or st.get("unknowns") or st.get("dead_ends"):
+                continue
+            candidates.append(
+                {
+                    "kind": "intent_gap",
+                    "goal_id": goal.get("goal_id"),
+                    "objective": objective,
+                    "subtask_id": st.get("subtask_id"),
+                    "intent": st.get("description") or "",
+                    "reason": (
+                        "stated task with no covering finding, no acknowledging unknown, "
+                        "and no attempt — you may be proceeding as if it's handled"
+                    ),
+                }
+            )
+    return candidates

--- a/tests/test_blindspot_intent_gap.py
+++ b/tests/test_blindspot_intent_gap.py
@@ -1,0 +1,79 @@
+"""Intent-gap blindspot detection — the least-noisy unknown-unknown signal.
+
+A candidate is an OPEN subtask under a non-terminal goal whose findings, unknowns,
+and dead_ends are all empty (stated intent, no coverage, no acknowledgment, no
+attempt). Any of the three lists — or a terminal status — masks it out.
+"""
+
+from __future__ import annotations
+
+from empirica.core.blindspots import detect_intent_gaps
+
+
+def _goal(status="active", subtasks=None, objective="Ship X"):
+    return {"goal_id": "g1", "objective": objective, "status": status, "subtasks": subtasks or []}
+
+
+def _sub(status="pending", findings=None, unknowns=None, dead_ends=None, desc="assess Y"):
+    return {
+        "subtask_id": "s1",
+        "description": desc,
+        "status": status,
+        "findings": findings or [],
+        "unknowns": unknowns or [],
+        "dead_ends": dead_ends or [],
+    }
+
+
+def test_open_uncovered_unacknowledged_subtask_is_a_candidate():
+    gaps = detect_intent_gaps([_goal(subtasks=[_sub()])])
+    assert len(gaps) == 1
+    g = gaps[0]
+    assert g["kind"] == "intent_gap"
+    assert g["intent"] == "assess Y"
+    assert g["objective"] == "Ship X"
+    assert g["subtask_id"] == "s1"
+
+
+def test_finding_masks_it_covered():
+    assert detect_intent_gaps([_goal(subtasks=[_sub(findings=["found something"])])]) == []
+
+
+def test_unknown_masks_it_acknowledged():
+    # an acknowledged gap is a known-unknown, not a blindspot
+    assert detect_intent_gaps([_goal(subtasks=[_sub(unknowns=["what about Z?"])])]) == []
+
+
+def test_dead_end_masks_it_attempted():
+    assert detect_intent_gaps([_goal(subtasks=[_sub(dead_ends=["tried A, failed"])])]) == []
+
+
+def test_terminal_subtask_status_masks_it():
+    for st in ("completed", "complete", "done", "cancelled", "abandoned"):
+        assert detect_intent_gaps([_goal(subtasks=[_sub(status=st)])]) == [], st
+
+
+def test_terminal_goal_status_masks_all_its_subtasks():
+    for st in ("completed", "abandoned", "cancelled", "stale", "done"):
+        assert detect_intent_gaps([_goal(status=st, subtasks=[_sub()])]) == [], st
+
+
+def test_empty_and_none_tree():
+    assert detect_intent_gaps([]) == []
+    assert detect_intent_gaps(None) == []
+
+
+def test_multiple_goals_only_uncovered_open_subtasks():
+    tree = [
+        _goal(objective="A", subtasks=[_sub(desc="a1"), _sub(desc="a2", findings=["x"])]),  # a1 gap, a2 covered
+        _goal(objective="B", status="completed", subtasks=[_sub(desc="b1")]),  # goal terminal → skip
+    ]
+    gaps = detect_intent_gaps(tree)
+    assert [g["intent"] for g in gaps] == ["a1"]
+
+
+def test_missing_status_treated_as_open():
+    # a subtask/goal with no status is non-terminal → still a candidate
+    sub = {"subtask_id": "s", "description": "d", "findings": [], "unknowns": [], "dead_ends": []}
+    goal = {"goal_id": "g", "objective": "o", "subtasks": [sub]}
+    assert len(detect_intent_gaps([goal])) == 1


### PR DESCRIPTION
First transaction of the blindspot build (goal `fb845b12`). Ships the module scaffold and the **least-noisy signal**, as a **dry-run** — instrument-and-eyeball before we ever nudge, same discipline as enforce.

## What a blindspot is (the definition we're building to)

*A predicted-necessary assessment that is **absent**, **unacknowledged**, and **inferred from the artifact corpus** — the negative space of what the practice logged.* Unlike an `unknown` (a known-unknown — an acknowledged gap), a blindspot is an **un**acknowledged gap.

## T1 — the intent-gap signal

The strongest, lowest-noise inference is against **stated intent**: an open goal/task with no covering finding, no acknowledging `unknown`, and no attempt. You said you'd assess X; nothing shows you did; you never flagged X as open.

- `empirica/core/blindspots/` — first-class, in-repo. Pure `detect_intent_gaps(goal_tree)` over `GoalDataRepository.get_goal_tree` — no embeddings, unit-testable. The per-subtask `findings` / `unknowns` / `dead_ends` lists are the **mask** (covered / acknowledged→known-unknown / attempted).
- `empirica blindspot-scan` — dry-run report (human/JSON), defaults to the current session. **Wired to nobody**: no CHECK nudge, no persistence, until T3/T2.
- Explicitly **not** keyword/ontology based — that brittleness is exactly what we're avoiding.

## Validated end-to-end

The dry-run surfaces real intent-gaps on a live session (planned subtasks left without coverage — the exact epistemic-hygiene gap it's meant to catch). 9 unit tests + 35 CLI-invariant tests green; full CI lint gate (ruff check + format) + pyright clean.

## Next in the plan
T2 persistence + `blindspot-report` telemetry · T3 CHECK advisory nudge · T4 POSTFLIGHT outcome/regret loop · T5 co-occurrence · T6 fossils + topology adaptation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)