### PR TITLE
feat(blindspots): persistence + telemetry + active-goal scoping — T2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Blindspot detection — persistence + telemetry + active-goal scoping (T2).**
+  `blindspot_events` (migration 053) is the durable, **fail-open** substrate for
+  blindspot outcomes (surfaced / acknowledged / dismissed / regretted); a new
+  `empirica blindspot-report` renders the telemetry (acknowledge-rate = the nudge
+  is useful; regret-rate = dismissed ones that later became mistakes/dead-ends).
+  Instrument-before-surface, the enforce-telemetry playbook. `detect_intent_gaps`
+  now scopes to **active goals by default** (excludes dormant `planned` backlog —
+  a dry-run inspection showed planned-goal subtasks are task-hygiene, not
+  unknown-unknowns); `blindspot-scan --include-planned` gives the full backlog
+  view. Verified: active-scope narrowed a live session from 9 candidates to the 2
+  genuinely-forward-looking ones.
 - **Blindspot detection — scaffold + intent-gap signal (`empirica blindspot-scan`,
   dry-run).** First step toward inferring unknown-unknowns from the artifact corpus.
   A blindspot is *absent + unacknowledged + inferred* — and the least-noisy signal

--- a/empirica/cli/cli_core.py
+++ b/empirica/cli/cli_core.py
@@ -395,6 +395,7 @@ _HELP_CATEGORIES = {
         "source-update",
         "enforcement-report",
         "blindspot-scan",
+        "blindspot-report",
         "act-log",
         "investigate-log",
         "log-artifacts",
@@ -906,6 +907,7 @@ def main(args=None):
             "source-update": handle_source_update_command,
             "enforcement-report": handle_enforcement_report_command,
             "blindspot-scan": handle_blindspot_scan_command,
+            "blindspot-report": handle_blindspot_report_command,
             "epp-activate": handle_epp_activate_command,
             # Training data export
             "training-export": handle_training_export_command,

--- a/empirica/cli/command_handlers/__init__.py
+++ b/empirica/cli/command_handlers/__init__.py
@@ -25,7 +25,7 @@ from .artifact_log_commands import (
     handle_unknown_resolve_command,
 )
 from .artifacts_commands import handle_artifacts_generate_command
-from .blindspot_commands import handle_blindspot_scan_command
+from .blindspot_commands import handle_blindspot_report_command, handle_blindspot_scan_command
 from .checkpoint_commands import (
     handle_checkpoint_create_command,
     handle_checkpoint_diff_command,
@@ -498,6 +498,7 @@ __all__ = [  # noqa: RUF022
     "handle_source_update_command",
     "handle_enforcement_report_command",
     "handle_blindspot_scan_command",
+    "handle_blindspot_report_command",
     "handle_sources_reconcile_command",
     # Sync commands (git notes synchronization)
     "handle_sync_config_command",

--- a/empirica/cli/command_handlers/blindspot_commands.py
+++ b/empirica/cli/command_handlers/blindspot_commands.py
@@ -11,14 +11,15 @@ from __future__ import annotations
 import json
 
 
-def _read_intent_gaps(db, session_id: str) -> list[dict]:
+def _read_intent_gaps(db, session_id: str, active_only: bool = True) -> list[dict]:
     """Read the session's goal tree and detect intent-gap candidates. Degrades to
-    [] on any read error — a scan must never raise."""
+    [] on any read error — a scan must never raise. ``active_only`` excludes dormant
+    ``planned`` goals (backlog, not a blindspot in active work)."""
     try:
         from empirica.core.blindspots import detect_intent_gaps
 
         tree = db.goals.get_goal_tree(session_id)
-        return detect_intent_gaps(tree)
+        return detect_intent_gaps(tree, active_only=active_only)
     except Exception:
         return []
 
@@ -34,9 +35,10 @@ def handle_blindspot_scan_command(args) -> None:
         print(json.dumps(msg) if getattr(args, "output", "human") == "json" else f"⚠️  {msg['error']}")
         return
 
+    active_only = not getattr(args, "include_planned", False)
     db = SessionDatabase()
     try:
-        gaps = _read_intent_gaps(db, session_id)
+        gaps = _read_intent_gaps(db, session_id, active_only=active_only)
     finally:
         db.close()
 
@@ -44,7 +46,8 @@ def handle_blindspot_scan_command(args) -> None:
         print(json.dumps({"session_id": session_id, "intent_gaps": gaps, "count": len(gaps)}, indent=2))
         return
 
-    print("\n🔦 Blindspot Scan — intent gaps (dry-run)")
+    scope = "active goals" if active_only else "all goals (incl. planned backlog)"
+    print(f"\n🔦 Blindspot Scan — intent gaps ({scope}, dry-run)")
     print("━" * 60)
     if not gaps:
         print("  no intent gaps — every open task carries a finding, unknown, or attempt")
@@ -57,4 +60,40 @@ def handle_blindspot_scan_command(args) -> None:
         print(f"      {g['reason']}")
     print("━" * 60)
     print("Dry-run only — surface an `unknown` to acknowledge one, or dismiss it.")
+    print("━" * 60)
+
+
+def handle_blindspot_report_command(args) -> None:
+    """Blindspot telemetry — surfaced / acknowledged / dismissed / regretted."""
+    from empirica.core.blindspots import aggregate_blindspot_events, read_blindspot_events
+    from empirica.data.session_database import SessionDatabase
+
+    session_id = getattr(args, "session_id", None)
+    db = SessionDatabase()
+    try:
+        rows = read_blindspot_events(db, session_id)
+    finally:
+        db.close()
+    summary = aggregate_blindspot_events(rows)
+
+    if getattr(args, "output", "human") == "json":
+        print(json.dumps(summary, indent=2))
+        return
+
+    print("\n🔦 Blindspot Report — outcomes")
+    print("━" * 60)
+    if summary["total"] == 0:
+        print("  (no blindspot events recorded yet — instrument is armed, nothing surfaced)")
+        print("━" * 60)
+        return
+    print(f"Surfaced:          {summary['total']}")
+    for outcome, n in sorted(summary["by_outcome"].items()):
+        print(f"  {outcome:<16} {n}")
+    ack, reg = summary["acknowledge_rate"], summary["regret_rate"]
+    if ack is not None:
+        print(f"Acknowledge rate:  {ack * 100:.0f}%  (surfaced → practitioner logged an unknown / acted)")
+    if reg is not None:
+        print(f"Regret rate:       {reg * 100:.0f}%  (dismissed → later became a mistake/dead-end)")
+    if summary["by_kind"]:
+        print("By signal:         " + ", ".join(f"{k}={v}" for k, v in sorted(summary["by_kind"].items())))
     print("━" * 60)

--- a/empirica/cli/parsers/checkpoint_parsers.py
+++ b/empirica/cli/parsers/checkpoint_parsers.py
@@ -1462,7 +1462,24 @@ def add_checkpoint_parsers(subparsers):
         ),
     )
     blindspot_scan_parser.add_argument("--session-id", help="Session to scan (default: current session)")
+    blindspot_scan_parser.add_argument(
+        "--include-planned",
+        action="store_true",
+        help="Include dormant 'planned' goals (backlog view); default scans active goals only",
+    )
     blindspot_scan_parser.add_argument("--output", choices=["human", "json"], default="human", help="Output format")
+
+    # Blindspot report (telemetry — surfaced/acknowledged/dismissed/regretted)
+    blindspot_report_parser = subparsers.add_parser(
+        "blindspot-report",
+        help=(
+            "Blindspot telemetry: surfaced / acknowledged / dismissed / regretted rates "
+            "from blindspot_events. acknowledge-rate = the nudge is useful; regret-rate = "
+            "dismissed ones that later became mistakes/dead-ends."
+        ),
+    )
+    blindspot_report_parser.add_argument("--session-id", help="Scope to one session (default: all events)")
+    blindspot_report_parser.add_argument("--output", choices=["human", "json"], default="human", help="Output format")
 
     # Sources reconcile (unified source identity — adopt catalogue uuids)
     sources_reconcile_parser = subparsers.add_parser(

--- a/empirica/core/blindspots/__init__.py
+++ b/empirica/core/blindspots/__init__.py
@@ -21,5 +21,15 @@ See ``docs`` / the blindspot goal for the full transaction plan.
 from __future__ import annotations
 
 from .intent_gap import detect_intent_gaps
+from .persist import (
+    aggregate_blindspot_events,
+    persist_blindspot_candidates,
+    read_blindspot_events,
+)
 
-__all__ = ["detect_intent_gaps"]
+__all__ = [
+    "aggregate_blindspot_events",
+    "detect_intent_gaps",
+    "persist_blindspot_candidates",
+    "read_blindspot_events",
+]

--- a/empirica/core/blindspots/intent_gap.py
+++ b/empirica/core/blindspots/intent_gap.py
@@ -22,9 +22,13 @@ from __future__ import annotations
 # Terminal states — no intent-gap possible (the work is done or abandoned).
 _TERMINAL_GOAL_STATUS = frozenset({"completed", "complete", "done", "abandoned", "cancelled", "stale"})
 _TERMINAL_TASK_STATUS = frozenset({"completed", "complete", "done", "cancelled", "abandoned"})
+# Dormant — logged but not started. A planned goal's untouched subtasks are backlog,
+# not a blindspot in the work you're doing now. Excluded from the nudge by default
+# (inspection finding: firing on stale backlog trains dismissal). See ``active_only``.
+_DORMANT_GOAL_STATUS = frozenset({"planned"})
 
 
-def detect_intent_gaps(goal_tree: list[dict] | None) -> list[dict]:
+def detect_intent_gaps(goal_tree: list[dict] | None, active_only: bool = True) -> list[dict]:
     """Return intent-gap blindspot candidates from a session's goal tree.
 
     ``goal_tree`` — the output of ``GoalDataRepository.get_goal_tree(session_id)``:
@@ -35,10 +39,17 @@ def detect_intent_gaps(goal_tree: list[dict] | None) -> list[dict]:
     whose findings, unknowns, and dead_ends are all empty — stated intent with no
     coverage, no acknowledgment, and no attempt. Conservative by design: any of the
     three lists being non-empty masks the subtask out.
+
+    ``active_only`` (default True) additionally skips **dormant ``planned`` goals** —
+    a not-yet-started goal's subtasks are backlog, not a blindspot in active work.
+    Pass ``active_only=False`` for a full backlog view (the ``--include-planned`` scan flag).
     """
     candidates: list[dict] = []
     for goal in goal_tree or []:
-        if (goal.get("status") or "").strip().lower() in _TERMINAL_GOAL_STATUS:
+        status = (goal.get("status") or "").strip().lower()
+        if status in _TERMINAL_GOAL_STATUS:
+            continue
+        if active_only and status in _DORMANT_GOAL_STATUS:
             continue
         objective = goal.get("objective") or ""
         for st in goal.get("subtasks") or []:

--- a/empirica/core/blindspots/persist.py
+++ b/empirica/core/blindspots/persist.py
@@ -1,0 +1,102 @@
+"""Persistence + aggregation for blindspot events (migration 053).
+
+Instrument-before-surface: ``persist_blindspot_candidates`` records surfaced
+candidates **fail-open** (a persistence error must never affect CHECK/POSTFLIGHT);
+``aggregate_blindspot_events`` powers the ``blindspot-report`` telemetry. The
+outcome starts ``surfaced`` and is advanced later — ``acknowledged`` when the
+practitioner logs an unknown for it, ``dismissed`` when ignored, ``regretted``
+when a dismissed one later becomes a mistake or dead-end (the T4 regret loop).
+"""
+
+from __future__ import annotations
+
+import time
+
+_EVENT_COLS = (
+    "session_id",
+    "transaction_id",
+    "created_timestamp",
+    "kind",
+    "goal_id",
+    "subtask_id",
+    "intent",
+    "surfaced_at",
+    "outcome",
+    "resolved_timestamp",
+)
+
+
+def persist_blindspot_candidates(db, session_id, transaction_id, candidates, surfaced_at) -> int:
+    """Record each candidate as a ``blindspot_events`` row (outcome=``surfaced``).
+
+    FAIL-OPEN — returns the number persisted, or 0 on any error (including a
+    missing table on an un-migrated DB). Never raises: the blindspot machinery
+    must not brick the loop it observes.
+    """
+    try:
+        now = time.time()
+        rows = [
+            (
+                session_id,
+                transaction_id,
+                now,
+                c.get("kind"),
+                c.get("goal_id"),
+                c.get("subtask_id"),
+                c.get("intent"),
+                surfaced_at,
+                "surfaced",
+            )
+            for c in (candidates or [])
+        ]
+        if not rows:
+            return 0
+        db.conn.executemany(
+            "INSERT INTO blindspot_events "
+            "(session_id, transaction_id, created_timestamp, kind, goal_id, subtask_id, "
+            "intent, surfaced_at, outcome) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            rows,
+        )
+        db.conn.commit()
+        return len(rows)
+    except Exception:
+        return 0
+
+
+def read_blindspot_events(db, session_id: str | None = None) -> list[dict]:
+    """Read blindspot_events (optionally scoped to a session). [] on any error."""
+    try:
+        sql = f"SELECT {', '.join(_EVENT_COLS)} FROM blindspot_events"
+        params: tuple = ()
+        if session_id:
+            sql += " WHERE session_id = ?"
+            params = (session_id,)
+        cur = db.conn.execute(sql, params)
+        return [dict(zip(_EVENT_COLS, row)) for row in cur.fetchall()]
+    except Exception:
+        return []
+
+
+def aggregate_blindspot_events(rows: list[dict]) -> dict:
+    """Aggregate into telemetry: totals, by-outcome, by-kind, acknowledge/regret rate.
+
+    - **acknowledge-rate** — of surfaced, how many were acted on (an ``unknown``
+      logged / investigated). High = the nudge is useful.
+    - **regret-rate** — of surfaced, how many were dismissed and *then* became a
+      mistake/dead-end. High = we were right and got ignored (surface louder).
+    - low acknowledge + low regret = crying wolf (surface quieter / raise the bar).
+    """
+    by_outcome: dict[str, int] = {}
+    by_kind: dict[str, int] = {}
+    for r in rows or []:
+        by_outcome[r.get("outcome") or "surfaced"] = by_outcome.get(r.get("outcome") or "surfaced", 0) + 1
+        by_kind[r.get("kind") or "unknown"] = by_kind.get(r.get("kind") or "unknown", 0) + 1
+    total = len(rows or [])
+    return {
+        "total": total,
+        "by_outcome": by_outcome,
+        "by_kind": by_kind,
+        "acknowledge_rate": round(by_outcome.get("acknowledged", 0) / total, 3) if total else None,
+        "dismiss_rate": round(by_outcome.get("dismissed", 0) / total, 3) if total else None,
+        "regret_rate": round(by_outcome.get("regretted", 0) / total, 3) if total else None,
+    }

--- a/empirica/data/migrations/migrations.py
+++ b/empirica/data/migrations/migrations.py
@@ -1476,6 +1476,11 @@ ALL_MIGRATIONS: list[tuple[str, str, Callable]] = [
         "Create weave_enforce_events — durable telemetry for the artifact-graph gate. The weave-enforce verdict at CHECK (connectivity vs floor, band, block/override) was computed transiently and never persisted; this table is the durable record one row per CHECK, written fail-open. Feeds enforcement-report telemetry and the adaptive-enforcement (patience) consecutive-miss history.",
         lambda cursor: migration_052_weave_enforce_events(cursor),
     ),
+    (
+        "053_blindspot_events",
+        "Create blindspot_events — durable substrate for blindspot detection: surfaced candidates + outcome (surfaced/acknowledged/dismissed/regretted). Written fail-open. Feeds blindspot-report telemetry and the POSTFLIGHT regret loop (a dismissed blindspot that later became a mistake/dead-end). Instrument-before-surface.",
+        lambda cursor: migration_053_blindspot_events(cursor),
+    ),
 ]
 
 
@@ -2066,6 +2071,43 @@ def migration_052_weave_enforce_events(cursor: sqlite3.Cursor):
     cursor.execute("CREATE INDEX IF NOT EXISTS idx_weave_events_txn ON weave_enforce_events(transaction_id)")
     cursor.execute("CREATE INDEX IF NOT EXISTS idx_weave_events_session ON weave_enforce_events(session_id)")
     logger.info("✅ Migration 052 complete: weave_enforce_events table created")
+
+
+def migration_053_blindspot_events(cursor: sqlite3.Cursor):
+    """Create `blindspot_events` — durable substrate for blindspot detection.
+
+    One row per surfaced blindspot candidate, plus its outcome over time. This is
+    the instrument-before-surface substrate: the ``blindspot-report`` telemetry
+    (surfaced / acknowledged / dismissed / regretted) and the POSTFLIGHT regret
+    loop (a dismissed blindspot that later became a mistake or dead-end) both read
+    it. Written fail-open — a persistence failure must never affect CHECK/POSTFLIGHT.
+
+    - ``kind``        — signal type (``intent_gap``; later ``co_occurrence`` / ``fossil``)
+    - ``surfaced_at`` — where it was raised (``scan`` / ``check`` / ``postflight``)
+    - ``outcome``     — ``surfaced`` → ``acknowledged`` (logged an unknown) / ``dismissed``
+                        / ``regretted`` (dismissed then became a mistake/dead-end)
+
+    Idempotent via CREATE TABLE IF NOT EXISTS.
+    """
+    cursor.execute("""
+        CREATE TABLE IF NOT EXISTS blindspot_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT,
+            transaction_id TEXT,
+            created_timestamp REAL NOT NULL,
+            kind TEXT,
+            goal_id TEXT,
+            subtask_id TEXT,
+            intent TEXT,
+            surfaced_at TEXT,
+            outcome TEXT NOT NULL DEFAULT 'surfaced',
+            resolved_timestamp REAL
+        )
+    """)
+    cursor.execute("CREATE INDEX IF NOT EXISTS idx_blindspot_events_txn ON blindspot_events(transaction_id)")
+    cursor.execute("CREATE INDEX IF NOT EXISTS idx_blindspot_events_session ON blindspot_events(session_id)")
+    cursor.execute("CREATE INDEX IF NOT EXISTS idx_blindspot_events_subtask ON blindspot_events(subtask_id)")
+    logger.info("✅ Migration 053 complete: blindspot_events table created")
 
 
 def migration_044_source_lifecycle(cursor: sqlite3.Cursor):

--- a/tests/test_blindspot_intent_gap.py
+++ b/tests/test_blindspot_intent_gap.py
@@ -44,6 +44,21 @@ def test_unknown_masks_it_acknowledged():
     assert detect_intent_gaps([_goal(subtasks=[_sub(unknowns=["what about Z?"])])]) == []
 
 
+def test_planned_goal_excluded_by_default():
+    # dormant 'planned' goal's untouched subtask is backlog, not an active blindspot
+    assert detect_intent_gaps([_goal(status="planned", subtasks=[_sub()])]) == []
+
+
+def test_planned_goal_included_when_active_only_false():
+    gaps = detect_intent_gaps([_goal(status="planned", subtasks=[_sub()])], active_only=False)
+    assert len(gaps) == 1  # backlog view surfaces it
+
+
+def test_in_progress_blocked_active_goals_are_in_scope():
+    for st in ("in_progress", "blocked", "active"):
+        assert len(detect_intent_gaps([_goal(status=st, subtasks=[_sub()])])) == 1, st
+
+
 def test_dead_end_masks_it_attempted():
     assert detect_intent_gaps([_goal(subtasks=[_sub(dead_ends=["tried A, failed"])])]) == []
 

--- a/tests/test_blindspot_persist.py
+++ b/tests/test_blindspot_persist.py
@@ -1,0 +1,100 @@
+"""blindspot_events persistence + aggregation (migration 053).
+
+Instrument-before-surface substrate: persist candidates fail-open, aggregate into
+the blindspot-report telemetry (acknowledge / dismiss / regret rates).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import types
+
+from empirica.core.blindspots import (
+    aggregate_blindspot_events,
+    persist_blindspot_candidates,
+    read_blindspot_events,
+)
+from empirica.data.migrations.migrations import migration_053_blindspot_events
+
+
+def _db():
+    conn = sqlite3.connect(":memory:")
+    migration_053_blindspot_events(conn.cursor())
+    conn.commit()
+    return types.SimpleNamespace(conn=conn)
+
+
+def _cand(subtask="s1", intent="assess Y"):
+    return {"kind": "intent_gap", "goal_id": "g1", "subtask_id": subtask, "intent": intent}
+
+
+def test_migration_creates_table_with_columns():
+    db = _db()
+    cols = {r[1] for r in db.conn.execute("PRAGMA table_info(blindspot_events)")}
+    assert {"session_id", "transaction_id", "kind", "goal_id", "subtask_id", "intent", "surfaced_at", "outcome"} <= cols
+
+
+def test_migration_idempotent():
+    db = _db()
+    migration_053_blindspot_events(db.conn.cursor())  # second run must not raise
+
+
+def test_persist_writes_rows_as_surfaced():
+    db = _db()
+    n = persist_blindspot_candidates(db, "sess", "tx1", [_cand("s1"), _cand("s2")], "check")
+    assert n == 2
+    rows = read_blindspot_events(db)
+    assert len(rows) == 2
+    assert all(r["outcome"] == "surfaced" and r["surfaced_at"] == "check" for r in rows)
+    assert {r["subtask_id"] for r in rows} == {"s1", "s2"}
+
+
+def test_persist_empty_is_noop():
+    db = _db()
+    assert persist_blindspot_candidates(db, "sess", "tx1", [], "check") == 0
+    assert read_blindspot_events(db) == []
+
+
+def test_persist_fail_open_missing_table():
+    conn = sqlite3.connect(":memory:")  # un-migrated
+    db = types.SimpleNamespace(conn=conn)
+    assert persist_blindspot_candidates(db, "sess", "tx1", [_cand()], "check") == 0  # no raise
+
+
+def test_persist_fail_open_db_error():
+    class Boom:
+        @property
+        def conn(self):
+            raise RuntimeError("locked")
+
+    assert persist_blindspot_candidates(Boom(), "s", "t", [_cand()], "check") == 0  # no raise
+
+
+def test_read_session_scoped():
+    db = _db()
+    persist_blindspot_candidates(db, "sA", "t", [_cand("s1")], "check")
+    persist_blindspot_candidates(db, "sB", "t", [_cand("s2")], "check")
+    assert len(read_blindspot_events(db, "sA")) == 1
+    assert len(read_blindspot_events(db)) == 2
+
+
+def test_aggregate_rates():
+    rows = [
+        {"outcome": "surfaced", "kind": "intent_gap"},
+        {"outcome": "acknowledged", "kind": "intent_gap"},
+        {"outcome": "dismissed", "kind": "intent_gap"},
+        {"outcome": "regretted", "kind": "intent_gap"},
+    ]
+    s = aggregate_blindspot_events(rows)
+    assert s["total"] == 4
+    assert s["acknowledge_rate"] == 0.25
+    assert s["dismiss_rate"] == 0.25
+    assert s["regret_rate"] == 0.25
+    assert s["by_kind"] == {"intent_gap": 4}
+
+
+def test_aggregate_empty():
+    s = aggregate_blindspot_events([])
+    assert s["total"] == 0
+    assert s["acknowledge_rate"] is None
+    assert s["regret_rate"] is None


### PR DESCRIPTION
Second transaction of the blindspot build (goal `fb845b12`). Instrument-before-surface — the enforce-telemetry playbook — plus the conservativeness refinement the T1 dry-run inspection surfaced.

## Persistence + telemetry
- **`blindspot_events` (migration 053)** — durable, **fail-open** substrate: one row per surfaced candidate + its outcome (`surfaced` → `acknowledged` / `dismissed` / `regretted`). A persistence error never affects CHECK/POSTFLIGHT.
- **`empirica blindspot-report`** — the telemetry: **acknowledge-rate** (surfaced → practitioner logged an unknown / acted = the nudge is useful) and **regret-rate** (dismissed → *later became a mistake or dead-end* = we were right and got ignored). Low both = crying wolf. This is the signal that will tune T3's conservativeness, exactly as enforcement-report tunes the floor.

## Active-goal scoping (from the T1 inspection)
The dry-run showed the intent-gap signal is precise (0 false positives) but conflates *forward-looking gaps in active work* with *done-but-unclosed backlog under dormant `planned` goals*. A nudge that fires on stale backlog trains dismissal. So `detect_intent_gaps(active_only=True)` now excludes `planned` goals; `blindspot-scan --include-planned` gives the full backlog view.

**Validated end-to-end:** active-scope narrowed a live session from **9 → 2** candidates — dropping the planned-goal backlog, keeping only the genuinely forward-looking gaps.

## Tests
21 blindspot (intent-gap incl. active-scope + persist/aggregate incl. fail-open) + 86 migration (053 chains cleanly) + 35 CLI-invariant, all green. Full CI lint gate (ruff check + format) + pyright clean.

## Next
T3 — CHECK advisory nudge (persists via this substrate, never blocks) · T4 — POSTFLIGHT outcome/regret loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)