### PR TITLE
feat(blindspots): POSTFLIGHT outcome/regret loop — T4 (closes the loop)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Blindspot detection — POSTFLIGHT outcome/regret loop (T4).** Closes the loop:
+  a surfaced blindspot is advanced at POSTFLIGHT to `acknowledged` (its flagged
+  task got engaged — a finding, unknown, dead_end, or completion) or `dismissed`
+  (the goal closed with the task still bare — you proceeded past the nudge); it
+  stays `surfaced` while work is in-flight (no premature dismiss). That makes
+  `blindspot-report`'s acknowledge/dismiss rates real — the dials that tune how
+  loud the detector earns the right to be. `regretted` (the training label — a
+  dismissed blindspot that later became a mistake/dead-end) gets its mechanism
+  (`mark_blindspot_regretted`); wiring its automatic trigger from the mistake log
+  is the next micro-step. Fail-open POSTFLIGHT stage — never affects the close.
 - **Blindspot detection — CHECK advisory nudge (T3).** The intent-gap detector now
   surfaces at CHECK: `result['intent_gaps']` lists predicted blindspots (active-goal
   tasks with no coverage and no acknowledging unknown) as an **advisory — never a

--- a/empirica/cli/command_handlers/_workflow_postflight.py
+++ b/empirica/cli/command_handlers/_workflow_postflight.py
@@ -1420,6 +1420,19 @@ def _cortex_extract_transaction_graph(session_id):
         return {}
 
 
+def _postflight_resolve_blindspots(session_id) -> int:
+    """Stage 5c helper: advance surfaced blindspots to acknowledged/dismissed.
+
+    Best-effort — the blindspot machinery must never affect POSTFLIGHT. Returns
+    the number of blindspot_events rows transitioned.
+    """
+    from empirica.core.blindspots import resolve_blindspot_outcomes
+
+    from ._workflow_shared import _get_db_for_session
+
+    return resolve_blindspot_outcomes(_get_db_for_session(session_id), session_id)
+
+
 def _write_auto_structural_edges(session_id, transaction_id) -> int:
     """Auto-edge (Gated Artifact-Graph map, work-stream 3): persist each
     artifact's structural edge to its goal in the canonical ``artifact_edges``
@@ -1855,6 +1868,11 @@ def handle_postflight_submit_command(args):
                 session_id,
                 tx_info["transaction_id"],
             )
+
+            # Stage 5c: Blindspot outcomes — advance surfaced blindspots to
+            # acknowledged/dismissed based on whether their flagged task got
+            # engaged this session (the POSTFLIGHT learning half). Fail-open.
+            _soft_run("blindspot_outcomes", warnings, _postflight_resolve_blindspots, session_id)
 
             # Stage 6: Beliefs + Grounded verification + Storage pipeline
             _soft_run(

--- a/empirica/core/blindspots/__init__.py
+++ b/empirica/core/blindspots/__init__.py
@@ -21,6 +21,7 @@ See ``docs`` / the blindspot goal for the full transaction plan.
 from __future__ import annotations
 
 from .intent_gap import detect_intent_gaps
+from .outcomes import mark_blindspot_regretted, resolve_blindspot_outcomes
 from .persist import (
     aggregate_blindspot_events,
     persist_blindspot_candidates,
@@ -30,6 +31,8 @@ from .persist import (
 __all__ = [
     "aggregate_blindspot_events",
     "detect_intent_gaps",
+    "mark_blindspot_regretted",
     "persist_blindspot_candidates",
     "read_blindspot_events",
+    "resolve_blindspot_outcomes",
 ]

--- a/empirica/core/blindspots/outcomes.py
+++ b/empirica/core/blindspots/outcomes.py
@@ -1,0 +1,95 @@
+"""Blindspot outcome resolution — the POSTFLIGHT learning half (T4).
+
+Closes the loop the CHECK advisory opened: a surfaced blindspot is advanced to
+``acknowledged`` (its flagged task got engaged) or ``dismissed`` (the goal closed
+with the task still bare — you proceeded past the nudge). That makes
+``blindspot-report``'s acknowledge/dismiss rates real, which is what tunes how
+loud the detector earns the right to be.
+
+``regretted`` — the training label (a *dismissed* blindspot that later became a
+mistake/dead-end) — gets its mechanism here (``mark_blindspot_regretted``); wiring
+the automatic trigger from the mistake/dead-end log is the documented next step.
+
+All fail-open — the blindspot machinery must never affect POSTFLIGHT.
+"""
+
+from __future__ import annotations
+
+import time
+
+from .intent_gap import _TERMINAL_GOAL_STATUS
+
+_ENGAGED_TASK_STATUS = frozenset({"completed", "complete", "done"})
+
+
+def resolve_blindspot_outcomes(db, session_id: str) -> int:
+    """Advance this session's ``surfaced`` blindspots at POSTFLIGHT.
+
+    For each subtask with a surfaced blindspot, re-read the goal tree:
+    - **engaged** (the subtask now has a finding, unknown, dead_end, or a complete
+      status) → ``acknowledged`` — the practitioner did something with the flagged
+      task (the nudge, or the work, addressed it).
+    - else, if the **parent goal is terminal** but the subtask stayed bare →
+      ``dismissed`` — the goal closed while the flagged gap was ignored.
+    - else → stay ``surfaced`` (work may still be in-flight; don't dismiss early).
+
+    Fail-open: returns the number of rows updated, or 0 on any error.
+    """
+    try:
+        cur = db.conn.execute(
+            "SELECT DISTINCT subtask_id FROM blindspot_events WHERE session_id = ? AND outcome = 'surfaced'",
+            (session_id,),
+        )
+        surfaced = {row[0] for row in cur.fetchall()}
+        if not surfaced:
+            return 0
+
+        # subtask_id -> (engaged, goal_terminal)
+        state: dict = {}
+        for goal in db.goals.get_goal_tree(session_id) or []:
+            gterm = (goal.get("status") or "").strip().lower() in _TERMINAL_GOAL_STATUS
+            for st in goal.get("subtasks") or []:
+                engaged = (
+                    bool(st.get("findings") or st.get("unknowns") or st.get("dead_ends"))
+                    or (st.get("status") or "").strip().lower() in _ENGAGED_TASK_STATUS
+                )
+                state[st.get("subtask_id")] = (engaged, gterm)
+
+        now = time.time()
+        updated = 0
+        for sid in surfaced:
+            engaged, gterm = state.get(sid, (False, False))
+            outcome = "acknowledged" if engaged else ("dismissed" if gterm else None)
+            if outcome is None:
+                continue
+            db.conn.execute(
+                "UPDATE blindspot_events SET outcome = ?, resolved_timestamp = ? "
+                "WHERE session_id = ? AND subtask_id = ? AND outcome = 'surfaced'",
+                (outcome, now, session_id, sid),
+            )
+            updated += 1
+        if updated:
+            db.conn.commit()
+        return updated
+    except Exception:
+        return 0
+
+
+def mark_blindspot_regretted(db, session_id: str, subtask_id: str) -> int:
+    """Flip a ``dismissed`` blindspot to ``regretted`` — the training label.
+
+    Called when a mistake or dead-end lands on a subtask that had a dismissed
+    blindspot (we warned, it was ignored, and the gap bit). Fail-open; returns
+    rows updated. The automatic trigger from the mistake/dead-end log is the
+    documented follow-up — this is the mechanism it will call.
+    """
+    try:
+        cur = db.conn.execute(
+            "UPDATE blindspot_events SET outcome = 'regretted', resolved_timestamp = ? "
+            "WHERE session_id = ? AND subtask_id = ? AND outcome = 'dismissed'",
+            (time.time(), session_id, subtask_id),
+        )
+        db.conn.commit()
+        return cur.rowcount if cur.rowcount and cur.rowcount > 0 else 0
+    except Exception:
+        return 0

--- a/tests/test_blindspot_outcomes.py
+++ b/tests/test_blindspot_outcomes.py
@@ -1,0 +1,97 @@
+"""Blindspot outcome resolution (T4) — the POSTFLIGHT learning half.
+
+surfaced → acknowledged (task engaged) / dismissed (goal closed bare) / stays
+surfaced (still in-flight). mark_blindspot_regretted flips dismissed → regretted.
+All fail-open.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import types
+
+from empirica.core.blindspots import (
+    mark_blindspot_regretted,
+    persist_blindspot_candidates,
+    resolve_blindspot_outcomes,
+)
+from empirica.data.migrations.migrations import migration_053_blindspot_events
+
+
+def _db(goal_tree):
+    conn = sqlite3.connect(":memory:")
+    migration_053_blindspot_events(conn.cursor())
+    conn.commit()
+    return types.SimpleNamespace(conn=conn, goals=types.SimpleNamespace(get_goal_tree=lambda sid: goal_tree))
+
+
+def _cand(sid="s1"):
+    return {"kind": "intent_gap", "goal_id": "g", "subtask_id": sid, "intent": "assess"}
+
+
+def _tree(goal_status="in_progress", status="pending", findings=None, unknowns=None, dead_ends=None):
+    st = {
+        "subtask_id": "s1",
+        "description": "d",
+        "status": status,
+        "findings": findings or [],
+        "unknowns": unknowns or [],
+        "dead_ends": dead_ends or [],
+    }
+    return [{"goal_id": "g", "objective": "o", "status": goal_status, "subtasks": [st]}]
+
+
+def _outcome(db, sid="s1"):
+    return db.conn.execute("SELECT outcome FROM blindspot_events WHERE subtask_id = ?", (sid,)).fetchone()[0]
+
+
+def test_engaged_subtask_becomes_acknowledged():
+    for engage in ({"unknowns": ["u"]}, {"findings": ["f"]}, {"dead_ends": ["d"]}, {"status": "completed"}):
+        db = _db(_tree(**engage))
+        persist_blindspot_candidates(db, "sess", "tx", [_cand()], "check")
+        assert resolve_blindspot_outcomes(db, "sess") == 1, engage
+        assert _outcome(db) == "acknowledged", engage
+
+
+def test_bare_subtask_under_terminal_goal_dismissed():
+    db = _db(_tree(goal_status="completed"))
+    persist_blindspot_candidates(db, "sess", "tx", [_cand()], "check")
+    assert resolve_blindspot_outcomes(db, "sess") == 1
+    assert _outcome(db) == "dismissed"
+
+
+def test_bare_subtask_under_active_goal_stays_surfaced():
+    db = _db(_tree(goal_status="in_progress"))
+    persist_blindspot_candidates(db, "sess", "tx", [_cand()], "check")
+    assert resolve_blindspot_outcomes(db, "sess") == 0  # still in-flight — don't dismiss early
+    assert _outcome(db) == "surfaced"
+
+
+def test_no_surfaced_events_is_noop():
+    assert resolve_blindspot_outcomes(_db(_tree()), "sess") == 0
+
+
+def test_mark_regretted_flips_dismissed():
+    db = _db(_tree(goal_status="completed"))
+    persist_blindspot_candidates(db, "sess", "tx", [_cand()], "check")
+    resolve_blindspot_outcomes(db, "sess")  # → dismissed
+    assert _outcome(db) == "dismissed"
+    assert mark_blindspot_regretted(db, "sess", "s1") == 1
+    assert _outcome(db) == "regretted"
+
+
+def test_mark_regretted_only_targets_dismissed():
+    db = _db(_tree())
+    persist_blindspot_candidates(db, "sess", "tx", [_cand()], "check")  # still surfaced
+    assert mark_blindspot_regretted(db, "sess", "s1") == 0  # not dismissed → no-op
+    assert _outcome(db) == "surfaced"
+
+
+def test_fail_open():
+    class Boom:
+        @property
+        def conn(self):
+            raise RuntimeError("db")
+
+    assert resolve_blindspot_outcomes(Boom(), "sess") == 0
+    assert mark_blindspot_regretted(Boom(), "sess", "s1") == 0


### PR DESCRIPTION
The learning half — the last transaction of the blindspot build (goal `fb845b12`). The detector now learns from its own hits and misses.

## What

`resolve_blindspot_outcomes` runs as a **fail-open POSTFLIGHT `_soft_run` stage (5c)** and advances each `surfaced` blindspot by re-reading the goal tree:

- **engaged** — the flagged task now has a finding, unknown, dead_end, or a complete status → **`acknowledged`** (the nudge, or the work, addressed it)
- else if the **parent goal is terminal** but the task stayed bare → **`dismissed`** (the goal closed while the flagged gap was ignored)
- else → stays **`surfaced`** (work may still be in-flight — conservative, no premature dismiss)

This makes `blindspot-report`'s **acknowledge/dismiss rates real** — the dials that tune how loud the detector earns the right to be, exactly as enforcement-report tunes the floor.

## The money signal

**`regretted`** — a *dismissed* blindspot that later became a mistake/dead-end — is the training label (we warned, it was ignored, the gap bit). T4 ships its mechanism (`mark_blindspot_regretted`); **wiring the automatic trigger from the mistake/dead-end log is the honest next micro-step**, so I'm not claiming the auto-correlation is live yet.

## Tests
7 outcome tests (acknowledged for each engagement kind, dismissed-on-terminal-goal, stays-surfaced-in-flight, regret flip, regret-only-targets-dismissed, fail-open) + 26 other blindspot tests, all green. Full CI lint gate (ruff check + format) + pyright clean.

## The pipeline, closed
```
log artifacts → PREFLIGHT surfaces priors (incl. mistakes) → CHECK advises
  (weave-enforce gates on fact + blindspots nudge on prediction) → POSTFLIGHT learns
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)