### PR TITLE
feat(sources): P2 sync-when-small — sources-reconcile --push-bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Unified Source Identity P2 — sync-when-small body upload (`sources-reconcile --push-bodies`).**
+  A source cortex knows only by catalogue pointer used to be un-fetchable by a peer
+  with no local copy. Now `sources-reconcile --apply --push-bodies` uploads the
+  **body** of each small adopted source (≤ 1MB default, override via
+  `EMPIRICA_SMALL_BODY_THRESHOLD`) to cortex's `POST /v1/sources/{cortex_uuid}/body`,
+  so cortex's `GET /content` serves the bytes to a remote peer (the reciprocal of
+  the local daemon's content endpoint). Best-effort + idempotent (cortex dedupes on
+  `body_hash`), tenant-gated (no-op without cortex creds), opt-in (default reconcile
+  behaviour unchanged). Contract pinned + shipped with cortex + extension. Create-time
+  upload is deferred to P3 (needs on-create catalogue register).
 - **`empirica goals-reopen` — reverse a completed goal (reversible close).**
   `goals-complete` was effectively irreversible via the CLI (`goals-activate` is
   planned-only), so an accidental or premature completion could only be undone by

--- a/empirica/cli/command_handlers/sources_reconcile_commands.py
+++ b/empirica/cli/command_handlers/sources_reconcile_commands.py
@@ -37,14 +37,65 @@ Dry-run by default; ``--apply`` adopts (alias), ``--apply --converge`` swaps.
 from __future__ import annotations
 
 import json
+import os
 import sqlite3
 import sys
 import urllib.error
 import urllib.request
+from pathlib import Path
 from typing import Any
 
 CATALOGUE_LOOKUP_PATH = "/v1/sources/catalogue"
 RECONCILE_PATH = "/v1/sources/reconcile"
+
+# P2 sync-when-small: only bodies at/below this size are pushed to cortex.
+# Threshold is empirica-owned tenant policy (cortex hard-caps at 100MB);
+# override per-tenant via the EMPIRICA_SMALL_BODY_THRESHOLD env var.
+_SMALL_BODY_THRESHOLD = int(os.environ.get("EMPIRICA_SMALL_BODY_THRESHOLD", 1024 * 1024))  # 1 MiB
+
+
+def _push_source_body_to_cortex(cortex_url, api_key, cortex_uuid: str, content: bytes, mime_type: str | None) -> dict:
+    """Best-effort POST /v1/sources/{id}/body — upload a small source body so a
+    remote peer can fetch it (P2 sync-when-small). Idempotent cortex-side
+    (dedupe on body_hash); server verifies its own SHA-256. Never raises."""
+    req = urllib.request.Request(
+        f"{cortex_url}/v1/sources/{cortex_uuid}/body",
+        data=content,
+        method="POST",
+        headers={
+            "Content-Type": mime_type or "application/octet-stream",
+            "Authorization": f"Bearer {api_key}",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30.0) as resp:
+            return {"pushed": True, "status": resp.status, "size_bytes": len(content)}
+    except urllib.error.HTTPError as e:
+        return {"pushed": False, "status": e.code, "error": f"HTTP {e.code}"}
+    except (urllib.error.URLError, OSError, TimeoutError) as e:
+        return {"pushed": False, "error": f"{type(e).__name__}: {e}"}
+
+
+def _maybe_push_small_body(cortex_url, api_key, cortex_uuid: str, row: dict | None) -> dict | None:
+    """Upload a source's body to cortex IF it is small (<= threshold) and has
+    readable local content. Returns a per-source status dict, or None when
+    skipped (too large / no size / no local path / unreadable). Best-effort."""
+    if not row or not cortex_url or not api_key:
+        return None
+    size = row.get("size_bytes")
+    path = row.get("canonical_path")
+    if size is None or size > _SMALL_BODY_THRESHOLD or not path:
+        return None
+    try:
+        p = Path(str(path).replace("file://", ""))
+        if not p.is_file():
+            return None
+        content = p.read_bytes()
+    except OSError:
+        return None
+    result = _push_source_body_to_cortex(cortex_url, api_key, cortex_uuid, content, row.get("mime_type"))
+    result["cortex_uuid"] = cortex_uuid
+    return result
 
 
 def handle_sources_reconcile_command(args) -> int:
@@ -56,6 +107,7 @@ def handle_sources_reconcile_command(args) -> int:
     output = getattr(args, "output", "human")
     apply = bool(getattr(args, "apply", False))
     converge = bool(getattr(args, "converge", False))
+    push_bodies = bool(getattr(args, "push_bodies", False))
 
     project_id = getattr(args, "project_id", None)
     if not project_id:
@@ -97,6 +149,8 @@ def handle_sources_reconcile_command(args) -> int:
 
         swapped: list[dict] = []
         aliased: list[dict] = []
+        bodies_pushed: list[dict] = []
+        by_id = {r["id"]: r for r in rows}
         if apply and confirmed:
             for pair in confirmed:
                 if converge:
@@ -105,6 +159,13 @@ def handle_sources_reconcile_command(args) -> int:
                 else:
                     # Default: non-destructive alias adopt (daemon resolves id OR cortex_uuid).
                     aliased.append(_set_cortex_uuid_alias(db, project_id, pair["local_uuid"], pair["cortex_uuid"]))
+                # P2 sync-when-small: push the body for small sources so remote peers can fetch it.
+                if push_bodies:
+                    pushed = _maybe_push_small_body(
+                        cortex_url, api_key, pair["cortex_uuid"], by_id.get(pair["local_uuid"])
+                    )
+                    if pushed is not None:
+                        bodies_pushed.append(pushed)
 
         payload = {
             "ok": True,
@@ -121,6 +182,7 @@ def handle_sources_reconcile_command(args) -> int:
             "rejected": rejected,
             "swapped": swapped,
             "aliased": aliased,
+            "bodies_pushed": bodies_pushed,
         }
         _emit(output, payload, _render_human(payload))
         return 0

--- a/empirica/cli/parsers/checkpoint_parsers.py
+++ b/empirica/cli/parsers/checkpoint_parsers.py
@@ -1546,6 +1546,16 @@ def add_checkpoint_parsers(subparsers):
         ),
     )
     sources_reconcile_parser.add_argument(
+        "--push-bodies",
+        action="store_true",
+        help=(
+            "With --apply: also upload the BODY of each small adopted source "
+            "(<= EMPIRICA_SMALL_BODY_THRESHOLD, default 1MB) to cortex via "
+            "POST /v1/sources/{id}/body, so a remote peer can fetch it — "
+            "sync-when-small (P2). Best-effort + idempotent (cortex dedupes on body_hash)."
+        ),
+    )
+    sources_reconcile_parser.add_argument(
         "--project-id", help="Project UUID (auto-derived from active session when omitted)"
     )
     sources_reconcile_parser.add_argument(

--- a/tests/test_source_body_push.py
+++ b/tests/test_source_body_push.py
@@ -1,0 +1,74 @@
+"""Tests for P2 sync-when-small body upload (_maybe_push_small_body gate).
+
+The gate decides whether a source's body is uploaded to cortex on a
+`sources-reconcile --apply --push-bodies` pass: small (<= threshold) +
+readable local content + cortex configured. Best-effort, never raises.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import empirica.cli.command_handlers.sources_reconcile_commands as rc
+
+
+def _row(size, path, mime="text/plain"):
+    return {"id": "l1", "size_bytes": size, "canonical_path": path, "mime_type": mime}
+
+
+def test_skips_when_too_large(tmp_path):
+    f = tmp_path / "big.txt"
+    f.write_text("x")
+    row = _row(rc._SMALL_BODY_THRESHOLD + 1, str(f))
+    assert rc._maybe_push_small_body("http://c", "k", "cx1", row) is None
+
+
+def test_skips_when_no_local_path():
+    assert rc._maybe_push_small_body("http://c", "k", "cx1", _row(10, None)) is None
+
+
+def test_skips_when_no_cortex_config(tmp_path):
+    f = tmp_path / "s.txt"
+    f.write_text("hi")
+    assert rc._maybe_push_small_body(None, None, "cx1", _row(2, str(f))) is None
+
+
+def test_skips_when_file_missing(tmp_path):
+    assert rc._maybe_push_small_body("http://c", "k", "cx1", _row(2, str(tmp_path / "nope.txt"))) is None
+
+
+def test_skips_when_row_none():
+    assert rc._maybe_push_small_body("http://c", "k", "cx1", None) is None
+
+
+def test_uploads_small_body(tmp_path):
+    f = tmp_path / "s.txt"
+    f.write_bytes(b"hello")
+    row = _row(5, str(f))
+    with patch.object(
+        rc,
+        "_push_source_body_to_cortex",
+        return_value={"pushed": True, "status": 200, "size_bytes": 5},
+    ) as mock:
+        res = rc._maybe_push_small_body("http://c", "k", "cx1", row)
+
+    mock.assert_called_once()
+    args = mock.call_args.args
+    assert args[2] == "cx1"  # cortex_uuid
+    assert args[3] == b"hello"  # file bytes read from canonical_path
+    assert args[4] == "text/plain"  # mime_type
+    assert res["pushed"] is True
+    assert res["cortex_uuid"] == "cx1"  # stamped on the result
+
+
+def test_push_helper_no_raise_on_network_error():
+    """_push_source_body_to_cortex must never raise — returns a status dict."""
+    res = rc._push_source_body_to_cortex(
+        "http://127.0.0.1:9",  # nothing listening
+        "k",
+        "cx1",
+        b"data",
+        "text/plain",
+    )
+    assert res["pushed"] is False
+    assert "error" in res


### PR DESCRIPTION
## What
The empirica client for **P2 sync-when-small** — the last mile of the Unified Source Identity plan. Cortex + extension shipped their side (receive `POST /v1/sources/{id}/body` + serve via `GET /content`, prod-verified); this uploads the bodies.

## How
`sources-reconcile --apply --push-bodies` uploads the **body** of each small adopted source to cortex, so a peer with no local copy can fetch it (the reciprocal of the local daemon's `/content`).
- `_push_source_body_to_cortex` — raw urllib `POST /v1/sources/{cortex_uuid}/body` (Content-Type stamped, Bearer auth, **never raises**).
- `_maybe_push_small_body` — gate: `size_bytes ≤ EMPIRICA_SMALL_BODY_THRESHOLD` (default 1MB) + readable `canonical_path` + cortex configured; else skip.
- Wired into the reconcile apply loop after alias-adopt; `payload.bodies_pushed`.

## Properties
Best-effort · **idempotent** (cortex dedupes on `body_hash`) · **tenant-gated** (no-op without cortex creds) · **opt-in** (default reconcile behaviour unchanged). Trigger is `reconcile` (where a source has its `cortex_uuid`); create-time upload is deferred to **P3** (needs on-create register).

## Test
`tests/test_source_body_push.py` — 7 (skip-too-large / no-path / no-config / file-missing / row-none / uploads-small-body / no-raise-on-network-error). Reconcile regression 13 pass; ruff + format + pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
