### PR TITLE
fix(forgejo): path-scope credential store + stop false 'provisioned' on re-publish

### DIFF
--- a/empirica/cli/command_handlers/forgejo_commands.py
+++ b/empirica/cli/command_handlers/forgejo_commands.py
@@ -144,6 +144,14 @@ def _set_forgejo_remote(project_path: Path, url: str) -> None:
         _git(project_path, "remote", "set-url", FORGEJO_REMOTE_NAME, url)
     else:
         _git(project_path, "remote", "add", FORGEJO_REMOTE_NAME, url)
+    # Path-scope git's credential store for THIS repo. `credential.helper=store`
+    # with useHttpPath unset keys ~/.git-credentials by host only — so a second
+    # forgejo repo's per-project token overwrites/collides with the first's under
+    # the same host (git.getempirica.com), and a later `git push forgejo` then
+    # authenticates with the wrong/stale token. Setting useHttpPath=true keys the
+    # stored credential by full path, giving each repo its own entry. Repo-local
+    # (--local) so the user's global git config is never touched.
+    _git(project_path, "config", "--local", "credential.useHttpPath", "true")
 
 
 NOTES_PUSH_BATCH = 250  # refs per RPC — pushing thousands of note refs in one
@@ -191,11 +199,19 @@ def handle_forgejo_publish_command(args) -> int:
             print(json.dumps(payload, indent=2))
         else:
             if payload.get("ok"):
-                print(f"✅ Forgejo provisioned: {payload.get('forgejo_repo_url')}")
-                for ref, ok in (payload.get("push_results") or {}).items():
-                    print(f"   {'✓' if ok else '✗'} {ref}")
-                if payload.get("token_path"):
-                    print(f"   token: {payload['token_path']} (0600)")
+                # Already-published re-call returns no token → nothing was
+                # pushed. Don't print a clean "✅ provisioned" (the false-success
+                # bug): the repo exists but this run pushed nothing, and the push
+                # path is still unauthenticated until `--rotate` mints a token.
+                if payload.get("note") and not payload.get("push_results"):
+                    print(f"⚠️  Forgejo already provisioned — nothing pushed: {payload.get('forgejo_repo_url')}")
+                    print(f"   {payload['note']}")
+                else:
+                    print(f"✅ Forgejo provisioned: {payload.get('forgejo_repo_url')}")
+                    for ref, ok in (payload.get("push_results") or {}).items():
+                        print(f"   {'✓' if ok else '✗'} {ref}")
+                    if payload.get("token_path"):
+                        print(f"   token: {payload['token_path']} (0600)")
             else:
                 print(f"❌ forgejo-publish: {payload.get('error') or payload.get('reason')}")
         return code

--- a/tests/test_forgejo_commands.py
+++ b/tests/test_forgejo_commands.py
@@ -109,6 +109,22 @@ def test_set_forgejo_remote_updates_when_present(tmp_path):
     assert ("remote", "add", "forgejo", _FORGEJO_URL) not in calls
 
 
+def test_set_forgejo_remote_path_scopes_credential_store(tmp_path):
+    """Bug #2 fix: must set credential.useHttpPath=true (repo-local) so each
+    forgejo repo's per-project token gets its own ~/.git-credentials entry
+    instead of colliding under a shared host-keyed store."""
+    calls = []
+
+    def fake_git(path, *args, **kw):
+        calls.append(args)
+        return _proc(stdout="origin\n")
+
+    with patch.object(fc, "_git", fake_git):
+        fc._set_forgejo_remote(tmp_path, _FORGEJO_URL)
+
+    assert ("config", "--local", "credential.useHttpPath", "true") in calls
+
+
 # ── handle_forgejo_publish_command ──────────────────────────────────────
 
 
@@ -225,6 +241,29 @@ def test_publish_already_published_no_key_is_ok_with_note(tmp_path, monkeypatch)
         args = SimpleNamespace(path=str(root), output="json", rotate=False, description=None)
         code = fc.handle_forgejo_publish_command(args)
     assert code == 0  # idempotent re-call is not an error
+
+
+def test_publish_already_published_human_output_warns_not_success(tmp_path, monkeypatch, capsys):
+    """Bug #1 fix: an already-published re-call (no token → no push) must NOT
+    print a bare '✅ Forgejo provisioned' — that's the false-success. It warns
+    that nothing was pushed and points at --rotate."""
+    root = _make_project(tmp_path)
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    with (
+        patch.object(fc, "_resolve_cortex_config", lambda: ("https://cortex.example", "ctx_k")),
+        patch.object(
+            fc,
+            "_forgejo_publish_post",
+            lambda *a, **k: (200, {"forgejo_repo_url": _FORGEJO_URL, "already_published": True}),
+        ),
+    ):
+        args = SimpleNamespace(path=str(root), output="human", rotate=False, description=None)
+        code = fc.handle_forgejo_publish_command(args)
+    out = capsys.readouterr().out
+    assert code == 0
+    assert "✅ Forgejo provisioned" not in out  # no false success
+    assert "⚠️" in out and "nothing pushed" in out
+    assert "--rotate" in out
 
 
 def test_publish_cortex_error_returns_nonzero(tmp_path, monkeypatch):


### PR DESCRIPTION
Two real `forgejo-publish` bugs from mesh-support (`prop_hp6ajlrc`), diagnosed on Philipp's box.

## Bug #2 (the root trap) — host-keyed credential collision
`forgejo-publish` sets the `forgejo` remote to a **clean, token-less URL**, so a later `git push forgejo` falls back to git's `credential.helper=store`. With `useHttpPath` **unset**, `~/.git-credentials` is keyed by **host only** — one entry per `git.getempirica.com` — so a **second** forgejo repo's per-project token collides with the first's, and the push authenticates with the wrong/stale token.

**Fix:** `_set_forgejo_remote` now runs `git config --local credential.useHttpPath true`, path-scoping the store so each repo's token gets its own entry. Repo-local (`--local`) — never touches the user's global git config.

## Bug #1 — false success on an already-published repo
The idempotent re-call (no `--rotate`) returns no token → nothing is pushed. But `_emit` printed a bare **"✅ Forgejo provisioned"** and never surfaced the note, so the user saw success while the push path was still unauthenticated (`git ls-remote` → "Repository not found").

**Fix:** the no-token path now prints **"⚠️ Forgejo already provisioned — nothing pushed"** + the "re-run with `--rotate`" note, instead of a clean ✅.

## Tests
+2: `useHttpPath` is set on remote config; already-published human output warns (no false ✅, points at `--rotate`). Full forgejo suite 18/18 green; ruff + pyright clean.

## Note
Corrected my own earlier fast-triage that called bug #2 "stale" — I'd read empirica's per-uuid token *stash* (`forgejo-tokens/<uuid>`), not git's *credential store*. Logged as a mistake + `invalidates`-edged the stale finding so retrieval won't resurface it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)