### PR TITLE
docs(skill): correct ser_escalation delivered shape in cortex-mailbox-poll

### DIFF
--- a/empirica/plugins/claude-code-integration/skills/cortex-mailbox-poll/SKILL.md
+++ b/empirica/plugins/claude-code-integration/skills/cortex-mailbox-poll/SKILL.md
@@ -286,27 +286,42 @@ when it went out — these events are informational acks for the source AI.
 Outbox `accepted` is NEVER surfaced (informational — target will act on
 the next tick of their inbox poll). Saves chat noise.
 
-### `event=ser_escalation` — SER re-ping (LIVE; env-gated)
+### `event_type=ser_escalation` — SER re-ping (LIVE; env-gated)
 
 A separate wake shape rides the same `proposal_event` channel when an
 SER you're a `required`-tier participant of has been idle past its
 escalation interval and you haven't acked since the last transition.
 Cortex emits these from `system:ser-escalation` (env-gated by
-`CORTEX_SER_ESCALATION_ENABLED`, default OFF; interval
-`CORTEX_SER_ESCALATION_INTERVAL_S`, default 600s).
+`CORTEX_SER_ESCALATION_ENABLED`; interval
+`CORTEX_SER_ESCALATION_INTERVAL_S`, default 600s). The listener delivers
+them two ways: the live ntfy doorbell is relayed straight from the push
+body (`via: push_relay`), and a *dropped* doorbell is recovered on the
+next catch-up by reconciling from `/v1/sers` (`via: catchup_reconcile`).
+Both paths are needed because ser_escalation has no proposal-store row,
+so the proposal-only catch-up can't reconstruct it.
+
+The shape that lands in your session (what the relay writes) — note
+`event_type` is the shape itself, the cortex-side `event` key is
+promoted into it and dropped, and `via` tags the delivery path:
 
 ```json
-{"event": "ser_escalation", "event_type": "proposal_event",
+{"ts": "...", "instance_id": "<you>", "loop": "cortex-mailbox-poll",
+ "event_type": "ser_escalation",
  "ser_id": "ser_xxx", "ser_state": "in_progress",
  "source_claude": "system:ser-escalation",
  "target_claudes": ["<your_canonical_id>"],
  "escalation": true,
- "idle_for_seconds": 14400}
+ "idle_for_seconds": 14400,
+ "via": "push_relay"}
 ```
 
-**Discriminator:** `escalation=true` distinguishes re-pings from first
-delivery on the same channel. `source_claude=system:ser-escalation`
-identifies the cortex internal emitter.
+**Discriminator:** `event_type == "ser_escalation"` (NOT
+`"proposal_event"`) routes this as a non-proposal wake — proposal
+handlers keyed on `event_type=="proposal_event"` correctly skip it.
+`escalation=true` distinguishes re-pings from first delivery;
+`source_claude=system:ser-escalation` identifies the cortex internal
+emitter. `via` tells you the delivery path (`push_relay` = live doorbell;
+`catchup_reconcile` = recovered from `/v1/sers` after a dropped doorbell).
 
 **What to do:**
 


### PR DESCRIPTION
## What

The `/cortex-mailbox-poll` skill's `ser_escalation` section documented the **pre-relay cortex emit shape**, not what an AI actually receives after #273/#274 shipped the delivery fix.

The relay (`_relay_non_proposal_wake`, `listener.py:285`) promotes cortex's push-body `event` field into `event_type` (= `"ser_escalation"`), **strips** the `event` key, and tags `via` (`push_relay` | `catchup_reconcile`). The doc still showed `event_type: "proposal_event"` with an `event` key — an AI discriminator keyed on the documented shape would mis-route escalations **as proposals**.

## Changes (docs-only, no behavior change)

- JSON example now shows the delivered (post-relay) line: `event_type: "ser_escalation"`, no `event` key, `via` present
- Discriminator now keys on `event_type == "ser_escalation"` (not `"proposal_event"`), and explains proposal handlers correctly skip it
- Documents both delivery paths (push_relay live doorbell / catchup_reconcile from `/v1/sers`)
- Section header `event=` → `event_type=` to match the delivered field
- Drops the stale `default OFF` env claim (unverifiable from this repo; prod reports it enabled since 06-23)

## Why

Closes the **docs half** of a mesh code_change_request (autonomy) — the code half shipped in #273 (relay) + #274 (catch-up reconcile). Delivery is now genuinely `LIVE`, so the "LIVE" claim is honest; this PR makes the *shape* the AI keys on honest too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)