### PR TITLE
feat(blindspots): regret auto-trigger — closes the loop's training signal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.12.15] — 2026-07-06
 
 ### Added
+- **Blindspot detection — regret auto-trigger.** Closes the loop's training
+  signal: a `dismissed` blindspot flips to `regretted` at POSTFLIGHT when a
+  mistake or dead-end lands on the same goal *after* the dismissal (we warned, it
+  was ignored, the gap bit). `created_timestamp > resolved_timestamp` enforces the
+  causal order; cross-transaction by construction. Fail-open. `blindspot-report`'s
+  regret-rate is now live — the money signal.
 - **Blindspot detection — POSTFLIGHT outcome/regret loop (T4).** Closes the loop:
   a surfaced blindspot is advanced at POSTFLIGHT to `acknowledged` (its flagged
   task got engaged — a finding, unknown, dead_end, or completion) or `dismissed`

--- a/empirica/cli/command_handlers/_workflow_postflight.py
+++ b/empirica/cli/command_handlers/_workflow_postflight.py
@@ -1426,11 +1426,16 @@ def _postflight_resolve_blindspots(session_id) -> int:
     Best-effort — the blindspot machinery must never affect POSTFLIGHT. Returns
     the number of blindspot_events rows transitioned.
     """
-    from empirica.core.blindspots import resolve_blindspot_outcomes
+    from empirica.core.blindspots import apply_blindspot_regret, resolve_blindspot_outcomes
 
     from ._workflow_shared import _get_db_for_session
 
-    return resolve_blindspot_outcomes(_get_db_for_session(session_id), session_id)
+    db = _get_db_for_session(session_id)
+    resolved = resolve_blindspot_outcomes(db, session_id)
+    # Then the regret pass: dismissed blindspots whose gap later bit (a mistake /
+    # dead-end on the same goal after the dismissal) become the training label.
+    regretted = apply_blindspot_regret(db, session_id)
+    return resolved + regretted
 
 
 def _write_auto_structural_edges(session_id, transaction_id) -> int:

--- a/empirica/core/blindspots/__init__.py
+++ b/empirica/core/blindspots/__init__.py
@@ -21,7 +21,7 @@ See ``docs`` / the blindspot goal for the full transaction plan.
 from __future__ import annotations
 
 from .intent_gap import detect_intent_gaps
-from .outcomes import mark_blindspot_regretted, resolve_blindspot_outcomes
+from .outcomes import apply_blindspot_regret, mark_blindspot_regretted, resolve_blindspot_outcomes
 from .persist import (
     aggregate_blindspot_events,
     persist_blindspot_candidates,
@@ -30,6 +30,7 @@ from .persist import (
 
 __all__ = [
     "aggregate_blindspot_events",
+    "apply_blindspot_regret",
     "detect_intent_gaps",
     "mark_blindspot_regretted",
     "persist_blindspot_candidates",

--- a/empirica/core/blindspots/outcomes.py
+++ b/empirica/core/blindspots/outcomes.py
@@ -7,8 +7,9 @@ with the task still bare — you proceeded past the nudge). That makes
 loud the detector earns the right to be.
 
 ``regretted`` — the training label (a *dismissed* blindspot that later became a
-mistake/dead-end) — gets its mechanism here (``mark_blindspot_regretted``); wiring
-the automatic trigger from the mistake/dead-end log is the documented next step.
+mistake/dead-end) — is applied automatically by ``apply_blindspot_regret`` at
+POSTFLIGHT (goal-level correlation, causally ordered); ``mark_blindspot_regretted``
+is the direct-subtask primitive it and callers use.
 
 All fail-open — the blindspot machinery must never affect POSTFLIGHT.
 """
@@ -91,5 +92,56 @@ def mark_blindspot_regretted(db, session_id: str, subtask_id: str) -> int:
         )
         db.conn.commit()
         return cur.rowcount if cur.rowcount and cur.rowcount > 0 else 0
+    except Exception:
+        return 0
+
+
+def apply_blindspot_regret(db, session_id: str) -> int:
+    """Auto-flip dismissed blindspots to ``regretted`` — the training label.
+
+    For each ``dismissed`` blindspot, if a mistake (``mistakes_made``) or dead-end
+    (``session_dead_ends``) with the same ``goal_id`` was logged *after* the
+    blindspot was dismissed (``resolved_timestamp``), the warned-about gap bit:
+    flip it to ``regretted``. The ``created_timestamp > resolved_timestamp`` guard
+    enforces the causal order (the mistake came after the dismissal). Cross-
+    transaction by construction — both the dismissal and the mistake persist.
+
+    Fail-open: returns rows flipped, or 0 on any error (including absent tables on
+    a partial DB). Runs at POSTFLIGHT after ``resolve_blindspot_outcomes``.
+    """
+    try:
+        dismissed = db.conn.execute(
+            "SELECT goal_id, subtask_id, resolved_timestamp FROM blindspot_events "
+            "WHERE session_id = ? AND outcome = 'dismissed'",
+            (session_id,),
+        ).fetchall()
+        if not dismissed:
+            return 0
+
+        flipped = 0
+        now = time.time()
+        for goal_id, subtask_id, resolved_ts in dismissed:
+            since = resolved_ts or 0
+            mistake_hit = db.conn.execute(
+                "SELECT 1 FROM mistakes_made WHERE session_id = ? AND goal_id = ? AND created_timestamp > ? LIMIT 1",
+                (session_id, goal_id, since),
+            ).fetchone()
+            dead_end_hit = None
+            if not mistake_hit:
+                dead_end_hit = db.conn.execute(
+                    "SELECT 1 FROM session_dead_ends WHERE session_id = ? "
+                    "AND (goal_id = ? OR subtask_id = ?) AND created_timestamp > ? LIMIT 1",
+                    (session_id, goal_id, subtask_id, since),
+                ).fetchone()
+            if mistake_hit or dead_end_hit:
+                db.conn.execute(
+                    "UPDATE blindspot_events SET outcome = 'regretted', resolved_timestamp = ? "
+                    "WHERE session_id = ? AND goal_id = ? AND subtask_id = ? AND outcome = 'dismissed'",
+                    (now, session_id, goal_id, subtask_id),
+                )
+                flipped += 1
+        if flipped:
+            db.conn.commit()
+        return flipped
     except Exception:
         return 0

--- a/tests/test_blindspot_regret.py
+++ b/tests/test_blindspot_regret.py
@@ -1,0 +1,90 @@
+"""Blindspot regret auto-trigger — the training label.
+
+A dismissed blindspot flips to `regretted` when a mistake / dead-end lands on the
+same goal *after* the dismissal (we warned, it was ignored, the gap bit). The
+`created_timestamp > resolved_timestamp` guard enforces the causal order.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import types
+
+from empirica.core.blindspots import apply_blindspot_regret
+from empirica.data.migrations.migrations import migration_053_blindspot_events
+
+
+def _db():
+    conn = sqlite3.connect(":memory:")
+    migration_053_blindspot_events(conn.cursor())
+    conn.execute("CREATE TABLE mistakes_made (id TEXT, session_id TEXT, goal_id TEXT, created_timestamp REAL)")
+    conn.execute(
+        "CREATE TABLE session_dead_ends (id TEXT, session_id TEXT, goal_id TEXT, subtask_id TEXT, created_timestamp REAL)"
+    )
+    conn.commit()
+    return types.SimpleNamespace(conn=conn)
+
+
+def _dismissed(db, goal="g", subtask="s1", resolved_ts=100.0):
+    db.conn.execute(
+        "INSERT INTO blindspot_events (session_id, transaction_id, created_timestamp, kind, goal_id, "
+        "subtask_id, intent, surfaced_at, outcome, resolved_timestamp) "
+        "VALUES ('sess', 'tx', 50.0, 'intent_gap', ?, ?, 'i', 'check', 'dismissed', ?)",
+        (goal, subtask, resolved_ts),
+    )
+    db.conn.commit()
+
+
+def _outcome(db, sid="s1"):
+    return db.conn.execute("SELECT outcome FROM blindspot_events WHERE subtask_id = ?", (sid,)).fetchone()[0]
+
+
+def test_mistake_after_dismiss_regrets():
+    db = _db()
+    _dismissed(db, resolved_ts=100.0)
+    db.conn.execute("INSERT INTO mistakes_made VALUES ('m', 'sess', 'g', 200.0)")  # after dismiss
+    db.conn.commit()
+    assert apply_blindspot_regret(db, "sess") == 1
+    assert _outcome(db) == "regretted"
+
+
+def test_dead_end_after_dismiss_regrets():
+    db = _db()
+    _dismissed(db, resolved_ts=100.0)
+    db.conn.execute("INSERT INTO session_dead_ends VALUES ('d', 'sess', 'g', 's1', 200.0)")
+    db.conn.commit()
+    assert apply_blindspot_regret(db, "sess") == 1
+    assert _outcome(db) == "regretted"
+
+
+def test_mistake_before_dismiss_no_regret():
+    db = _db()
+    _dismissed(db, resolved_ts=100.0)
+    db.conn.execute("INSERT INTO mistakes_made VALUES ('m', 'sess', 'g', 50.0)")  # before dismiss — not causal
+    db.conn.commit()
+    assert apply_blindspot_regret(db, "sess") == 0
+    assert _outcome(db) == "dismissed"
+
+
+def test_mistake_different_goal_no_regret():
+    db = _db()
+    _dismissed(db, goal="g", resolved_ts=100.0)
+    db.conn.execute("INSERT INTO mistakes_made VALUES ('m', 'sess', 'OTHER', 200.0)")
+    db.conn.commit()
+    assert apply_blindspot_regret(db, "sess") == 0
+
+
+def test_no_dismissed_is_noop():
+    assert apply_blindspot_regret(_db(), "sess") == 0
+
+
+def test_fail_open_on_missing_correlation_tables():
+    conn = sqlite3.connect(":memory:")
+    migration_053_blindspot_events(conn.cursor())  # no mistakes_made / session_dead_ends
+    conn.execute(
+        "INSERT INTO blindspot_events (session_id, transaction_id, created_timestamp, kind, goal_id, "
+        "subtask_id, intent, surfaced_at, outcome, resolved_timestamp) "
+        "VALUES ('sess', 'tx', 50.0, 'intent_gap', 'g', 's1', 'i', 'check', 'dismissed', 100.0)"
+    )
+    conn.commit()
+    assert apply_blindspot_regret(types.SimpleNamespace(conn=conn), "sess") == 0  # fail-open, no raise


### PR DESCRIPTION
Wires the **money signal** the T4 loop left as a documented next step.

`apply_blindspot_regret` runs at POSTFLIGHT (after `resolve_blindspot_outcomes`, in `_postflight_resolve_blindspots`): for each **dismissed** blindspot, if a mistake (`mistakes_made`) or dead-end (`session_dead_ends`) with the same `goal_id` was logged **after** the blindspot's `resolved_timestamp` — the warned-about gap bit — flip it to **`regretted`**.

- `created_timestamp > resolved_timestamp` enforces the causal order (the mistake came *after* the dismissal, not before).
- **Cross-transaction by construction** — the dismissal and the mistake both persist; a later POSTFLIGHT catches the correlation.
- **Fail-open** — absent correlation tables or any error → 0, never affects POSTFLIGHT.

`blindspot-report`'s **regret-rate is now live**: dismissed nudges that turned out to matter. Goal-level correlation for now; subtask-level + semantic is a future refinement (noted).

## Tests
6 regret tests (mistake-after-dismiss, dead-end-after-dismiss, mistake-*before*-dismiss→no-regret, different-goal→no-regret, no-dismissed→noop, fail-open-on-missing-tables) + 7 outcome tests, green. Full CI lint gate + pyright clean.

The blindspot loop is now fully closed: **surface → dismiss/acknowledge → regret** — the detector learns which of its ignored warnings actually bit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)