### PR TITLE
feat(goals): goals-archive + goals-list --include-archived — archive-closed-after-X hygiene

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`is_completed`, `completed_timestamp`), and re-links it to the current
   transaction. Matches on `status='completed'` OR `is_completed=1` (the latter is
   the source of truth); records a `reopen_history` entry in `goal_data`. Part 1 of
-  the goal-lifecycle directive (reversibility) — archive-closed-after-X follows.
+  the goal-lifecycle directive (reversibility).
+- **`empirica goals-archive` + `goals-list --include-archived` — archive-closed-after-X hygiene.**
+  Part 2 of the goal-lifecycle directive. `goals-archive [--older-than N] [--apply]`
+  archives completed goals whose completion is older than N days (default 30) so the
+  completed view doesn't grow unbounded — dry-run by default, `--goal-id` archives a
+  single completed goal regardless of age. Mirrors the source-archive lifecycle
+  (migration 056 adds `archived`/`archived_at` to `goals`). Archived goals are hidden
+  from `goals-list` unless `--include-archived`; `goals-reopen` un-archives. The
+  active `goals-list` is unaffected (archived goals are completed).
 - **Unified Source Identity P1 — one source, two addresses (dual-resolution).**
   A source that only cortex knows by its catalogue uuid — but whose file exists
   locally under a *different* local uuid — used to 404 on the daemon (`GET

--- a/empirica/cli/cli_core.py
+++ b/empirica/cli/cli_core.py
@@ -943,6 +943,8 @@ def main(args=None):
             "goal-activate": handle_goals_activate_command,
             "goals-reopen": handle_goals_reopen_command,
             "goal-reopen": handle_goals_reopen_command,
+            "goals-archive": handle_goals_archive_command,
+            "goal-archive": handle_goals_archive_command,
             "goals-refresh": handle_goals_refresh_command,
             # Vision commands
             "vision": handle_vision_analyze,

--- a/empirica/cli/command_handlers/__init__.py
+++ b/empirica/cli/command_handlers/__init__.py
@@ -110,6 +110,7 @@ from .goal_commands import (
     handle_goals_activate_command,
     handle_goals_add_dependency_command,
     handle_goals_add_task_command,
+    handle_goals_archive_command,
     handle_goals_claim_command,
     handle_goals_complete_command,
     handle_goals_complete_task_command,
@@ -358,6 +359,7 @@ __all__ = [  # noqa: RUF022
     "handle_forgejo_publish_command",
     "handle_goals_activate_command",  # Activate planned goal → in_progress
     "handle_goals_reopen_command",  # Reopen completed goal → in_progress (reversible close)
+    "handle_goals_archive_command",  # Archive completed goals older than N days (hygiene)
     "handle_goals_add_dependency_command",
     "handle_goals_add_task_command",
     "handle_goals_claim_command",  # Phase 3a - Git bridge

--- a/empirica/cli/command_handlers/goal_commands.py
+++ b/empirica/cli/command_handlers/goal_commands.py
@@ -1293,6 +1293,12 @@ def handle_goals_list_command(args):
         base_query += status_sql
         params.extend(status_params)
 
+        # Hide archived goals by default (archive-after-X hygiene); --include-archived
+        # surfaces them. Placed BEFORE the count_query so the "N of M" total also
+        # excludes archived. COALESCE handles pre-migration-056 NULLs.
+        if not getattr(args, "include_archived", False):
+            base_query += " AND COALESCE(g.archived, 0) = 0"
+
         # Full match count (pre-LIMIT) for "N of M" truncation transparency.
         total_matching = None
         try:
@@ -1941,6 +1947,52 @@ def handle_goals_reopen_command(args):
         from empirica.cli.cli_utils import handle_cli_error
 
         handle_cli_error(e, "Reopen goal", getattr(args, "verbose", False))
+
+
+def handle_goals_archive_command(args):
+    """Handle goals-archive command — archive completed goals older than N days.
+
+    Goal-lifecycle hygiene (mirrors source-archive): archived goals drop out of
+    the completed list unless `goals-list --include-archived`. Dry-run by default;
+    pass --apply to actually archive. goals-reopen un-archives.
+    """
+    try:
+        from empirica.data.repositories.goals import GoalDataRepository
+        from empirica.data.session_database import SessionDatabase
+
+        older_than = getattr(args, "older_than", 30)
+        apply = bool(getattr(args, "apply", False))
+        goal_id = getattr(args, "goal_id", None)
+        output_format = getattr(args, "output", "json")
+
+        db = SessionDatabase()
+        repo = GoalDataRepository(db.conn)
+        affected = repo.archive_stale_completed(older_than_days=older_than, apply=apply, goal_id=goal_id)
+        db.close()
+
+        result = {
+            "ok": True,
+            "dry_run": not apply,
+            "older_than_days": older_than,
+            "count": len(affected),
+            "archived": affected if apply else [],
+            "would_archive": [] if apply else affected,
+        }
+        if output_format == "json":
+            print(json.dumps(result))
+        else:
+            verb = "Archived" if apply else "Would archive"
+            icon = "✅" if apply else "📋"
+            print(f"{icon} {verb} {len(affected)} completed goal(s) older than {older_than}d")
+            for g in affected[:15]:
+                print(f"   • {g['id'][:8]} — {(g['objective'] or '')[:60]}")
+            if not apply and affected:
+                print("   (dry-run — pass --apply to archive)")
+
+    except Exception as e:
+        from empirica.cli.cli_utils import handle_cli_error
+
+        handle_cli_error(e, "Archive goals", getattr(args, "verbose", False))
 
 
 def handle_goals_refresh_command(args):

--- a/empirica/cli/parsers/checkpoint_parsers.py
+++ b/empirica/cli/parsers/checkpoint_parsers.py
@@ -1904,6 +1904,11 @@ Example:
         help='Filter by lifecycle status. Takes precedence over --completed. "drift" surfaces rows where status text disagrees with is_completed (canonical).',
     )
     goals_list_parser.add_argument("--limit", type=int, default=20, help="Max results (default: 20)")
+    goals_list_parser.add_argument(
+        "--include-archived",
+        action="store_true",
+        help="Include archived completed goals (hidden by default; archive via goals-archive)",
+    )
     goals_list_parser.add_argument("--output", choices=["human", "json"], default="human", help="Output format")
     goals_list_parser.add_argument("--verbose", action="store_true", help="Show detailed operation info")
 
@@ -2138,6 +2143,30 @@ written to git notes (breadcrumbs ref) for audit trail.
     goals_reopen_parser.add_argument("--goal-id", required=True, help="Goal UUID to reopen (prefix match)")
     goals_reopen_parser.add_argument("--reason", help="Optional note recorded in the goal's reopen history")
     goals_reopen_parser.add_argument("--output", choices=["human", "json"], default="json", help="Output format")
+
+    # Goals archive command (archive completed goals older than N days — hygiene)
+    goals_archive_parser = subparsers.add_parser(
+        "goals-archive",
+        aliases=["goal-archive"],
+        help=(
+            "Archive completed goals older than N days so the completed list "
+            "doesn't grow unbounded (mirrors source-archive). Archived goals drop "
+            "out of goals-list unless --include-archived; goals-reopen un-archives. "
+            "Dry-run by default; pass --apply to archive."
+        ),
+    )
+    goals_archive_parser.add_argument(
+        "--older-than",
+        type=int,
+        default=30,
+        dest="older_than",
+        help="Age threshold in days on completion time (default: 30)",
+    )
+    goals_archive_parser.add_argument(
+        "--goal-id", help="Archive one completed goal by id/prefix (ignores --older-than)"
+    )
+    goals_archive_parser.add_argument("--apply", action="store_true", help="Actually archive (default: dry-run report)")
+    goals_archive_parser.add_argument("--output", choices=["human", "json"], default="json", help="Output format")
 
     # Goals refresh command (mark stale goal as in_progress after regaining context)
     goals_refresh_parser = subparsers.add_parser(

--- a/empirica/data/migrations/migrations.py
+++ b/empirica/data/migrations/migrations.py
@@ -1491,6 +1491,11 @@ ALL_MIGRATIONS: list[tuple[str, str, Callable]] = [
         "Add cortex_uuid alias column to epistemic_sources — Unified Source Identity P1 (Option A, dual-resolution). A local source keeps its own PK and stores the catalogue uuid as an alias; the daemon resolves `id OR cortex_uuid` so a client holding only the cortex uuid still resolves the local source (kills the two-id-space 404). sources-reconcile populates the alias non-destructively by default; the destructive PK-swap stays opt-in via --converge. Indexed. Additive + idempotent via add_column_if_missing.",
         lambda cursor: migration_055_source_cortex_uuid(cursor),
     ),
+    (
+        "056_goals_archived",
+        "Add archived/archived_at columns to goals — goal-lifecycle archive-after-X (mirrors source-archive). A completed goal older than N days can be archived (hidden from the completed list unless --include-archived) so the completed view doesn't grow unbounded; goals-reopen un-archives. Indexed. Additive + idempotent via add_column_if_missing.",
+        lambda cursor: migration_056_goals_archived(cursor),
+    ),
 ]
 
 
@@ -2068,6 +2073,22 @@ def migration_055_source_cortex_uuid(cursor: sqlite3.Cursor):
     add_column_if_missing(cursor, "epistemic_sources", "cortex_uuid", "TEXT", "NULL")
     cursor.execute("CREATE INDEX IF NOT EXISTS idx_epistemic_sources_cortex_uuid ON epistemic_sources(cortex_uuid)")
     logger.info("✅ Migration 055 complete: cortex_uuid alias column added to epistemic_sources")
+
+
+def migration_056_goals_archived(cursor: sqlite3.Cursor):
+    """Add archived/archived_at columns to goals — goal-lifecycle archive-after-X.
+
+    Mirrors the source-archive lifecycle (epistemic_sources.archived/archived_at):
+    a COMPLETED goal older than N days can be ARCHIVED (hidden from the completed
+    list by default, surfaced with ``goals-list --include-archived``) so the
+    completed view doesn't grow unbounded. Archival is reversible — ``goals-reopen``
+    un-archives. Nullable, additive, idempotent via add_column_if_missing; indexed
+    for the goals-list ``WHERE COALESCE(archived,0)=0`` filter.
+    """
+    add_column_if_missing(cursor, "goals", "archived", "BOOLEAN", "0")
+    add_column_if_missing(cursor, "goals", "archived_at", "REAL", "NULL")
+    cursor.execute("CREATE INDEX IF NOT EXISTS idx_goals_archived ON goals(archived)")
+    logger.info("✅ Migration 056 complete: archived/archived_at columns added to goals")
 
 
 def migration_051_goals_engagement_id(cursor: sqlite3.Cursor):

--- a/empirica/data/repositories/goals.py
+++ b/empirica/data/repositories/goals.py
@@ -544,7 +544,10 @@ class GoalDataRepository(BaseRepository):
         goal_data.setdefault("reopen_history", []).append(entry)
 
         params: list = [json.dumps(goal_data)]
-        sql = "UPDATE goals SET status = 'in_progress', is_completed = 0, completed_timestamp = NULL, goal_data = ?"
+        sql = (
+            "UPDATE goals SET status = 'in_progress', is_completed = 0, "
+            "completed_timestamp = NULL, archived = 0, archived_at = NULL, goal_data = ?"
+        )
         if transaction_id:
             sql += ", transaction_id = ?"
             params.append(transaction_id)
@@ -554,6 +557,52 @@ class GoalDataRepository(BaseRepository):
         self._execute(sql, tuple(params))
         self.commit()
         return True
+
+    def archive_stale_completed(
+        self, older_than_days: int = 30, apply: bool = False, goal_id: str | None = None
+    ) -> list[dict]:
+        """Archive completed goals whose completion is older than N days (hygiene).
+
+        Mirrors the source-archive lifecycle: archived goals are hidden from the
+        completed list by default (``goals-list --include-archived`` surfaces them)
+        so the completed view doesn't grow unbounded. Reversible via ``goals-reopen``.
+        Dry-run by default (apply=False) — returns the affected goals either way.
+
+        Args:
+            older_than_days: age threshold on completed_timestamp (default 30)
+            apply: actually archive when True; dry-run report only when False
+            goal_id: archive a single completed goal by id/prefix (ignores the age
+                threshold); when None, archive all completed goals older than N days
+
+        Returns:
+            List of {id, objective, completed_timestamp} that were (or would be) archived
+        """
+        if goal_id:
+            cursor = self._execute(
+                "SELECT id, objective, completed_timestamp FROM goals "
+                "WHERE id LIKE ? AND (status = 'completed' OR is_completed = 1) "
+                "AND COALESCE(archived, 0) = 0",
+                (f"{goal_id}%",),
+            )
+        else:
+            cutoff = time.time() - older_than_days * 86400
+            cursor = self._execute(
+                "SELECT id, objective, completed_timestamp FROM goals "
+                "WHERE (status = 'completed' OR is_completed = 1) "
+                "AND COALESCE(archived, 0) = 0 "
+                "AND completed_timestamp IS NOT NULL AND completed_timestamp < ?",
+                (cutoff,),
+            )
+        rows = [{"id": r[0], "objective": r[1], "completed_timestamp": r[2]} for r in cursor.fetchall()]
+        if apply and rows:
+            now = time.time()
+            for r in rows:
+                self._execute(
+                    "UPDATE goals SET archived = 1, archived_at = ? WHERE id = ?",
+                    (now, r["id"]),
+                )
+            self.commit()
+        return rows
 
     def refresh_goal(self, goal_id: str) -> bool:
         """No-op — stale status removed. Goals stay in_progress across compaction.

--- a/tests/test_goals_archive.py
+++ b/tests/test_goals_archive.py
@@ -1,0 +1,111 @@
+"""Tests for GoalDataRepository.archive_stale_completed + reopen un-archive.
+
+goal-lifecycle archive-after-X hygiene (mirrors source-archive): a completed
+goal older than N days can be archived (hidden from the completed list unless
+`goals-list --include-archived`); `goals-reopen` un-archives (David directive
+2026-07-08, Part 2).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+import uuid
+
+from empirica.data.repositories.goals import GoalDataRepository
+
+SESSION = str(uuid.uuid4())
+
+
+def _conn() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.execute(
+        """
+        CREATE TABLE goals (
+            id TEXT PRIMARY KEY,
+            session_id TEXT NOT NULL,
+            objective TEXT NOT NULL,
+            description TEXT,
+            scope TEXT NOT NULL DEFAULT '{}',
+            estimated_complexity REAL,
+            created_timestamp REAL NOT NULL,
+            completed_timestamp REAL,
+            is_completed BOOLEAN DEFAULT 0,
+            goal_data TEXT NOT NULL DEFAULT '{}',
+            status TEXT DEFAULT 'in_progress',
+            beads_issue_id TEXT,
+            project_id TEXT,
+            transaction_id TEXT,
+            archived BOOLEAN DEFAULT 0,
+            archived_at REAL
+        )
+        """
+    )
+    conn.commit()
+    return conn
+
+
+def _insert(conn, *, status="completed", is_completed=1, completed_ago_days=None, archived=0) -> str:
+    gid = str(uuid.uuid4())
+    completed_ts = (time.time() - completed_ago_days * 86400) if completed_ago_days is not None else None
+    conn.execute(
+        "INSERT INTO goals (id, session_id, objective, scope, created_timestamp, "
+        "completed_timestamp, is_completed, goal_data, status, archived) "
+        "VALUES (?, ?, ?, '{}', ?, ?, ?, '{}', ?, ?)",
+        (gid, SESSION, "g", time.time(), completed_ts, is_completed, status, archived),
+    )
+    conn.commit()
+    return gid
+
+
+def test_archive_dry_run_does_not_mutate():
+    conn = _conn()
+    gid = _insert(conn, completed_ago_days=40)
+    repo = GoalDataRepository(conn)
+    affected = repo.archive_stale_completed(older_than_days=30, apply=False)
+    assert len(affected) == 1 and affected[0]["id"] == gid
+    assert conn.execute("SELECT archived FROM goals WHERE id = ?", (gid,)).fetchone()[0] == 0
+
+
+def test_archive_apply_archives_only_old_completed():
+    conn = _conn()
+    old = _insert(conn, completed_ago_days=40)
+    recent = _insert(conn, completed_ago_days=5)
+    active = _insert(conn, status="in_progress", is_completed=0, completed_ago_days=None)
+    repo = GoalDataRepository(conn)
+
+    affected = repo.archive_stale_completed(older_than_days=30, apply=True)
+
+    assert {a["id"] for a in affected} == {old}
+    old_row = conn.execute("SELECT archived, archived_at FROM goals WHERE id = ?", (old,)).fetchone()
+    assert old_row[0] == 1 and old_row[1] is not None
+    # recent completed + active goal untouched
+    assert conn.execute("SELECT archived FROM goals WHERE id = ?", (recent,)).fetchone()[0] == 0
+    assert conn.execute("SELECT archived FROM goals WHERE id = ?", (active,)).fetchone()[0] == 0
+
+
+def test_archive_by_goal_id_ignores_age():
+    conn = _conn()
+    recent = _insert(conn, completed_ago_days=1)
+    repo = GoalDataRepository(conn)
+    affected = repo.archive_stale_completed(goal_id=recent[:8], apply=True)
+    assert len(affected) == 1
+    assert conn.execute("SELECT archived FROM goals WHERE id = ?", (recent,)).fetchone()[0] == 1
+
+
+def test_archive_skips_already_archived():
+    conn = _conn()
+    _insert(conn, completed_ago_days=40, archived=1)
+    repo = GoalDataRepository(conn)
+    assert repo.archive_stale_completed(older_than_days=30, apply=True) == []
+
+
+def test_reopen_unarchives():
+    conn = _conn()
+    gid = _insert(conn, completed_ago_days=40, archived=1)
+    repo = GoalDataRepository(conn)
+    assert repo.reopen_goal(gid) is True
+    row = conn.execute("SELECT status, archived, archived_at FROM goals WHERE id = ?", (gid,)).fetchone()
+    assert row[0] == "in_progress"
+    assert row[1] == 0  # un-archived
+    assert row[2] is None

--- a/tests/test_goals_reopen.py
+++ b/tests/test_goals_reopen.py
@@ -36,7 +36,9 @@ def _conn() -> sqlite3.Connection:
             status TEXT DEFAULT 'in_progress',
             beads_issue_id TEXT,
             project_id TEXT,
-            transaction_id TEXT
+            transaction_id TEXT,
+            archived BOOLEAN DEFAULT 0,
+            archived_at REAL
         )
         """
     )


### PR DESCRIPTION
## What
Part 2 of the goal-lifecycle directive: archive **completed** goals older than N days so the completed view doesn't grow unbounded. Complements PR #298 (`goals-reopen`).

## How
- **migration 056** — `archived`/`archived_at` on `goals` (mirrors the source-archive lifecycle), indexed, idempotent.
- `GoalDataRepository.archive_stale_completed(older_than_days=30, apply=False, goal_id=None)` — archives completed goals with `completed_timestamp` older than N days; dry-run by default; `--goal-id` archives one regardless of age; skips already-archived.
- `goals-archive` / `goal-archive` verb (parser + handler + dispatch + export).
- `goals-list` hides archived unless `--include-archived` — the filter is placed **before** the N-of-M count so the total also excludes archived; `COALESCE`-safe.
- `reopen_goal` now **un-archives** (reversibility all the way).

## Safety
Archived goals are *completed*, so the default active `goals-list` is unaffected — the filter only touches completed/all views. The column is migration-guaranteed (goals-list runs through SessionDatabase, which runs migrations).

## Test
`tests/test_goals_archive.py` — 5 (dry-run, apply-only-old, by-id-ignores-age, skip-archived, reopen-un-archives) + reopen fixture updated. **388 passed** across the goal/parser/cli_core/migration regression; ruff + format + pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
