### PR TITLE
docs(changelog): sync [Unreleased] + fix pre-release doc drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.12.15] — 2026-07-06
-
 ### Added
+- **`empirica source-review` — the REVIEW half of the source-lifecycle triad
+  (CHECK → UPDATE → REVIEW).** Records a review verdict + `last_reviewed_at` on a
+  source (migration adds both columns to `epistemic_sources`), so a corpus can be
+  judged current/stale, not just present. Completes the triad alongside
+  `sources-check` (detects drift) and `source-update` (re-fetches).
 - **`empirica sources-sanctify` — source-corpus hygiene pass.** Classifies each
   active source **dead** (canonical_path missing), **duplicate** (shared
   `content_hash`), **zombie** (no `sourced_from` reference — nothing cites it), or
   **valid**, and recommends a lifecycle action. Report-only (deletions are a
   judgment that go through review — ARTIFACT_HYGIENE); retire flagged sources via
   `source-archive`. The two new detectors (zombie, duplicate) sit on top of the
-  existing dead/stale probing. This is the prerequisite for sources joining the
+  existing dead probing. This is the prerequisite for sources joining the
   PREFLIGHT retrieval surface — a corpus can't nudge attention until it's trusted.
 - **Blindspot detection — regret auto-trigger.** Closes the loop's training
   signal: a `dismissed` blindspot flips to `regretted` at POSTFLIGHT when a
@@ -24,6 +27,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   was ignored, the gap bit). `created_timestamp > resolved_timestamp` enforces the
   causal order; cross-transaction by construction. Fail-open. `blindspot-report`'s
   regret-rate is now live — the money signal.
+
+### Fixed
+- **`forgejo-publish`: path-scoped credential store + honest re-publish output.**
+  Sets `credential.useHttpPath=true` (repo-local) so each project's per-project
+  Forgejo token gets its own `~/.git-credentials` entry instead of colliding under
+  a shared host-keyed store — a fleet-wide fix for multi-repo mirroring. An
+  already-published re-run now warns "nothing pushed" and points at `--rotate`
+  instead of printing a false "✅ provisioned".
+- **session-init: harness-aware plugin auto-sync (`EMPIRICA_HARNESS`).** The
+  SessionStart hook's `plugin-sync` self-heal now no-ops off Claude Code (default
+  `claude-code` preserves current behavior; a non-CC harness sets `EMPIRICA_HARNESS`
+  once) and honors the existing `EMPIRICA_NO_AUTOSYNC` opt-out — so a non-CC harness
+  stops re-healing a plugin path it never loads, and a CC user can turn off silent
+  self-heal without forking the hook.
+
+### Changed
+- **Lean system prompt: taxonomy + load-bearing-flag sync.** The distributed
+  system-prompt template + AI-facing skills now reflect the current `*-log` flag
+  surface (`--prevention`, `--reversibility {exploratory,committal,forced}`, etc.),
+  and a CI conformance guard fails if the prompt or a skill references an `empirica`
+  verb that doesn't exist — anti-drift for the AI-facing injection surface.
+
+## [1.12.15] — 2026-07-06
+
+### Added
 - **Blindspot detection — POSTFLIGHT outcome/regret loop (T4).** Closes the loop:
   a surfaced blindspot is advanced at POSTFLIGHT to `acknowledged` (its flagged
   task got engaged — a finding, unknown, dead_end, or completion) or `dismissed`

--- a/empirica/cli/parsers/checkpoint_parsers.py
+++ b/empirica/cli/parsers/checkpoint_parsers.py
@@ -502,7 +502,7 @@ def add_checkpoint_parsers(subparsers):
         help=(
             "Provision a managed Forgejo remote for a project (operator / "
             "self-hosting power-user tool, not an end-user default): POST "
-            "cortex's forgejo-publish endpoint, write the deploy key 0600, add "
+            "cortex's forgejo-publish endpoint, write the access token 0600, add "
             "the 'forgejo' git remote, and push the cortex-supplied refspecs. "
             "This is the PUSH mode for projects with no existing remote — "
             "distinct from the managed pull-mirror path. Leaves 'origin' "
@@ -515,7 +515,7 @@ def add_checkpoint_parsers(subparsers):
     forgejo_publish_parser.add_argument(
         "--rotate",
         action="store_true",
-        help="Mint a fresh deploy key (revokes the prior) — also the way to re-push an already-published project.",
+        help="Mint a fresh access token (revokes the prior) — also the way to re-push an already-published project.",
     )
     forgejo_publish_parser.add_argument("--description", help="Optional Forgejo repo description.")
     forgejo_publish_parser.add_argument("--output", choices=["human", "json"], default="human", help="Output format")

--- a/empirica/core/blindspots/outcomes.py
+++ b/empirica/core/blindspots/outcomes.py
@@ -81,8 +81,9 @@ def mark_blindspot_regretted(db, session_id: str, subtask_id: str) -> int:
 
     Called when a mistake or dead-end lands on a subtask that had a dismissed
     blindspot (we warned, it was ignored, and the gap bit). Fail-open; returns
-    rows updated. The automatic trigger from the mistake/dead-end log is the
-    documented follow-up — this is the mechanism it will call.
+    rows updated. The automatic trigger (``apply_blindspot_regret``, run at
+    POSTFLIGHT) shipped alongside this; that path runs its own scoped UPDATE,
+    so this remains the direct/manual entry point.
     """
     try:
         cur = db.conn.execute(

--- a/empirica/core/sources/__init__.py
+++ b/empirica/core/sources/__init__.py
@@ -2,7 +2,7 @@
 
 We've historically been poor at logging epistemic sources, so the corpus carries
 legacy / dead / zombie / duplicate entries. Sanctification classifies each active
-source (dead / duplicate / zombie / stale / valid) and recommends a lifecycle
+source (dead / duplicate / zombie / valid) and recommends a lifecycle
 action, so the corpus can be trusted enough to join the retrieval surface (the
 read-side complement to source-update / source-archive). Report-only by default —
 deletions are a judgment that go through review (ARTIFACT_HYGIENE).

--- a/empirica/core/sources/sanctify.py
+++ b/empirica/core/sources/sanctify.py
@@ -23,8 +23,8 @@ _RECOMMENDATION = {
     "zombie": "review — no artifact references it (sourced_from); retire if truly unused",
     "valid": "keep",
 }
-# The subset --execute may auto-apply (safe, reversible archival). Zombie stays
-# manual: an unreferenced source may still be legitimately citable.
+# The subset a future auto-apply mode could safely archive (safe, reversible).
+# Zombie stays manual: an unreferenced source may still be legitimately citable.
 AUTO_SAFE = frozenset({"dead", "duplicate"})
 
 
@@ -42,7 +42,7 @@ def classify_sources(
     - ``missing_paths`` — canonical_paths that don't exist on disk
 
     Precedence: dead → duplicate → zombie → valid. Returns one classification per
-    source with its recommended action and whether ``--execute`` may auto-apply it.
+    source with its recommended action and whether it's auto-safe to archive.
     """
     out: list[dict] = []
     for s in sources:


### PR DESCRIPTION
Pre-release docs sweep for the v1.12.15→HEAD delta (#285–#294). Deterministic half GREEN (ruff/format/pyright/pytest/compliance 13-13) and the broccoli structural pattern-hunt GREEN — this PR fixes the doc-alignment YELLOW findings.

## CHANGELOG (the release blocker)
- `[Unreleased]` was empty while 10 commits shipped.
- **`sources-sanctify` (#286) + `regret auto-trigger` (#285)** were misfiled under the released `[1.12.15]` heading — they landed *after* the tag (v1.12.15 tip = #284). Moved to `[Unreleased]`.
- Added missing entries: **`source-review` (#288, new user-facing verb)**, **forgejo-publish fix (#293)**, **harness-guard (#294)**, prompt/conformance (#290–#292).

## Low doc nits
- `sanctify.py` / `sources/__init__.py`: dropped the phantom `--execute` flag references + the non-existent `stale` verdict (`VERDICTS = dead/duplicate/zombie/valid`).
- `blindspots/outcomes.py`: `mark_blindspot_regretted` docstring no longer calls the auto-trigger a "follow-up" (it shipped alongside as `apply_blindspot_regret`).
- `checkpoint_parsers.py`: forgejo help says "access token", not "deploy key" (HTTPS+token, not SSH).

No behavior change — docs/comments/help-text only. ruff + format clean, affected tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)