### PR TITLE
fix(serve): enrich /entities/{id}/artifacts with source content (knowledge pane)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Extension needs zero change (it already requests by the cortex uuid).
 
 ### Fixed
+- **`GET /entities/{id}/artifacts` returns source content, not just pointers.**
+  The entity knowledge pane got opaque `{artifact_id, artifact_source}` edges — a
+  UUID + a dir path, not renderable knowledge. Each source-type edge is now
+  enriched with `{title, description, source_type, path}` resolved from the
+  source's home `.empirica` DB (`<artifact_source>/sessions/sessions.db`); sources
+  from another project resolve cross-DB the same way (grouped, one open per DB).
+  Read-only + best-effort — a missing/unreadable sibling DB leaves a bare pointer
+  rather than failing the response. Unblocks the extension knowledge pane
+  (workspace `prop_tu3o343`).
 - **`source-archive`: clear the source's semantic-search embed too.** Archiving a
   source hard-deleted its content chunks (`_docs_collection`) but left its metadata
   embed in `_memory_collection`, so an archived (soft-deleted) source stayed

--- a/empirica/api/routes/entities.py
+++ b/empirica/api/routes/entities.py
@@ -181,6 +181,62 @@ async def list_entities(
     return {"ok": True, "count": len(out), "entities": out}
 
 
+def _enrich_source_artifacts(artifacts: list[dict]) -> None:
+    """Enrich source-type edge rows IN PLACE with their content — title,
+    description, source_type, path — resolved from the source's home ``.empirica``
+    DB. Turns opaque ``{artifact_id, artifact_source}`` pointers into renderable
+    knowledge for the entity knowledge pane (workspace prop_tu3o343).
+
+    ``artifact_source`` is the ABSOLUTE ``.empirica`` dir path (written as
+    ``str(Path(project_path)/'.empirica')``), so the source rows live in
+    ``<artifact_source>/sessions/sessions.db``. Sources from another project (e.g.
+    mesh-support-sourced edges) resolve the same way — just a different DB path.
+
+    Read-only + best-effort: a missing/unreadable sibling DB (or one without an
+    ``epistemic_sources`` table) leaves that row as a bare pointer rather than
+    failing the whole response. Grouped by DB so each is opened once.
+    """
+    import sqlite3
+    from collections import defaultdict
+    from pathlib import Path
+
+    by_db: dict[str, list[dict]] = defaultdict(list)
+    for a in artifacts:
+        if a.get("artifact_type") == "source" and a.get("artifact_source") and a.get("artifact_id"):
+            by_db[a["artifact_source"]].append(a)
+
+    for empirica_dir, rows in by_db.items():
+        db_path = Path(empirica_dir) / "sessions" / "sessions.db"
+        if not db_path.is_file():
+            continue
+        ids = [r["artifact_id"] for r in rows]
+        content: dict[str, dict] = {}
+        try:
+            conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+            try:
+                placeholders = ",".join("?" for _ in ids)
+                cur = conn.execute(
+                    "SELECT id, title, source_url, canonical_path, description, source_type "
+                    f"FROM epistemic_sources WHERE id IN ({placeholders})",
+                    ids,
+                )
+                for r in cur.fetchall():
+                    content[r[0]] = {
+                        "title": r[1],
+                        "path": r[3] or r[2],  # canonical_path, else source_url
+                        "description": r[4],
+                        "source_type": r[5],
+                    }
+            finally:
+                conn.close()
+        except sqlite3.Error:
+            continue
+        for row in rows:
+            hit = content.get(row["artifact_id"])
+            if hit:
+                row.update(hit)
+
+
 @router.get("/entities/{entity_id}/artifacts", dependencies=[Depends(verify_mint_bearer)])
 async def list_entity_artifacts(
     entity_id: str,
@@ -208,6 +264,9 @@ async def list_entity_artifacts(
     with WorkspaceDBRepository.open() as repo:
         entity_type = type or repo.get_entity_type(entity_id)
         artifacts = repo.get_scoped_artifacts(entity_id, entity_type, limit=limit)
+    # Join each source-type edge to its content so the knowledge pane renders
+    # titles/descriptions, not opaque UUIDs (prop_tu3o343). Best-effort.
+    _enrich_source_artifacts(artifacts)
     return {
         "ok": True,
         "entity_id": entity_id,

--- a/tests/test_entity_artifacts_enrich.py
+++ b/tests/test_entity_artifacts_enrich.py
@@ -1,0 +1,86 @@
+"""Tests for _enrich_source_artifacts — join entity-artifact source edges to
+their content so the knowledge pane renders titles/descriptions, not opaque
+UUIDs (workspace prop_tu3o343). Best-effort, read-only, cross-DB by
+``artifact_source`` (the source's home ``.empirica`` dir).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from empirica.api.routes.entities import _enrich_source_artifacts
+
+
+def _make_source_db(empirica_dir: Path, sources: list[tuple]) -> None:
+    """sources rows = (id, title, source_url, canonical_path, description, source_type)."""
+    db_dir = empirica_dir / "sessions"
+    db_dir.mkdir(parents=True)
+    conn = sqlite3.connect(str(db_dir / "sessions.db"))
+    conn.execute(
+        "CREATE TABLE epistemic_sources (id TEXT PRIMARY KEY, title TEXT, source_url TEXT, "
+        "canonical_path TEXT, description TEXT, source_type TEXT)"
+    )
+    conn.executemany("INSERT INTO epistemic_sources VALUES (?,?,?,?,?,?)", sources)
+    conn.commit()
+    conn.close()
+
+
+def test_enriches_source_row(tmp_path):
+    ed = tmp_path / "proj" / ".empirica"
+    _make_source_db(ed, [("s1", "CEO brain download", None, "/docs/ceo.md", "the curated skill", "document")])
+    arts = [{"artifact_type": "source", "artifact_id": "s1", "artifact_source": str(ed)}]
+    _enrich_source_artifacts(arts)
+    assert arts[0]["title"] == "CEO brain download"
+    assert arts[0]["path"] == "/docs/ceo.md"
+    assert arts[0]["description"] == "the curated skill"
+    assert arts[0]["source_type"] == "document"
+
+
+def test_path_falls_back_to_url(tmp_path):
+    ed = tmp_path / "p" / ".empirica"
+    _make_source_db(ed, [("s2", "RFC 7519", "https://x/rfc", None, None, "url")])
+    arts = [{"artifact_type": "source", "artifact_id": "s2", "artifact_source": str(ed)}]
+    _enrich_source_artifacts(arts)
+    assert arts[0]["path"] == "https://x/rfc"
+
+
+def test_cross_db_resolution(tmp_path):
+    ed1 = tmp_path / "a" / ".empirica"
+    _make_source_db(ed1, [("x", "A-title", None, "/a", None, "doc")])
+    ed2 = tmp_path / "b" / ".empirica"
+    _make_source_db(ed2, [("y", "B-title", None, "/b", None, "doc")])
+    arts = [
+        {"artifact_type": "source", "artifact_id": "x", "artifact_source": str(ed1)},
+        {"artifact_type": "source", "artifact_id": "y", "artifact_source": str(ed2)},
+    ]
+    _enrich_source_artifacts(arts)
+    assert arts[0]["title"] == "A-title"
+    assert arts[1]["title"] == "B-title"
+
+
+def test_missing_db_leaves_pointer(tmp_path):
+    arts = [{"artifact_type": "source", "artifact_id": "s1", "artifact_source": str(tmp_path / "gone" / ".empirica")}]
+    _enrich_source_artifacts(arts)
+    assert "title" not in arts[0]  # unchanged — best-effort
+
+
+def test_non_source_type_untouched(tmp_path):
+    ed = tmp_path / "p" / ".empirica"
+    _make_source_db(ed, [("s1", "T", None, "/p", None, "doc")])
+    arts = [{"artifact_type": "goal", "artifact_id": "g1", "artifact_source": str(ed)}]
+    _enrich_source_artifacts(arts)
+    assert "title" not in arts[0]
+
+
+def test_no_epistemic_sources_table_is_best_effort(tmp_path):
+    ed = tmp_path / "p" / ".empirica"
+    db_dir = ed / "sessions"
+    db_dir.mkdir(parents=True)
+    conn = sqlite3.connect(str(db_dir / "sessions.db"))
+    conn.execute("CREATE TABLE other (x TEXT)")
+    conn.commit()
+    conn.close()
+    arts = [{"artifact_type": "source", "artifact_id": "s1", "artifact_source": str(ed)}]
+    _enrich_source_artifacts(arts)
+    assert "title" not in arts[0]  # OperationalError swallowed, row untouched


### PR DESCRIPTION
## What
`GET /api/v1/entities/{id}/artifacts` returned opaque `{artifact_id, artifact_source}` edge pointers — a UUID + a dir path, not renderable knowledge. Blocks the extension's entity knowledge pane (workspace `prop_tu3o343`).

## How
`_enrich_source_artifacts` joins each **source**-type edge to its content — `{title, description, source_type, path}` — resolved from the source's home `.empirica` DB. `artifact_source` is the **absolute `.empirica` dir path** (code-confirmed: `str(Path(project_path)/".empirica")`), so the source rows live in `<artifact_source>/sessions/sessions.db`. Cross-project edges (e.g. mesh-support-sourced) resolve the *same way* — just a different DB path; grouped so each DB opens once.

## Properties
Read-only · **best-effort** (missing/unreadable sibling DB, or no `epistemic_sources` table → row keeps its bare pointer, response never fails) · additive (rows gain fields; no schema change) · non-source types untouched.

Grounded the `artifact_source` format from code rather than guessing the storage layer (a known failure mode) — no workspace round-trip needed.

## Test
`tests/test_entity_artifacts_enrich.py` — 6 (enrich, url-fallback, cross-DB, missing-DB best-effort, non-source untouched, no-table best-effort). Entities regression **173 pass**; ruff + format + pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
