### PR TITLE
feat(blindspots): CHECK advisory nudge — T3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Blindspot detection — CHECK advisory nudge (T3).** The intent-gap detector now
+  surfaces at CHECK: `result['intent_gaps']` lists predicted blindspots (active-goal
+  tasks with no coverage and no acknowledging unknown) as an **advisory — never a
+  block**. Unlike weave-enforce (which gates on a measured fact), a blindspot is a
+  prediction, so it nudges but never flips `proceed→investigate`. Each fresh
+  candidate persists to `blindspot_events` (deduped across repeated CHECKs) so the
+  telemetry + regret loop accrue from the first nudge. Fail-open — a measurement
+  error yields no advisory and never affects CHECK.
 - **Blindspot detection — persistence + telemetry + active-goal scoping (T2).**
   `blindspot_events` (migration 053) is the durable, **fail-open** substrate for
   blindspot outcomes (surfaced / acknowledged / dismissed / regretted); a new

--- a/empirica/cli/command_handlers/_workflow_check.py
+++ b/empirica/cli/command_handlers/_workflow_check.py
@@ -753,6 +753,50 @@ def _check_apply_weave_enforce(result, decision, session_id, transaction_id):
     return decision
 
 
+def _check_surface_blindspots(result, session_id, transaction_id):
+    """Advisory: surface active-goal intent-gap blindspots in the CHECK response.
+
+    ADVISORY ONLY — never touches ``decision``. Unlike weave-enforce (which gates
+    on a *measured fact*), a blindspot is a *prediction*; you never block real work
+    on a guess. Attaches ``result['intent_gaps']`` (distinct from the external
+    predictor's ``result['blindspots']``) and persists each NEW candidate to
+    ``blindspot_events`` (surfaced_at='check') for telemetry + the regret loop —
+    deduped against already-surfaced-unresolved rows so repeated CHECKs don't
+    duplicate. Fail-open: any error yields no advisory and never affects CHECK.
+    """
+    try:
+        from empirica.core.blindspots import (
+            detect_intent_gaps,
+            persist_blindspot_candidates,
+            read_blindspot_events,
+        )
+
+        from ._workflow_shared import _get_db_for_session
+
+        db = _get_db_for_session(session_id)
+        gaps = detect_intent_gaps(db.goals.get_goal_tree(session_id), active_only=True)
+        if not gaps:
+            return
+        result["intent_gaps"] = {
+            "predicted": gaps[:5],
+            "note": (
+                "Predicted blindspots — stated tasks with no coverage and no acknowledging "
+                "unknown. ADVISORY (not a block): log an `unknown` to acknowledge one, "
+                "cover it with a finding, or dismiss it."
+            ),
+        }
+        already = {
+            r.get("subtask_id")
+            for r in read_blindspot_events(db, session_id)
+            if (r.get("outcome") or "surfaced") == "surfaced"
+        }
+        fresh = [g for g in gaps if g.get("subtask_id") not in already]
+        if fresh:
+            persist_blindspot_candidates(db, session_id, transaction_id, fresh, "check")
+    except Exception as e:
+        logger.debug(f"blindspot surface skipped (non-fatal): {e}")
+
+
 def _check_store_and_publish(session_id, round_num, vectors, decision, reasoning, cycle):
     """Store CHECK checkpoint (3-layer) and publish bus event.
 
@@ -1291,6 +1335,11 @@ def handle_check_submit_command(args):
             # Dormant by default (report-only strictness) — only blocks when a
             # practice dials strictness into the enforce band. Map work-stream 1.
             decision = _check_apply_weave_enforce(result, decision, session_id, check_transaction_id)
+
+            # Stage 13.6: Blindspot advisory — surface active-goal intent-gaps.
+            # ADVISORY ONLY (never overrides decision — a blindspot is a prediction,
+            # not a measured fact). Persists to blindspot_events for telemetry.
+            _check_surface_blindspots(result, session_id, check_transaction_id)
 
             # Stage 14: Pattern retrieval + codebase context
             _check_enrich_context(result, bootstrap_result, bootstrap_status, vectors, reasoning)

--- a/tests/test_check_surface_blindspots.py
+++ b/tests/test_check_surface_blindspots.py
@@ -1,0 +1,89 @@
+"""CHECK Stage 13.6 — the blindspot advisory.
+
+ADVISORY ONLY: attaches result['intent_gaps'], never touches the decision (a
+blindspot is a prediction, not a measured fact), persists fresh candidates
+(deduped), and is fail-open.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import types
+
+from empirica.cli.command_handlers import _workflow_check as wc
+from empirica.cli.command_handlers import _workflow_shared as ws
+from empirica.data.migrations.migrations import migration_053_blindspot_events
+
+
+def _fake_db(goal_tree):
+    conn = sqlite3.connect(":memory:")
+    migration_053_blindspot_events(conn.cursor())
+    conn.commit()
+    return types.SimpleNamespace(conn=conn, goals=types.SimpleNamespace(get_goal_tree=lambda sid: goal_tree))
+
+
+def _tree(status="in_progress", findings=None):
+    return [
+        {
+            "goal_id": "g",
+            "objective": "Ship X",
+            "status": status,
+            "subtasks": [
+                {
+                    "subtask_id": "s1",
+                    "description": "assess X",
+                    "status": "pending",
+                    "findings": findings or [],
+                    "unknowns": [],
+                    "dead_ends": [],
+                }
+            ],
+        }
+    ]
+
+
+def test_surfaces_advisory_without_touching_decision(monkeypatch):
+    db = _fake_db(_tree())
+    monkeypatch.setattr(ws, "_get_db_for_session", lambda sid: db)
+    result = {"decision": "proceed"}
+    wc._check_surface_blindspots(result, "sess", "tx1")
+    assert "intent_gaps" in result
+    assert len(result["intent_gaps"]["predicted"]) == 1
+    assert result["decision"] == "proceed"  # NEVER overridden — advisory only
+    assert list(db.conn.execute("SELECT subtask_id, surfaced_at FROM blindspot_events")) == [("s1", "check")]
+
+
+def test_no_gaps_no_advisory(monkeypatch):
+    db = _fake_db(_tree(findings=["covered"]))  # covered → not a gap
+    monkeypatch.setattr(ws, "_get_db_for_session", lambda sid: db)
+    result = {"decision": "proceed"}
+    wc._check_surface_blindspots(result, "sess", "tx1")
+    assert "intent_gaps" not in result
+
+
+def test_planned_goal_not_surfaced(monkeypatch):
+    db = _fake_db(_tree(status="planned"))  # dormant → excluded by active_only
+    monkeypatch.setattr(ws, "_get_db_for_session", lambda sid: db)
+    result = {"decision": "proceed"}
+    wc._check_surface_blindspots(result, "sess", "tx1")
+    assert "intent_gaps" not in result
+
+
+def test_persist_deduped_across_checks(monkeypatch):
+    db = _fake_db(_tree())
+    monkeypatch.setattr(ws, "_get_db_for_session", lambda sid: db)
+    r = {"decision": "proceed"}
+    wc._check_surface_blindspots(r, "sess", "tx1")
+    wc._check_surface_blindspots(r, "sess", "tx1")  # second CHECK, same gap
+    assert db.conn.execute("SELECT COUNT(*) FROM blindspot_events").fetchone()[0] == 1  # not duplicated
+
+
+def test_fail_open_never_raises_or_blocks(monkeypatch):
+    def boom(sid):
+        raise RuntimeError("db locked")
+
+    monkeypatch.setattr(ws, "_get_db_for_session", boom)
+    result = {"decision": "proceed"}
+    wc._check_surface_blindspots(result, "sess", "tx1")  # must not raise
+    assert "intent_gaps" not in result
+    assert result["decision"] == "proceed"


### PR DESCRIPTION
Third transaction of the blindspot build (goal `fb845b12`). The detector now **speaks up on its own** — the first time it surfaces to practitioners, at CHECK, fleet-wide.

## Advisory, never a block

New CHECK **Stage 13.6** (`_check_surface_blindspots`). Predicted blindspots — active-goal tasks with no coverage and no acknowledging unknown — attach to `result['intent_gaps']`. The core invariant:

> **It never touches `decision`.** Unlike weave-enforce (which gates on a *measured fact* — connectivity below the floor), a blindspot is a *prediction*. You don't block real work on a guess. It nudges; it never flips `proceed→investigate`.

- Distinct key `result['intent_gaps']` (the external predictor owns `result['blindspots']`; T6 unifies when that predictor is modularised in-repo).
- Persists fresh candidates to `blindspot_events` (`surfaced_at='check'`), **deduped** against already-surfaced-unresolved so repeated CHECKs in a session don't duplicate — telemetry + the regret loop accrue cleanly from the first nudge.
- **Fail-open** — a measurement error yields no advisory and never affects CHECK (the path is fleet-critical).

## Tests
5 advisory tests — never-touches-decision, no-gap-no-advisory, planned-goal-excluded, dedup-across-checks, fail-open — plus check-weave regression, all green. Full CI lint gate (ruff check + format) + pyright clean.

## Where the pipeline stands
Artifacts log → surface at PREFLIGHT (mistakes now included) → advise at CHECK (weave-enforce **+ blindspots**). Next: **T4** — POSTFLIGHT outcome/regret loop (a dismissed blindspot that later became a mistake/dead-end = the training label), which closes the loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)