### PR TITLE
fix(sources): source-archive clears the memory-collection embed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`source-archive`: clear the source's semantic-search embed too.** Archiving a
+  source hard-deleted its content chunks (`_docs_collection`) but left its metadata
+  embed in `_memory_collection`, so an archived (soft-deleted) source stayed
+  discoverable via `sources-map` / cross-project semantic search. Archive now also
+  removes the `item_type='source'` point (filtered by `artifact_id` + `type`), so
+  the "remove" step propagates to *every* Qdrant surface, not just the docs
+  collection. Surfaced by a source-lifecycle boundary-hygiene audit — the
+  companion `source-update` "stale embed" suspicion was a false alarm (source
+  embeds are metadata-only; update never changes title/description/url). Archive
+  result JSON gains `memory_embed_deleted`.
+
 ## [1.12.16] — 2026-07-07
 
 ### Added

--- a/empirica/cli/command_handlers/artifact_log_commands.py
+++ b/empirica/cli/command_handlers/artifact_log_commands.py
@@ -2306,6 +2306,45 @@ def _hard_delete_source_chunks(project_id: str, source_id: str) -> int:
         return 0
 
 
+def _hard_delete_source_memory_embed(project_id: str, source_id: str) -> int:
+    """Best-effort delete of the source's metadata embed from the memory collection.
+
+    A source is embedded at add-time into ``_memory_collection`` as an
+    ``item_type='source'`` point (payload ``artifact_id=source_id``, ``type='source'``)
+    so it is discoverable via ``sources-map`` / cross-project semantic search. On
+    archive that embed must go too — otherwise the archived source stays
+    discoverable even though it is soft-deleted. This is DISTINCT from
+    ``_hard_delete_source_chunks``, which clears content chunks in
+    ``_docs_collection`` (a different collection that CLI-added sources don't
+    populate). Returns points deleted (0 if Qdrant unavailable or none found).
+    """
+    try:
+        from empirica.core.qdrant.collections import _memory_collection
+        from empirica.core.qdrant.connection import _get_qdrant_client
+    except ImportError:
+        return 0
+    client = _get_qdrant_client()
+    if client is None:
+        return 0
+    try:
+        from qdrant_client.models import FieldCondition, Filter, MatchValue
+
+        coll = _memory_collection(project_id)
+        if not client.collection_exists(coll):
+            return 0
+        flt = Filter(
+            must=[
+                FieldCondition(key="artifact_id", match=MatchValue(value=source_id)),
+                FieldCondition(key="type", match=MatchValue(value="source")),
+            ]
+        )
+        result = client.delete(collection_name=coll, points_selector=flt)
+        return getattr(result, "deleted", 0) or 0
+    except Exception as e:
+        logger.debug(f"_hard_delete_source_memory_embed: qdrant delete failed: {e}")
+        return 0
+
+
 def _push_source_archive_to_cortex(full_id: str, reason: str, target_id: str | None) -> dict | None:
     """Best-effort `DELETE /v1/sources/{id}` to Cortex (Phase 1.5).
 
@@ -2463,6 +2502,9 @@ def handle_source_archive_command(args):
 
         # Hard-delete chunks (best-effort; non-fatal)
         chunks_deleted = _hard_delete_source_chunks(project_id, full_id)
+        # Remove the source's metadata embed from the memory collection too —
+        # otherwise the archived source stays discoverable via sources-map / search.
+        memory_deleted = _hard_delete_source_memory_embed(project_id, full_id)
 
         # Optional Cortex sync (Phase 1.5) — no-op when env vars unset
         cortex_status = _push_source_archive_to_cortex(full_id, reason, target_id)
@@ -2476,6 +2518,7 @@ def handle_source_archive_command(args):
             "archive_target_id": target_id,
             "archived_at": now,
             "chunks_deleted": chunks_deleted,
+            "memory_embed_deleted": memory_deleted,
             "audit_log": existing_log,
             "message": "Source archived (soft-delete; edges + citing artifacts preserved)",
         }

--- a/tests/test_source_archive.py
+++ b/tests/test_source_archive.py
@@ -216,6 +216,35 @@ def test_archive_user_deleted_round_trip(project_db: Path, capsys):
     assert row[3] is not None  # epoch set
 
 
+def test_archive_removes_memory_embed(project_db: Path, capsys):
+    """source-archive must clear the source's metadata embed from the memory
+    collection (else the archived source stays discoverable via sources-map)."""
+    sid = _seed_source(project_db)
+
+    with patch("empirica.data.session_database.SessionDatabase") as MockDB:
+        MockDB.return_value.conn = sqlite3.connect(
+            str(project_db / ".empirica" / "sessions" / "sessions.db"),
+        )
+        with patch(
+            "empirica.cli.command_handlers.artifact_log_commands._hard_delete_source_chunks",
+            return_value=0,
+        ), patch(
+            "empirica.cli.command_handlers.artifact_log_commands._hard_delete_source_memory_embed",
+            return_value=1,
+        ) as mock_mem:
+            rc = handle_source_archive_command(
+                _make_args(source_id=sid, reason="user_deleted")
+            )
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    # the memory-embed cleanup was invoked with the resolved source id ...
+    mock_mem.assert_called_once()
+    assert mock_mem.call_args.args[1] == sid
+    # ... and its result is surfaced in the payload
+    assert payload["memory_embed_deleted"] == 1
+
+
 def test_archive_superseded_with_target(project_db: Path, capsys):
     src = _seed_source(project_db, title="Old version")
     replacement = _seed_source(project_db, title="New version")

--- a/tests/test_source_archive.py
+++ b/tests/test_source_archive.py
@@ -225,16 +225,17 @@ def test_archive_removes_memory_embed(project_db: Path, capsys):
         MockDB.return_value.conn = sqlite3.connect(
             str(project_db / ".empirica" / "sessions" / "sessions.db"),
         )
-        with patch(
-            "empirica.cli.command_handlers.artifact_log_commands._hard_delete_source_chunks",
-            return_value=0,
-        ), patch(
-            "empirica.cli.command_handlers.artifact_log_commands._hard_delete_source_memory_embed",
-            return_value=1,
-        ) as mock_mem:
-            rc = handle_source_archive_command(
-                _make_args(source_id=sid, reason="user_deleted")
-            )
+        with (
+            patch(
+                "empirica.cli.command_handlers.artifact_log_commands._hard_delete_source_chunks",
+                return_value=0,
+            ),
+            patch(
+                "empirica.cli.command_handlers.artifact_log_commands._hard_delete_source_memory_embed",
+                return_value=1,
+            ) as mock_mem,
+        ):
+            rc = handle_source_archive_command(_make_args(source_id=sid, reason="user_deleted"))
 
     assert rc == 0
     payload = json.loads(capsys.readouterr().out)


### PR DESCRIPTION
## What
`source-archive` now removes the source's metadata embed from `_memory_collection`, not just content chunks from `_docs_collection`.

## Why
A source is embedded at add-time into `_memory_collection` (`item_type='source'`, `artifact_id=source_id`) for semantic discovery via `sources-map` / cross-project search. Archive hard-deleted `_docs_collection` chunks (which CLI-added sources don't even populate) but **left the memory embed** — so an archived (soft-deleted) source stayed semantically discoverable. This closes the "remove" half of source-lifecycle propagation so it reaches *every* Qdrant surface.

## How
- New `_hard_delete_source_memory_embed(project_id, source_id)` — mirrors `_hard_delete_source_chunks` but targets `_memory_collection`, filtered by `artifact_id` + `type='source'`. Best-effort, non-fatal.
- Wired into `handle_source_archive_command`; archive result JSON gains `memory_embed_deleted`.
- +1 test (`test_archive_removes_memory_embed`).

## Provenance
Surfaced by a source-lifecycle boundary-hygiene audit (the SQLite↔Qdrant↔Cortex boundary). The companion `source-update` "stale embed" suspicion was a **false alarm** and corrected — source embeds are metadata-only (title/description/url), which `source-update` never changes.

## Test
`pytest tests/test_source_archive.py` → **18 passed**. ruff + pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
