### PR TITLE
feat(daemon): surface org detail in entity projection (industry/description/domain/org_type/tags)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Daemon org-entity projection surfaces org detail (industry/description/domain/org_type/tags).**
+  `GET /api/v1/entities?type=organization` projected only `id/name/status`, while the
+  **contact** projection already surfaced rich detail — an asymmetry that left
+  workspace-populated org profiles (industry, description, domain, org_type, tags)
+  invisible to extension/practices. A new `WorkspaceDBRepository.get_org_detail_map()`
+  (the org-side peer to `get_contact_detail_map` — `_table_exists`-guarded, `tags`
+  JSON-parsed to a list) is joined into the `organization` branch of `list_entities`.
+  Additive, no schema change (the fields live in workspace's `organizations` detail
+  table). Needs a daemon restart to go live (deploy-staleness).
 - **Unified Source Identity P2 — sync-when-small body upload (`sources-reconcile --push-bodies`).**
   A source cortex knows only by catalogue pointer used to be un-fetchable by a peer
   with no local copy. Now `sources-reconcile --apply --push-bodies` uploads the

--- a/empirica/api/routes/entities.py
+++ b/empirica/api/routes/entities.py
@@ -129,6 +129,10 @@ async def list_entities(
         # the whole org set (small: umbrella + brands), not per-row — preserves
         # the single-query intent that deferred the broader v1.1 enrichment.
         org_parents = repo.get_org_parent_map()
+        # Org detail (industry/description/domain/org_type/tags) from the
+        # workspace organizations table — the org-side peer to the contact
+        # detail map below, closing the projection asymmetry (prop_2yfn3ok).
+        org_details = repo.get_org_detail_map()
         # Contact→org affiliation (id + name + role) + richer CRM detail fields.
         # Same entity_memberships source as the parent_org filter, so filter and
         # enrichment agree.
@@ -155,6 +159,15 @@ async def list_entities(
             # entity_memberships; other types omit the field.
             if et == "organization":
                 entry["parent_org_id"] = org_parents.get(eid)
+                # Surface the organizations-table detail (mirrors how the contact
+                # branch surfaces contact detail) so extension/practices see
+                # industry/description/domain/org_type/tags, not just name/status.
+                od = org_details.get(eid) or {}
+                entry["industry"] = od.get("industry")
+                entry["description"] = od.get("description")
+                entry["domain"] = od.get("domain")
+                entry["org_type"] = od.get("org_type")
+                entry["tags"] = od.get("tags")
             elif et == "contact":
                 cod = contact_org_details.get(eid) or {}
                 cd = contact_details.get(eid) or {}

--- a/empirica/data/repositories/workspace_db.py
+++ b/empirica/data/repositories/workspace_db.py
@@ -1169,6 +1169,42 @@ class WorkspaceDBRepository(BaseRepository):
             }
         return out
 
+    def get_org_detail_map(self) -> dict[str, dict[str, Any]]:
+        """Map org_id → the org detail projection fields from the ``organizations``
+        table (industry/description/domain/org_type/tags). One query; ``tags`` is
+        JSON-parsed to a list (honest-empty on malformed). Returns ``{}`` when the
+        ``organizations`` table is absent.
+
+        The org-side peer to ``get_contact_detail_map`` — closes the projection
+        asymmetry where the contact list surfaced rich detail but the org list did
+        not (workspace prop_2yfn3ok). ``organizations`` is a workspace-owned detail
+        table (not vendored into core), so the ``_table_exists`` guard lets a
+        minimal workspace DB / test fixture degrade to {} rather than raise.
+        """
+        if not self._table_exists("organizations"):
+            return {}
+
+        cursor = self._execute(
+            """SELECT org_id, industry, description, domain, org_type, tags
+               FROM organizations"""
+        )
+        out: dict[str, dict[str, Any]] = {}
+        for row in cursor.fetchall():
+            tags = row["tags"]
+            if isinstance(tags, str):
+                try:
+                    tags = json.loads(tags)
+                except (ValueError, TypeError):
+                    tags = []
+            out[row["org_id"]] = {
+                "industry": row["industry"],
+                "description": row["description"],
+                "domain": row["domain"],
+                "org_type": row["org_type"],
+                "tags": tags if isinstance(tags, list) else [],
+            }
+        return out
+
     def get_engagement_tasks(self, engagement_id: str) -> list[dict[str, Any]]:
         """List an engagement's tasks from workspace ``engagement_tasks`` (task_id,
         title, status, assigned_to, due_at, completed_at, blocked_by, …), oldest

--- a/tests/test_workspace_crm_projection.py
+++ b/tests/test_workspace_crm_projection.py
@@ -46,6 +46,14 @@ def repo() -> WorkspaceDBRepository:
             ('t1','eng-1','Provision seat','d','open','carly',NULL,NULL,NULL,'2026-01-01'),
             ('t2','eng-1','Verify','d','done','carly',NULL,'2026-02-01',NULL,'2026-01-02'),
             ('t3','eng-2','Other','d','open','x',NULL,NULL,NULL,'2026-01-01');
+
+        CREATE TABLE organizations (
+            org_id TEXT PRIMARY KEY, name TEXT, domain TEXT, industry TEXT,
+            org_type TEXT, description TEXT, tags TEXT, status TEXT
+        );
+        INSERT INTO organizations VALUES
+            ('o-nle','NLE','nle.com','Live Entertainment','client','Live events co','["priority"]','active'),
+            ('o-bad','BadOrg',NULL,NULL,NULL,NULL,'not-json','active');
         """
     )
     return WorkspaceDBRepository(conn)
@@ -67,6 +75,22 @@ def test_contact_detail_map_projects_crm_fields(repo):
 
 def test_contact_detail_map_malformed_tags_is_empty_list(repo):
     assert repo.get_contact_detail_map()["c-bad"]["tags"] == []
+
+
+# ── org detail map (prop_2yfn3ok — closes the org/contact projection asymmetry) ─
+
+
+def test_org_detail_map_projects_fields(repo):
+    o = repo.get_org_detail_map()["o-nle"]
+    assert o["industry"] == "Live Entertainment"
+    assert o["org_type"] == "client"
+    assert o["domain"] == "nle.com"
+    assert o["description"] == "Live events co"
+    assert o["tags"] == ["priority"]  # JSON-parsed to a list
+
+
+def test_org_detail_map_malformed_tags_is_empty_list(repo):
+    assert repo.get_org_detail_map()["o-bad"]["tags"] == []
 
 
 # ── contact→org details (name + role) ─────────────────────────────────────────
@@ -155,6 +179,8 @@ def test_crm_projections_degrade_when_optional_tables_absent():
     repo = WorkspaceDBRepository(conn)
     assert repo.get_contact_detail_map() == {}
     assert repo.get_engagement_tasks("eng-1") == []
+    # organizations table absent → org detail map degrades to {} (same _table_exists guard).
+    assert repo.get_org_detail_map() == {}
     # entity_memberships IS present → the org-details map still works (returns {}).
     assert repo.get_contact_org_details_map() == {}
 


### PR DESCRIPTION
## What

Closes the org/contact **projection asymmetry** in the daemon entity list. `GET /api/v1/entities?type=organization` projected only `id/name/status`, while the **contact** projection already surfaced 12+ detail fields. Result: workspace populated all 13 org profiles (industry, description, domain, org_type, tags — in the `organizations` detail table) but they were **invisible** to extension/practices.

## Change

- **`WorkspaceDBRepository.get_org_detail_map()`** — the org-side peer to `get_contact_detail_map()`. `_table_exists('organizations')`-guarded (degrades to `{}` on minimal DBs/fixtures), one query, `tags` JSON-parsed to a list (honest-empty on malformed).
- **`list_entities` org branch** — surfaces `industry/description/domain/org_type/tags`, mirroring how the contact branch surfaces contact detail. Single-query intent preserved (one map load).

Additive, **no schema change** — the fields already live in workspace's `organizations` table (workspace-owned; core reads it, like `contacts`).

## Verification

- 13 tests pass in `test_workspace_crm_projection.py` (2 new org-detail cases + the degrade guard extended).
- Verified against the **live** workspace.db: all **13 orgs** return their detail (e.g. `o-n26` = Fintech/Digital Banking, `o-nio` = Automotive/EV) — the #218 "verify columns against live data first" discipline.

## Deploy note

Like #302, the running daemon must be **restarted** to pick this up (deploy-staleness).