### PR TITLE
docs(prompt): sync taxonomy + load-bearing flags in lean system prompt

### DIFF
--- a/empirica/plugins/claude-code-integration/templates/empirica-system-prompt-lean.md
+++ b/empirica/plugins/claude-code-integration/templates/empirica-system-prompt-lean.md
@@ -90,6 +90,13 @@ numbers need adjusting.
 | Verification outputs | **Grounded evidence** | test results, artifact ratios, git metrics, goal completion |
 | Measurement cycle | **Epistemic transaction** | PREFLIGHT -> work -> POSTFLIGHT -> post-test |
 
+> **Verb mapping for the two non-`*-log` noetic types:** *blindspots* aren't
+> logged — they're **detected** (`blindspot-scan`; a blindspot is an
+> unknown-unknown by definition, so if you can write it down it's really an
+> `unknown`). *lessons* are **authored** via `lesson-create` (a structured
+> distillation), not a `lesson-log` verb. The other four (findings, unknowns,
+> dead-ends, mistakes) each have a matching `<type>-log` verb.
+
 ---
 
 ## 13 EPISTEMIC VECTORS (0.0-1.0)
@@ -432,11 +439,12 @@ Infer epistemic actions from conversation naturally:
 | Single-step task described | `goals-create --objective "<title>" --description "<context-rich markdown body: why, success criteria, links>"`. Write `--description` as **markdown** (extension renders it as prettified markdown — use headings, lists, code fences, links). Skip `--description` only for truly trivial titles. |
 | Multi-step task described | `goals-create` first, then `goals-add-task` per step — each task is one tracked unit of AI work |
 | Task completed (commit/test/result) | `goals-complete-task --task-id <ID> --evidence "..."` (commit SHA, test result, link) |
-| Discovery made | `finding-log` |
-| Uncertainty | `unknown-log` |
-| Approach failed | `deadend-log` |
-| Error made | `mistake-log` |
-| Choice point | `decision-log` |
+| Discovery made | `finding-log --finding "..." [--impact 0-1]` |
+| Uncertainty | `unknown-log --unknown "..."` |
+| Unverified belief you're acting on | `assumption-log --assumption "..." --confidence <0-1> --domain <area>` — the pre-blindspot surface: bank what you're taking for granted so it stays falsifiable later |
+| Approach failed | `deadend-log --approach "..." --why-failed "..."` |
+| Error made | `mistake-log --mistake "..." --why-wrong "..." --prevention "..."` — `--prevention` is the load-bearing field (what future-you needs to not repeat it), not optional |
+| Choice point | `decision-log --choice "..." --rationale "..." --reversibility <exploratory\|committal\|forced>` |
 | Something to check on later, but not worth a full artifact yet (a doubt, a follow-up, "this smells off", "ask peer X") | `empirica note "..."` (optionally `--tag followup\|doubt\|idea`) — a fast scratchpad note-to-self. Pure metadata, not shared, survives compaction; surfaces at POSTFLIGHT for triage (`note --list`, then promote to an artifact/goal or `note --clear`). Capture now, classify later. |
 | External material cited (URL, doc, paper, transcript) | `source-add` then link via `sourced_from` in `log-artifacts` |
 | Logging ≥3 related artifacts in one breath, or any artifact with edges to others | `log-artifacts -` (one batch with `nodes` + `edges` JSON) instead of N individual `*-log` calls |


### PR DESCRIPTION
## What
Fixes the phantom-verb + missing-flag drift cortex flagged (`prop_rooicu2my`/`prop_wsdy3uvl`) in the **canonical lean system-prompt template** (`empirica-system-prompt-lean.md`, which `setup-claude-code` deploys to `~/.claude`).

## Changes (docs-only)
1. **VOCABULARY** — note that the two non-`*-log` noetic types map to *real* verbs: **blindspots** are DETECTED (`blindspot-scan`; un-loggable by definition), **lessons** are AUTHORED (`lesson-create`). Kills the `empirica lesson-log`/`blindspot-log` → command-not-found trap **without inventing verbs** (per David: point the taxonomy at the real verbs, rather than ship a `lesson-log` that fights the already-10-verb `lesson-*` family).
2. **COLLABORATIVE MODE signal table** — add the missing `assumption-log` row (the pre-blindspot surface); surface the load-bearing flags that were previously only in `--help`:
   - `mistake-log --why-wrong --prevention` (`--prevention` is the load-bearing field)
   - `decision-log --rationale --reversibility {exploratory|committal|forced}`
   - key flags added to finding/unknown/deadend rows too.

## Anti-drift discipline
Every flag name/choice was **verified against `checkpoint_parsers.py`** before writing — so this fix doesn't introduce fresh drift (documenting a wrong flag would be the same bug class).

## Scope
Canonical lean template only. The `docs/human/developers/system-prompts/` model variants (CLAUDE/QWEN/GEMINI/COPILOT/ROVODEV) are a separate hand-maintained spread — deferred to **T2** (the `prompt-parser-conformance` check), which will catch that systematically rather than by error-prone hand-sync. T1c of the CLI-drift plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)