### PR TITLE
feat(goals): goals-reopen — reverse a completed goal (reversible close)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **`empirica goals-reopen` — reverse a completed goal (reversible close).**
+  `goals-complete` was effectively irreversible via the CLI (`goals-activate` is
+  planned-only), so an accidental or premature completion could only be undone by
+  hand-editing the DB. `goals-reopen --goal-id <id> [--reason ...]` flips a
+  completed goal back to `in_progress`, clears the completed flags
+  (`is_completed`, `completed_timestamp`), and re-links it to the current
+  transaction. Matches on `status='completed'` OR `is_completed=1` (the latter is
+  the source of truth); records a `reopen_history` entry in `goal_data`. Part 1 of
+  the goal-lifecycle directive (reversibility) — archive-closed-after-X follows.
 - **Unified Source Identity P1 — one source, two addresses (dual-resolution).**
   A source that only cortex knows by its catalogue uuid — but whose file exists
   locally under a *different* local uuid — used to 404 on the daemon (`GET

--- a/empirica/cli/cli_core.py
+++ b/empirica/cli/cli_core.py
@@ -941,6 +941,8 @@ def main(args=None):
             "goals-get-stale": handle_goals_get_stale_command,
             "goals-activate": handle_goals_activate_command,
             "goal-activate": handle_goals_activate_command,
+            "goals-reopen": handle_goals_reopen_command,
+            "goal-reopen": handle_goals_reopen_command,
             "goals-refresh": handle_goals_refresh_command,
             # Vision commands
             "vision": handle_vision_analyze,

--- a/empirica/cli/command_handlers/__init__.py
+++ b/empirica/cli/command_handlers/__init__.py
@@ -108,7 +108,6 @@ from .forgejo_commands import handle_forgejo_publish_command
 from .git_commands import handle_history_command, handle_save_command
 from .goal_commands import (
     handle_goals_activate_command,
-    handle_goals_reopen_command,
     handle_goals_add_dependency_command,
     handle_goals_add_task_command,
     handle_goals_claim_command,
@@ -124,6 +123,7 @@ from .goal_commands import (
     handle_goals_prune_command,
     handle_goals_ready_command,
     handle_goals_refresh_command,
+    handle_goals_reopen_command,
     handle_goals_resume_command,
     handle_goals_search_command,
     handle_sessions_resume_command,

--- a/empirica/cli/command_handlers/__init__.py
+++ b/empirica/cli/command_handlers/__init__.py
@@ -108,6 +108,7 @@ from .forgejo_commands import handle_forgejo_publish_command
 from .git_commands import handle_history_command, handle_save_command
 from .goal_commands import (
     handle_goals_activate_command,
+    handle_goals_reopen_command,
     handle_goals_add_dependency_command,
     handle_goals_add_task_command,
     handle_goals_claim_command,
@@ -356,6 +357,7 @@ __all__ = [  # noqa: RUF022
     "handle_note_command",
     "handle_forgejo_publish_command",
     "handle_goals_activate_command",  # Activate planned goal → in_progress
+    "handle_goals_reopen_command",  # Reopen completed goal → in_progress (reversible close)
     "handle_goals_add_dependency_command",
     "handle_goals_add_task_command",
     "handle_goals_claim_command",  # Phase 3a - Git bridge

--- a/empirica/cli/command_handlers/goal_commands.py
+++ b/empirica/cli/command_handlers/goal_commands.py
@@ -1890,6 +1890,59 @@ def handle_goals_activate_command(args):
         handle_cli_error(e, "Activate goal", getattr(args, "verbose", False))
 
 
+def handle_goals_reopen_command(args):
+    """Handle goals-reopen command — transition a COMPLETED goal back to in_progress.
+
+    Makes goals-complete reversible: undo an accidental or premature completion,
+    re-linking the goal to the current transaction. The inverse of goals-complete.
+    """
+    try:
+        from empirica.data.repositories.goals import GoalDataRepository
+        from empirica.data.session_database import SessionDatabase
+
+        goal_id = args.goal_id
+        reason = getattr(args, "reason", None)
+        output_format = getattr(args, "output", "json")
+
+        transaction_id = None
+        try:
+            transaction_id = R.transaction_id()
+        except Exception:
+            pass
+
+        db = SessionDatabase()
+        repo = GoalDataRepository(db.conn)
+        reopened = repo.reopen_goal(goal_id, reason=reason, transaction_id=transaction_id)
+        db.close()
+
+        if reopened:
+            result = {
+                "ok": True,
+                "goal_id": goal_id,
+                "status": "in_progress",
+                "reason": reason,
+                "transaction_id": transaction_id,
+                "message": f"Goal {goal_id[:8]} reopened — back to in_progress",
+            }
+            if output_format == "json":
+                print(json.dumps(result))
+            else:
+                print(f"✅ Reopened goal: {goal_id[:8]} — now in_progress")
+                if reason:
+                    print(f"   Reason: {reason}")
+                if transaction_id:
+                    print(f"   Linked to transaction: {transaction_id[:8]}")
+        else:
+            result = {"ok": False, "error": f"Goal {goal_id} not found or not in 'completed' status"}
+            print(json.dumps(result))
+            sys.exit(1)
+
+    except Exception as e:
+        from empirica.cli.cli_utils import handle_cli_error
+
+        handle_cli_error(e, "Reopen goal", getattr(args, "verbose", False))
+
+
 def handle_goals_refresh_command(args):
     """Handle goals-refresh command - Mark a stale goal as in_progress
 

--- a/empirica/cli/parsers/checkpoint_parsers.py
+++ b/empirica/cli/parsers/checkpoint_parsers.py
@@ -2125,6 +2125,20 @@ written to git notes (breadcrumbs ref) for audit trail.
     goals_activate_parser.add_argument("--goal-id", required=True, help="Goal UUID to activate (prefix match)")
     goals_activate_parser.add_argument("--output", choices=["human", "json"], default="json", help="Output format")
 
+    # Goals reopen command (reverse a completed goal back to in_progress)
+    goals_reopen_parser = subparsers.add_parser(
+        "goals-reopen",
+        aliases=["goal-reopen"],
+        help=(
+            "Reopen a COMPLETED goal — flip it back to in_progress and re-link "
+            "it to the active transaction. The inverse of goals-complete: undo "
+            "an accidental or premature completion so it re-enters the active list."
+        ),
+    )
+    goals_reopen_parser.add_argument("--goal-id", required=True, help="Goal UUID to reopen (prefix match)")
+    goals_reopen_parser.add_argument("--reason", help="Optional note recorded in the goal's reopen history")
+    goals_reopen_parser.add_argument("--output", choices=["human", "json"], default="json", help="Output format")
+
     # Goals refresh command (mark stale goal as in_progress after regaining context)
     goals_refresh_parser = subparsers.add_parser(
         "goals-refresh",

--- a/empirica/data/repositories/goals.py
+++ b/empirica/data/repositories/goals.py
@@ -515,6 +515,46 @@ class GoalDataRepository(BaseRepository):
         self.commit()
         return True
 
+    def reopen_goal(self, goal_id: str, reason: str | None = None, transaction_id: str | None = None) -> bool:
+        """Reopen a COMPLETED goal — flip status back to in_progress and clear
+        the completed flags. Makes ``goals-complete`` reversible via the CLI
+        (an accidental or premature completion can be undone).
+
+        Args:
+            goal_id: Goal UUID (prefix match supported)
+            reason: Optional note appended to goal_data.reopen_history
+            transaction_id: Current transaction UUID to re-link the goal to
+
+        Returns:
+            True if reopened, False if goal not found or not completed
+        """
+        cursor = self._execute(
+            "SELECT id, goal_data FROM goals WHERE id LIKE ? AND (status = 'completed' OR is_completed = 1)",
+            (f"{goal_id}%",),
+        )
+        row = cursor.fetchone()
+        if not row:
+            return False
+
+        full_id = row[0]
+        goal_data = json.loads(row[1]) if row[1] else {}
+        entry: dict = {"at": time.time()}
+        if reason:
+            entry["reason"] = reason
+        goal_data.setdefault("reopen_history", []).append(entry)
+
+        params: list = [json.dumps(goal_data)]
+        sql = "UPDATE goals SET status = 'in_progress', is_completed = 0, completed_timestamp = NULL, goal_data = ?"
+        if transaction_id:
+            sql += ", transaction_id = ?"
+            params.append(transaction_id)
+        params.append(full_id)
+        sql += " WHERE id = ?"
+
+        self._execute(sql, tuple(params))
+        self.commit()
+        return True
+
     def refresh_goal(self, goal_id: str) -> bool:
         """No-op — stale status removed. Goals stay in_progress across compaction.
 

--- a/tests/test_goals_reopen.py
+++ b/tests/test_goals_reopen.py
@@ -1,0 +1,114 @@
+"""Tests for GoalDataRepository.reopen_goal — reversible goal completion.
+
+`goals-complete` used to be irreversible via the CLI (finding: no reopen path).
+`reopen_goal` flips a completed goal back to in_progress and clears the completed
+flags, so an accidental or premature completion can be undone (David directive
+2026-07-08).
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+import uuid
+
+from empirica.data.repositories.goals import GoalDataRepository
+
+SESSION = str(uuid.uuid4())
+
+
+def _conn() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.execute(
+        """
+        CREATE TABLE goals (
+            id TEXT PRIMARY KEY,
+            session_id TEXT NOT NULL,
+            objective TEXT NOT NULL,
+            description TEXT,
+            scope TEXT NOT NULL DEFAULT '{}',
+            estimated_complexity REAL,
+            created_timestamp REAL NOT NULL,
+            completed_timestamp REAL,
+            is_completed BOOLEAN DEFAULT 0,
+            goal_data TEXT NOT NULL DEFAULT '{}',
+            status TEXT DEFAULT 'in_progress',
+            beads_issue_id TEXT,
+            project_id TEXT,
+            transaction_id TEXT
+        )
+        """
+    )
+    conn.commit()
+    return conn
+
+
+def _insert(conn, *, status="completed", is_completed=1, completed=True) -> str:
+    gid = str(uuid.uuid4())
+    conn.execute(
+        "INSERT INTO goals (id, session_id, objective, scope, created_timestamp, "
+        "completed_timestamp, is_completed, goal_data, status) "
+        "VALUES (?, ?, ?, '{}', ?, ?, ?, '{}', ?)",
+        (
+            gid,
+            SESSION,
+            "test goal",
+            time.time(),
+            time.time() if completed else None,
+            is_completed,
+            status,
+        ),
+    )
+    conn.commit()
+    return gid
+
+
+def test_reopen_completed_goal_resets_to_in_progress():
+    conn = _conn()
+    gid = _insert(conn, status="completed", is_completed=1, completed=True)
+    repo = GoalDataRepository(conn)
+
+    assert repo.reopen_goal(gid, reason="premature close", transaction_id="tx-1") is True
+
+    row = conn.execute(
+        "SELECT status, is_completed, completed_timestamp, goal_data, transaction_id FROM goals WHERE id = ?",
+        (gid,),
+    ).fetchone()
+    assert row[0] == "in_progress"
+    assert row[1] == 0  # is_completed cleared
+    assert row[2] is None  # completed_timestamp cleared
+    assert row[4] == "tx-1"  # re-linked to the current transaction
+    data = json.loads(row[3])
+    assert data["reopen_history"][0]["reason"] == "premature close"
+
+
+def test_reopen_accepts_id_prefix():
+    conn = _conn()
+    gid = _insert(conn)
+    repo = GoalDataRepository(conn)
+    assert repo.reopen_goal(gid[:8]) is True
+    assert conn.execute("SELECT status FROM goals WHERE id = ?", (gid,)).fetchone()[0] == "in_progress"
+
+
+def test_reopen_non_completed_goal_returns_false():
+    conn = _conn()
+    gid = _insert(conn, status="in_progress", is_completed=0, completed=False)
+    repo = GoalDataRepository(conn)
+    assert repo.reopen_goal(gid) is False
+
+
+def test_reopen_missing_goal_returns_false():
+    conn = _conn()
+    repo = GoalDataRepository(conn)
+    assert repo.reopen_goal("nonexistent-id") is False
+
+
+def test_reopen_matches_is_completed_even_if_status_stale():
+    """is_completed=1 with a stale status still reopens (is_completed is the
+    source of truth per statusline_empirica)."""
+    conn = _conn()
+    gid = _insert(conn, status="something_odd", is_completed=1, completed=True)
+    repo = GoalDataRepository(conn)
+    assert repo.reopen_goal(gid) is True
+    assert conn.execute("SELECT status, is_completed FROM goals WHERE id = ?", (gid,)).fetchone()[0] == "in_progress"


### PR DESCRIPTION
## What
`goals-complete` was effectively irreversible via the CLI (`goals-activate` is planned-only, `goals-resume` needs git notes) — an accidental or premature completion could only be undone by hand-editing the DB. This adds **`empirica goals-reopen`**.

## How
- `GoalDataRepository.reopen_goal(goal_id, reason=None, transaction_id=None)` — flips a completed goal back to `in_progress`, clears `is_completed` + `completed_timestamp`, re-links to the current transaction, appends a `reopen_history` entry to `goal_data`. Matches `status='completed'` **OR** `is_completed=1` (the latter is the source of truth per `statusline_empirica`). Mirrors `activate_goal`.
- `goals-reopen` / `goal-reopen` verb (parser + handler + dispatch + `__init__` export).

## Why
Part 1 of David's goal-lifecycle directive (2026-07-08): *"goals should be reversible."* This lowers the stakes on hygiene sweeps (a mis-close is now recoverable). **Part 2 — archive-closed-after-X-days** — follows in a second PR.

## Test
`tests/test_goals_reopen.py` — 5 tests (reset-to-in_progress, id-prefix, non-completed → False, missing → False, is_completed-source-of-truth). **300 passed** across the goal/parser/cli_core regression sweep; ruff + format + pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
