### PR TITLE
feat(sources): Unified Source Identity P1 — cortex_uuid alias + daemon dual-resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Unified Source Identity P1 — one source, two addresses (dual-resolution).**
+  A source that only cortex knows by its catalogue uuid — but whose file exists
+  locally under a *different* local uuid — used to 404 on the daemon (`GET
+  /api/v1/sources/{id}/content`): the daemon and cortex kept separate id-spaces.
+  Now a local row can carry the catalogue uuid as an **alias** (`cortex_uuid`,
+  migration 055) and the daemon resolves **`id OR cortex_uuid`**, so a client
+  holding only the cortex uuid still reaches the local source. `sources-reconcile`
+  populates the alias **non-destructively by default**; the pre-existing
+  destructive PK-swap (rewrite the local id to the catalogue uuid + cascade
+  edges) is now opt-in via **`--converge`**. Offline-safe (no cortex call at
+  request time), no Qdrant re-key. Contract pinned with cortex + extension.
+  Extension needs zero change (it already requests by the cortex uuid).
+
 ### Fixed
 - **`source-archive`: clear the source's semantic-search embed too.** Archiving a
   source hard-deleted its content chunks (`_docs_collection`) but left its metadata

--- a/empirica/api/routes/artifacts.py
+++ b/empirica/api/routes/artifacts.py
@@ -754,13 +754,29 @@ async def get_source_content(
 
 
 def _fetch_source_row(db, project_id: str, source_id: str) -> dict | None:
-    """Read one ``epistemic_sources`` row by id, scoped to project."""
+    """Read one ``epistemic_sources`` row, scoped to project.
+
+    Resolves EITHER the local PK ``id`` OR the ``cortex_uuid`` alias (Unified
+    Source Identity, Option A) so a client that only holds the catalogue uuid
+    still reaches the local source. Falls back to id-only on a DB that predates
+    the ``cortex_uuid`` column (migration 055) — ``_open_db_for`` is read-only
+    and runs no migrations, so an older daemon DB may lack the column.
+    """
+    import sqlite3
+
     cursor = db.conn.cursor()
-    cursor.execute(
-        "SELECT id, title, source_url, source_type, description "
-        "FROM epistemic_sources WHERE project_id = ? AND id = ? LIMIT 1",
-        (project_id, source_id),
-    )
+    try:
+        cursor.execute(
+            "SELECT id, title, source_url, source_type, description "
+            "FROM epistemic_sources WHERE project_id = ? AND (id = ? OR cortex_uuid = ?) LIMIT 1",
+            (project_id, source_id, source_id),
+        )
+    except sqlite3.OperationalError:
+        cursor.execute(
+            "SELECT id, title, source_url, source_type, description "
+            "FROM epistemic_sources WHERE project_id = ? AND id = ? LIMIT 1",
+            (project_id, source_id),
+        )
     r = cursor.fetchone()
     if not r:
         return None

--- a/empirica/cli/command_handlers/sources_reconcile_commands.py
+++ b/empirica/cli/command_handlers/sources_reconcile_commands.py
@@ -20,14 +20,18 @@ Four phases:
      ``/v1/sources/reconcile`` (pinned contract). The catalogue validates
      hash + tenancy; rejections come back typed (cortex_uuid_not_found →
      re-register as fresh; hash_mismatch → divergent fork, no swap).
-  4. **Swap** (``--apply`` only) — per confirmed pair, one SQLite
-     transaction: epistemic_sources PK, artifact_edges from_id/to_id,
-     archive_target_id supersession pointers, project_findings.source_refs
-     JSON arrays. Workspace-DB entity_artifacts rows are swapped
-     best-effort (separate database). Qdrant points are NOT re-pointed
-     here — ``empirica rebuild`` regenerates them from SQLite.
+  4. **Adopt** (``--apply``) — per confirmed pair. The DEFAULT is a
+     non-destructive ALIAS: the local row keeps its PK and stores the
+     catalogue uuid in ``cortex_uuid`` (the daemon resolves ``id OR
+     cortex_uuid``, so both address the same source — no cascade, no
+     Qdrant change, offline-safe). ``--converge`` instead PK-SWAPS in one
+     SQLite transaction — epistemic_sources PK, artifact_edges
+     from_id/to_id, archive_target_id supersession pointers,
+     project_findings.source_refs JSON arrays, plus best-effort
+     workspace-DB entity_artifacts. Qdrant points are NOT re-pointed on
+     swap — ``empirica rebuild`` regenerates them from SQLite.
 
-Dry-run by default; ``--apply`` performs the swaps.
+Dry-run by default; ``--apply`` adopts (alias), ``--apply --converge`` swaps.
 """
 
 from __future__ import annotations
@@ -51,6 +55,7 @@ def handle_sources_reconcile_command(args) -> int:
 
     output = getattr(args, "output", "human")
     apply = bool(getattr(args, "apply", False))
+    converge = bool(getattr(args, "converge", False))
 
     project_id = getattr(args, "project_id", None)
     if not project_id:
@@ -91,20 +96,20 @@ def handle_sources_reconcile_command(args) -> int:
             confirm_status = "skipped_no_matches"
 
         swapped: list[dict] = []
+        aliased: list[dict] = []
         if apply and confirmed:
             for pair in confirmed:
-                swapped.append(
-                    _swap_source_id(
-                        db,
-                        project_id,
-                        pair["local_uuid"],
-                        pair["cortex_uuid"],
-                    )
-                )
+                if converge:
+                    # Opt-in: destructive one-uuid PK-swap + cascade.
+                    swapped.append(_swap_source_id(db, project_id, pair["local_uuid"], pair["cortex_uuid"]))
+                else:
+                    # Default: non-destructive alias adopt (daemon resolves id OR cortex_uuid).
+                    aliased.append(_set_cortex_uuid_alias(db, project_id, pair["local_uuid"], pair["cortex_uuid"]))
 
         payload = {
             "ok": True,
             "dry_run": not apply,
+            "mode": "converge" if converge else "alias",
             "project_id": project_id,
             "local_sources": len(rows),
             "backfilled_identity": backfilled,
@@ -115,6 +120,7 @@ def handle_sources_reconcile_command(args) -> int:
             "confirmed": confirmed,
             "rejected": rejected,
             "swapped": swapped,
+            "aliased": aliased,
         }
         _emit(output, payload, _render_human(payload))
         return 0
@@ -302,6 +308,33 @@ def _confirm_matches(
         return [], [], f"unavailable_http_{e.code}"
     except (urllib.error.URLError, OSError, json.JSONDecodeError) as e:
         return [], [], f"unavailable: {e}"
+
+
+def _set_cortex_uuid_alias(db, project_id: str, local_uuid: str, cortex_uuid: str) -> dict:
+    """Non-destructive adopt (Unified Source Identity, Option A): record the
+    catalogue uuid as an ALIAS on the local row WITHOUT rewriting its PK.
+
+    The daemon resolves ``id OR cortex_uuid``, so both address the same source —
+    no edge cascade, no Qdrant re-key, offline-safe. Use ``--converge`` for the
+    destructive one-uuid PK-swap (``_swap_source_id``) when full convergence is
+    wanted. Returns a status dict mirroring ``_swap_source_id``'s shape.
+    """
+    result = {"local_uuid": local_uuid, "cortex_uuid": cortex_uuid, "aliased": False}
+    cursor = db.conn.cursor()
+    try:
+        cursor.execute(
+            "UPDATE epistemic_sources SET cortex_uuid = ? WHERE id = ? AND project_id = ?",
+            (cortex_uuid, local_uuid, project_id),
+        )
+        db.conn.commit()
+        if cursor.rowcount == 0:
+            result["error"] = "local row not found"
+        else:
+            result["aliased"] = True
+    except Exception as e:
+        db.conn.rollback()
+        result["error"] = str(e)
+    return result
 
 
 def _swap_source_id(

--- a/empirica/cli/parsers/checkpoint_parsers.py
+++ b/empirica/cli/parsers/checkpoint_parsers.py
@@ -1523,16 +1523,27 @@ def add_checkpoint_parsers(subparsers):
         "sources-reconcile",
         help=(
             "Match local sources against the central catalogue by content "
-            "identity and adopt the catalogue uuid (PK-swap + cascade of "
-            "edges, supersession pointers, finding source_refs). Also "
-            "lazy-backfills content_hash/size/canonical_path on file-backed "
-            "rows that predate migration 050. Dry-run by default; pass "
-            "--apply to perform the swaps. Run `empirica rebuild` after an "
-            "applied reconcile to re-point Qdrant entries."
+            "identity and adopt the catalogue uuid. Default adopt is "
+            "NON-DESTRUCTIVE: the local row keeps its PK and stores the "
+            "catalogue uuid as an alias (the daemon resolves id OR cortex_uuid). "
+            "Pass --converge for the destructive one-uuid PK-swap + cascade "
+            "(edges, supersession pointers, finding source_refs), then run "
+            "`empirica rebuild` to re-point Qdrant. Also lazy-backfills "
+            "content_hash/size/canonical_path on file-backed rows predating "
+            "migration 050. Dry-run by default; pass --apply to mutate."
         ),
     )
     sources_reconcile_parser.add_argument(
-        "--apply", action="store_true", help="Perform the confirmed swaps (default: dry-run report)"
+        "--apply", action="store_true", help="Perform the confirmed adopts (default: dry-run report)"
+    )
+    sources_reconcile_parser.add_argument(
+        "--converge",
+        action="store_true",
+        help=(
+            "With --apply: PK-swap local ids to the catalogue uuid (destructive "
+            "one-uuid convergence + edge cascade). Default is a non-destructive "
+            "alias adopt. Run `empirica rebuild` after --converge to re-point Qdrant."
+        ),
     )
     sources_reconcile_parser.add_argument(
         "--project-id", help="Project UUID (auto-derived from active session when omitted)"

--- a/empirica/data/migrations/migrations.py
+++ b/empirica/data/migrations/migrations.py
@@ -1486,6 +1486,11 @@ ALL_MIGRATIONS: list[tuple[str, str, Callable]] = [
         "Add review-state columns (last_reviewed_at, review_verdict) to epistemic_sources — the REVIEW half of the source-lifecycle triad (CHECK=sources-check, UPDATE=source-update). source-review appends a 'reviewed' event to lifecycle_audit_log AND stamps the latest verdict here so review state is queryable (surface unreviewed / stale-review sources) without parsing the JSON audit log. Additive + idempotent via add_column_if_missing.",
         lambda cursor: migration_054_source_review_state(cursor),
     ),
+    (
+        "055_source_cortex_uuid",
+        "Add cortex_uuid alias column to epistemic_sources — Unified Source Identity P1 (Option A, dual-resolution). A local source keeps its own PK and stores the catalogue uuid as an alias; the daemon resolves `id OR cortex_uuid` so a client holding only the cortex uuid still resolves the local source (kills the two-id-space 404). sources-reconcile populates the alias non-destructively by default; the destructive PK-swap stays opt-in via --converge. Indexed. Additive + idempotent via add_column_if_missing.",
+        lambda cursor: migration_055_source_cortex_uuid(cursor),
+    ),
 ]
 
 
@@ -2044,6 +2049,25 @@ def migration_054_source_review_state(cursor: sqlite3.Cursor):
     add_column_if_missing(cursor, "epistemic_sources", "last_reviewed_at", "REAL", "NULL")
     add_column_if_missing(cursor, "epistemic_sources", "review_verdict", "TEXT", "NULL")
     logger.info("✅ Migration 054 complete: review-state columns added to epistemic_sources")
+
+
+def migration_055_source_cortex_uuid(cursor: sqlite3.Cursor):
+    """Add `cortex_uuid` alias column to epistemic_sources — Unified Source Identity P1 (Option A).
+
+    A local source keeps its OWN uuid as the primary key and stores the
+    catalogue's uuid as an ALIAS. The daemon resolves ``id OR cortex_uuid``
+    (api/routes/artifacts.py::_fetch_source_row), so a client that only holds
+    the catalogue uuid still reaches the local source — killing the
+    two-id-space 404 WITHOUT the destructive PK-swap (which stays opt-in via
+    ``sources-reconcile --converge``). ``sources-reconcile`` populates the
+    alias non-destructively by default.
+
+    Nullable, additive, idempotent via add_column_if_missing. Indexed for the
+    daemon's ``WHERE cortex_uuid = ?`` lookup.
+    """
+    add_column_if_missing(cursor, "epistemic_sources", "cortex_uuid", "TEXT", "NULL")
+    cursor.execute("CREATE INDEX IF NOT EXISTS idx_epistemic_sources_cortex_uuid ON epistemic_sources(cortex_uuid)")
+    logger.info("✅ Migration 055 complete: cortex_uuid alias column added to epistemic_sources")
 
 
 def migration_051_goals_engagement_id(cursor: sqlite3.Cursor):

--- a/tests/test_serve_sources_content.py
+++ b/tests/test_serve_sources_content.py
@@ -301,3 +301,45 @@ def test_oversized_file_returns_truncation_marker(tmp_path, reset_daemon_cache, 
     assert body["content"] is None
     assert body["size_bytes"] == 200
     assert "exceeds" in body["hint"]
+
+
+# ── Cortex-uuid alias resolution (Unified Source Identity, Option A) ──
+
+
+def test_source_resolves_by_cortex_uuid_alias(tmp_path, reset_daemon_cache):
+    """A source requested by its CATALOGUE uuid (not its local PK) still
+    resolves — the two-id-space 404 fix (migration 055, dual-resolution).
+    Extension always requests by the cortex uuid, which is the only id its
+    projection gives it."""
+    pid = str(uuid.uuid4())
+    proj = _make_project_with_db(tmp_path, pid)
+    # Simulate a migration-055 DB: add the alias column.
+    db_path = proj / ".empirica" / "sessions" / "sessions.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("ALTER TABLE epistemic_sources ADD COLUMN cortex_uuid TEXT")
+    conn.commit()
+    conn.close()
+
+    (proj / "spec.md").write_text("# Spec\n\nHello.\n", encoding="utf-8")
+    local_id = _insert_source(proj, pid, "spec.md", title="Spec doc")
+
+    # Adopt the catalogue uuid as an alias (what `sources-reconcile` does by default).
+    cortex_uuid = str(uuid.uuid4())
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        "UPDATE epistemic_sources SET cortex_uuid = ? WHERE id = ?",
+        (cortex_uuid, local_id),
+    )
+    conn.commit()
+    conn.close()
+
+    # Request by the CORTEX uuid → resolves the local file (was a 404 before P1).
+    code, body = _get_content(proj, cortex_uuid)
+    assert code == 200
+    assert body["kind"] == "file"
+    assert "Hello." in body["content"]
+
+    # The local id still resolves too — both address the same source.
+    code2, body2 = _get_content(proj, local_id)
+    assert code2 == 200
+    assert body2["kind"] == "file"

--- a/tests/test_sources_reconcile.py
+++ b/tests/test_sources_reconcile.py
@@ -52,7 +52,8 @@ def _schema(conn: sqlite3.Connection) -> None:
             content_hash TEXT,
             size_bytes INTEGER,
             canonical_path TEXT,
-            mime_type TEXT
+            mime_type TEXT,
+            cortex_uuid TEXT
         );
         CREATE TABLE artifact_edges (
             from_id TEXT NOT NULL,
@@ -321,6 +322,7 @@ def test_swap_missing_row_reports_error_without_partial_writes(db):
 def _make_args(**overrides):
     defaults = {
         "apply": False,
+        "converge": False,
         "project_id": PROJECT,
         "cortex_url": "https://c.test",
         "api_key": "k",
@@ -371,7 +373,8 @@ def test_dry_run_confirms_but_never_swaps(db, capsys):
     assert cur.fetchone() is not None  # untouched
 
 
-def test_apply_swaps_confirmed_and_passes_rejected_through(db, capsys):
+def test_converge_swaps_confirmed_and_passes_rejected_through(db, capsys):
+    """--apply --converge does the destructive PK-swap (opt-in one-uuid)."""
     l1, c1 = str(uuid.uuid4()), str(uuid.uuid4())
     l2, c2 = str(uuid.uuid4()), str(uuid.uuid4())
     _insert_source(db, l1, content_hash="sha256:aa")
@@ -380,7 +383,7 @@ def test_apply_swaps_confirmed_and_passes_rejected_through(db, capsys):
 
     out = _run(
         db,
-        _make_args(apply=True),
+        _make_args(apply=True, converge=True),
         capsys,
         catalogue={
             "sources": [
@@ -394,8 +397,34 @@ def test_apply_swaps_confirmed_and_passes_rejected_through(db, capsys):
         },
     )
     assert out["dry_run"] is False
+    assert out["mode"] == "converge"
     assert out["swapped"][0]["swapped"] is True
+    assert out["aliased"] == []
     assert out["rejected"][0]["reason"] == "hash_mismatch"
     cur = db.conn.execute("SELECT id FROM epistemic_sources WHERE id IN (?,?)", (c1, l2))
     ids = {r[0] for r in cur.fetchall()}
     assert ids == {c1, l2}  # l1 swapped to c1; rejected l2 untouched
+
+
+def test_apply_default_aliases_non_destructively(db, capsys):
+    """Default --apply (no --converge) records the catalogue uuid as an ALIAS:
+    the local PK is unchanged and cortex_uuid is set, so the daemon can resolve
+    either id. No edge cascade, no Qdrant re-key (Unified Source Identity, A)."""
+    l1, c1 = str(uuid.uuid4()), str(uuid.uuid4())
+    _insert_source(db, l1, content_hash="sha256:aa")
+    db.close = lambda: None
+
+    out = _run(
+        db,
+        _make_args(apply=True),  # no converge → alias mode
+        capsys,
+        catalogue={"sources": [{"id": c1, "content_hash": "sha256:aa"}]},
+        confirm={"confirmed": [{"local_uuid": l1, "cortex_uuid": c1}], "rejected": []},
+    )
+    assert out["dry_run"] is False
+    assert out["mode"] == "alias"
+    assert out["swapped"] == []
+    assert out["aliased"][0]["aliased"] is True
+    row = db.conn.execute("SELECT id, cortex_uuid FROM epistemic_sources WHERE id = ?", (l1,)).fetchone()
+    assert row[0] == l1  # local PK preserved (non-destructive)
+    assert row[1] == c1  # cortex_uuid alias recorded


### PR DESCRIPTION
## What
Kills the two-id-space **404** (extension SER `prop_zhgsjgtphndgxditwranp…`): a source cortex knows by its catalogue uuid, whose file exists locally under a *different* local uuid, previously 404'd on `GET /api/v1/sources/{id}/content` because the daemon and cortex kept separate id-spaces.

## How (Option A — dual-resolution, pinned with cortex + extension)
- **migration 055** — additive `cortex_uuid` alias column on `epistemic_sources` (+ index), idempotent.
- **daemon** `_fetch_source_row` resolves **`id OR cortex_uuid`**, with an `OperationalError` fallback to id-only for un-migrated read-only daemon DBs (`_open_db_for` runs no migrations).
- **`sources-reconcile`** populates the alias **non-destructively by default** (`_set_cortex_uuid_alias`); the pre-existing destructive PK-swap is now **opt-in via `--converge`**. `mode`/`aliased` surfaced in the payload.

## Why A
Offline-safe (no cortex call at request time), no Qdrant re-key (sidesteps the PK-swap's rebuild-staleness), and **zero extension change** — it already requests by the cortex uuid. `--converge` keeps the pure one-uuid path available on demand.

## Tests
`test_serve_sources_content.py::test_source_resolves_by_cortex_uuid_alias` (resolve by cortex uuid), `test_sources_reconcile.py::test_apply_default_aliases_non_destructively` + `test_converge_swaps_confirmed…` (alias default vs opt-in swap). Migration verified idempotent. **130 passed** across the source/serve/reconcile/migration surface; ruff + format + pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
