### PR TITLE
fix(hooks): harness-guard session-init _auto_sync_plugin (EMPIRICA_HARNESS)

### DIFF
--- a/empirica/plugins/claude-code-integration/hooks/session-init.py
+++ b/empirica/plugins/claude-code-integration/hooks/session-init.py
@@ -1082,12 +1082,14 @@ def _bootstrap_for_existing_session(session_id: str, project_root: Path) -> bool
 def _write_practitioner_presence(claude_session_id: str, ai_id: str, empirica_session_id: str) -> None:
     """Best-effort presence write/refresh, keyed on the durable claude_session_id.
 
-    Stamps ``session_pid`` = ``os.getppid()`` (the Claude Code parent — this hook
-    is spawned by CC). That pid is the daemon's liveness anchor: both
+    Stamps ``session_pid`` = ``os.getppid()`` (the harness parent — this hook is
+    spawned by the harness, Claude Code or otherwise; ``getppid`` is already
+    harness-agnostic). That pid is the daemon's liveness anchor: both
     ``refresh_live_presence`` and ``list_presence``'s pid-liveness override
     (``kill -0``) key off it to keep an alive-but-quiet session visible. Called on
-    BOTH new-session init AND resume — on ``claude --resume`` the OS gives the
-    session a fresh CC parent, so re-stamping keeps the pid current (a stale pid
+    BOTH new-session init AND resume — on a harness resume (e.g. ``claude
+    --resume``) the OS gives the session a fresh parent, so re-stamping keeps the
+    pid current (a stale pid
     would make the resumed session read as dead and vanish from the fleet).
     Never fails session-init on a presence write.
     """
@@ -1475,6 +1477,20 @@ EOF
 """
 
 
+def _harness() -> str:
+    """Which harness is hosting this hook.
+
+    Defaults to ``'claude-code'`` — the original behavior. Non-CC harnesses
+    (e.g. codex, which injects ``EMPIRICA_HARNESS=codex`` from its plugin
+    launcher) set this env var so the hooks skip Claude-Code-specific side
+    effects — like ``_auto_sync_plugin``, which heals a plugin path only CC
+    loads. Keeping the identity in one env signal (rather than N single-purpose
+    opt-outs) is what lets a non-CC harness stop forking hook bodies per
+    re-vendor: it sets EMPIRICA_HARNESS once and the guards below read it.
+    """
+    return (os.environ.get("EMPIRICA_HARNESS") or "claude-code").strip() or "claude-code"
+
+
 def _auto_sync_plugin():
     """Best-effort: heal a stale installed CC plugin so hook fixes from a pip
     upgrade reach this session. Shells out to `empirica plugin-sync` (a no-op
@@ -1485,7 +1501,18 @@ def _auto_sync_plugin():
     ~/.claude/plugins/local/empirica/ until a manual setup-claude-code --force,
     so running CC sessions keep loading the stale gate. Never blocks session
     start — short timeout, all failures swallowed.
+
+    Skipped off Claude Code (``EMPIRICA_HARNESS != 'claude-code'``): plugin-sync
+    heals ``~/.claude/plugins/local/empirica/``, a path other harnesses never
+    load, so it would be pure wasted work each session start. Also honors the
+    explicit ``EMPIRICA_NO_AUTOSYNC`` opt-out (parity with the CLI-level
+    auto-sync in ``cli_core._maybe_autosync_plugin``) so a CC user who doesn't
+    want silent plugin self-heal can turn it off without forking the hook.
     """
+    if _harness() != "claude-code":
+        return
+    if os.environ.get("EMPIRICA_NO_AUTOSYNC"):
+        return
     try:
         subprocess.run(
             ["empirica", "plugin-sync", "--quiet"],

--- a/tests/test_session_init_harness_guard.py
+++ b/tests/test_session_init_harness_guard.py
@@ -1,0 +1,80 @@
+"""Harness-guard on session-init's `_auto_sync_plugin` (ecodex prop_gcwxecse).
+
+`_auto_sync_plugin` shells `empirica plugin-sync` on every SessionStart to heal
+a stale installed CC plugin. That only makes sense under Claude Code: plugin-sync
+heals ``~/.claude/plugins/local/empirica/``, a path other harnesses never load.
+These tests pin the guard: it fires under CC (default), no-ops under a non-CC
+harness (``EMPIRICA_HARNESS=codex``), and honors the explicit
+``EMPIRICA_NO_AUTOSYNC`` opt-out — while never raising.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+HOOK_PATH = (
+    Path(__file__).parent.parent / "empirica" / "plugins" / "claude-code-integration" / "hooks" / "session-init.py"
+)
+_spec = importlib.util.spec_from_file_location("session_init_harness_guard", HOOK_PATH)
+assert _spec is not None and _spec.loader is not None
+session_init = importlib.util.module_from_spec(_spec)
+sys.modules["session_init_harness_guard"] = session_init
+_spec.loader.exec_module(session_init)
+
+
+# ── _harness() — the identity signal ────────────────────────────────────
+
+
+def test_harness_defaults_to_claude_code(monkeypatch):
+    monkeypatch.delenv("EMPIRICA_HARNESS", raising=False)
+    assert session_init._harness() == "claude-code"
+
+
+def test_harness_reads_env(monkeypatch):
+    monkeypatch.setenv("EMPIRICA_HARNESS", "codex")
+    assert session_init._harness() == "codex"
+
+
+def test_harness_blank_falls_back_to_claude_code(monkeypatch):
+    # An empty / whitespace value must not defeat the default (env set to "" by a
+    # launcher shouldn't read as a distinct harness that skips the CC side effects).
+    monkeypatch.setenv("EMPIRICA_HARNESS", "   ")
+    assert session_init._harness() == "claude-code"
+
+
+# ── _auto_sync_plugin() — the guard ─────────────────────────────────────
+
+
+def test_autosync_fires_under_claude_code(monkeypatch):
+    monkeypatch.delenv("EMPIRICA_HARNESS", raising=False)
+    monkeypatch.delenv("EMPIRICA_NO_AUTOSYNC", raising=False)
+    with patch.object(session_init.subprocess, "run") as run:
+        session_init._auto_sync_plugin()
+    assert run.call_count == 1
+    assert run.call_args[0][0] == ["empirica", "plugin-sync", "--quiet"]
+
+
+def test_autosync_skipped_under_non_cc_harness(monkeypatch):
+    monkeypatch.setenv("EMPIRICA_HARNESS", "codex")
+    monkeypatch.delenv("EMPIRICA_NO_AUTOSYNC", raising=False)
+    with patch.object(session_init.subprocess, "run") as run:
+        session_init._auto_sync_plugin()
+    run.assert_not_called()  # heals a path codex never loads — pure wasted work
+
+
+def test_autosync_honors_no_autosync_optout_under_cc(monkeypatch):
+    monkeypatch.delenv("EMPIRICA_HARNESS", raising=False)  # => claude-code
+    monkeypatch.setenv("EMPIRICA_NO_AUTOSYNC", "1")
+    with patch.object(session_init.subprocess, "run") as run:
+        session_init._auto_sync_plugin()
+    run.assert_not_called()  # CC user opted out — parity with cli_core auto-sync
+
+
+def test_autosync_never_raises_on_subprocess_error(monkeypatch):
+    monkeypatch.delenv("EMPIRICA_HARNESS", raising=False)
+    monkeypatch.delenv("EMPIRICA_NO_AUTOSYNC", raising=False)
+    with patch.object(session_init.subprocess, "run", side_effect=OSError("boom")):
+        session_init._auto_sync_plugin()  # best-effort — must not raise


### PR DESCRIPTION
## Why
`session-init.py::_auto_sync_plugin()` (called as the first line of `main()`) shells `empirica plugin-sync --quiet` on **every** SessionStart to self-heal a stale installed CC plugin (deploy-staleness deadlock class). That only makes sense under Claude Code — `plugin-sync` heals `~/.claude/plugins/local/empirica/`, a path other harnesses (e.g. codex) never load. Off-CC it's pure wasted work each session start, and it's a silent plugin-file-mutation surface with no opt-out (design/integrity concern David flagged during ecodex's re-vendor audit).

## Change
- **`_harness()`** — reads `EMPIRICA_HARNESS` (default `'claude-code'`, preserving current behavior). One env identity signal a non-CC harness sets once (codex injects `EMPIRICA_HARNESS=codex` from its launcher) instead of forking hook bodies per re-vendor.
- **`_auto_sync_plugin()` no-ops** when `_harness() != 'claude-code'`.
- **Also honors `EMPIRICA_NO_AUTOSYNC`** in the hook — parity with the CLI-level `cli_core._maybe_autosync_plugin`, so a CC user can turn off silent plugin self-heal without forking the hook (directly answers "user can't opt out").
- Presence-write docstring made harness-generic (`os.getppid()` is already harness-agnostic — no functional change there).

## Deliberately out of scope
Gating **CC's** auto-sync *default* behind opt-in would reintroduce the deploy-staleness deadlock class the self-heal exists to prevent — that's a real trade-off and a separate decision (David's call), not bundled here.

## Tests
`tests/test_session_init_harness_guard.py` — 5 cases (default→CC fires; `EMPIRICA_HARNESS=codex`→skip; `EMPIRICA_NO_AUTOSYNC`→skip; blank env→default; never raises). Full green with the existing autosync + presence suites (24 passed). ruff clean.

Closes ecodex `prop_gcwxecse`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)