### PR TITLE
fix(sentinel): flag-robust read-only sqlite3 classification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Sentinel: flag-robust read-only `sqlite3` classification.** `is_safe_sqlite_command`
+  assumed the db path was the first arg after `sqlite3`, so any flag before it
+  (`-header`, `-separator ' | '`, `-json`, `-line`) broke the regex match and fell
+  through to *gated-as-praxic* — false positives that forced reroutes on pure read-only
+  DB inspection. Rewritten with `shlex` tokenization: skip leading flags (incl
+  value-taking `-separator`/`-cmd`/`-init`), take the query as the arg after the db path
+  (so a trailing `2>/dev/null` no longer fools it), allow `WITH` (CTE reads), and keep a
+  write-keyword backstop that also catches writable CTEs. Writes, file-writing meta
+  (`.output`/`.import`/…), and interactive REPL stay praxic.
+
 ### Added
 - **Daemon org-entity projection surfaces org detail (industry/description/domain/org_type/tags).**
   `GET /api/v1/entities?type=organization` projected only `id/name/status`, while the

--- a/empirica/plugins/claude-code-integration/hooks/sentinel-gate.py
+++ b/empirica/plugins/claude-code-integration/hooks/sentinel-gate.py
@@ -2028,18 +2028,70 @@ def is_safe_sqlite_command(command: str) -> bool:
     - sqlite3 db "INSERT/UPDATE/DELETE/DROP/CREATE/ALTER ..."
     """
     import re
+    import shlex
 
-    # Extract the SQL/command part (everything after db path in quotes)
-    # Pattern: sqlite3 <db_path> "<query>" or sqlite3 <db_path> '<query>'
-    # Also handles: sqlite3 <db_path> ".tables" (dot commands)
-    match = re.search(r'sqlite3\s+\S+\s+["\'](.+?)["\']', command)
-    if not match:
-        # No quoted query found - could be interactive mode, block it
+    # Tokenize the way the shell would, so flags BEFORE the db path
+    # (-header, -separator ' | ', -json, -line, -box, -readonly …) don't fool
+    # us. The old regex assumed the db path was the first arg after `sqlite3`,
+    # so `sqlite3 -header db "SELECT…"` failed to match and got gated as praxic
+    # — a false positive on pure reads. shlex handles quotes; on malformed
+    # input (unbalanced quotes) we fall back to the conservative deny.
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        return False
+    if not tokens or tokens[0] != "sqlite3":
         return False
 
-    query = match.group(1).strip().upper()
+    # Walk the flags. Value-taking flags consume the next token too.
+    value_flags = {"-separator", "-nullvalue", "-newline", "-cmd", "-init", "-mode", "-column"}
+    positionals: list[str] = []
+    args = tokens[1:]
+    i = 0
+    while i < len(args):
+        tok = args[i]
+        if tok in value_flags:
+            i += 2  # skip the flag AND its value
+            continue
+        if tok.startswith("-"):
+            i += 1  # bare flag (-header/-json/-line/-box/-csv/-readonly/…)
+            continue
+        positionals.append(tok)
+        i += 1
 
-    # Safe meta commands (dot commands)
+    # Shape is `sqlite3 [flags] <db_path> <query> [redirects…]`. The query is
+    # the arg RIGHT AFTER the db path (positionals[1]) — taking the last
+    # positional would be fooled by a trailing `2>/dev/null`. No query means an
+    # interactive REPL (which can write) → block.
+    if len(positionals) < 2:
+        return False
+    query = positionals[1].strip().upper()
+
+    # Write-keyword backstop (defense in depth): any DML/DDL anywhere in the
+    # query — including inside a writable CTE (`WITH … DELETE`) — → praxic.
+    write_kw = (
+        "INSERT",
+        "UPDATE",
+        "DELETE",
+        "DROP",
+        "CREATE",
+        "ALTER",
+        "REPLACE",
+        "ATTACH",
+        "DETACH",
+        "VACUUM",
+        "REINDEX",
+        "TRUNCATE",
+    )
+    if any(re.search(r"\b" + kw + r"\b", query) for kw in write_kw):
+        return False
+
+    # File-writing / shell-escaping meta commands → praxic.
+    unsafe_meta = (".OUTPUT", ".ONCE", ".IMPORT", ".BACKUP", ".CLONE", ".RESTORE", ".SHELL", ".SYSTEM", ".EXCEL")
+    if any(query.startswith(m) for m in unsafe_meta):
+        return False
+
+    # Safe display-only meta (dot) commands.
     safe_meta = (
         ".SCHEMA",
         ".TABLES",
@@ -2051,13 +2103,14 @@ def is_safe_sqlite_command(command: str) -> bool:
         ".WIDTH",
         ".HELP",
         ".DATABASES",
+        ".FULLSCHEMA",
     )
-    for meta in safe_meta:
-        if query.startswith(meta):
-            return True
+    if any(query.startswith(meta) for meta in safe_meta):
+        return True
 
-    # Safe SQL operations (read-only)
-    safe_sql = ("SELECT", "PRAGMA", "EXPLAIN", "ANALYZE")
+    # Safe read-only SQL (WITH = CTE reads; the write backstop above already
+    # rejected writable CTEs).
+    safe_sql = ("SELECT", "WITH", "PRAGMA", "EXPLAIN", "ANALYZE")
     return any(query.startswith(sql) for sql in safe_sql)
 
 

--- a/tests/test_sentinel_shell_constructs.py
+++ b/tests/test_sentinel_shell_constructs.py
@@ -53,6 +53,55 @@ def gate():
     return _load_sentinel_gate()
 
 
+# ─── read-only sqlite3 classification (flag-robust) ─────────────────────────
+
+
+class TestSqliteClassifier:
+    """is_safe_sqlite_command must classify read-only sqlite3 as noetic even
+    when display flags precede the db path (the old regex assumed the db path
+    was the first arg, so `sqlite3 -header db "SELECT…"` got false-gated)."""
+
+    DB = "/home/x/.empirica/workspace/workspace.db"
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            'sqlite3 {db} "SELECT * FROM t"',
+            'sqlite3 {db} ".schema organizations"',
+            'sqlite3 {db} "PRAGMA table_info(t)"',
+            'sqlite3 {db} "WITH x AS (SELECT 1 AS n) SELECT n FROM x"',  # CTE read
+            'sqlite3 -header {db} "SELECT a, b FROM t"',  # bare flag before path
+            'sqlite3 -json {db} "SELECT 1"',
+            'sqlite3 -line -readonly {db} "SELECT 1"',  # multiple bare flags
+            "sqlite3 -separator ' | ' {db} \"SELECT a, b FROM t\"",  # value-flag
+            'sqlite3 -header {db} "SELECT 1" 2>/dev/null',  # trailing redirect ignored
+        ],
+    )
+    def test_reads_are_noetic(self, gate, cmd):
+        assert gate.is_safe_sqlite_command(cmd.format(db=self.DB)) is True
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            'sqlite3 {db} "INSERT INTO t VALUES (1)"',
+            'sqlite3 {db} "UPDATE t SET a=1"',
+            'sqlite3 {db} "DELETE FROM t"',
+            'sqlite3 {db} "DROP TABLE t"',
+            'sqlite3 -header {db} "DELETE FROM t"',  # flag + write still blocked
+            'sqlite3 {db} "WITH x AS (SELECT 1) DELETE FROM t"',  # writable CTE
+            'sqlite3 {db} ".output /tmp/x"',  # file-writing meta
+            "sqlite3 {db}",  # interactive REPL — no query
+        ],
+    )
+    def test_writes_and_interactive_are_praxic(self, gate, cmd):
+        assert gate.is_safe_sqlite_command(cmd.format(db=self.DB)) is False
+
+    def test_end_to_end_via_is_safe_bash(self, gate):
+        # The dispatch path callers actually hit.
+        assert gate.is_safe_bash_command({"command": f'sqlite3 -header {self.DB} "SELECT 1"'}) is True
+        assert gate.is_safe_bash_command({"command": f'sqlite3 {self.DB} "DROP TABLE t"'}) is False
+
+
 # ─── command-substitution extractor ────────────────────────────────────────
 
 


### PR DESCRIPTION
## Problem

`is_safe_sqlite_command` (sentinel-gate.py) classified read-only `sqlite3` as noetic via a regex that assumed the **db path was the first arg** after `sqlite3`:

```
sqlite3\s+\S+\s+["'](.+?)["']
```

Any flag before the path broke the match → fell through to **gated-as-praxic**, a false positive on pure read-only inspection:
- `sqlite3 -header db "SELECT…"` — `\S+` matched `-header`, no quote followed → no match
- `sqlite3 -separator ' | ' db "SELECT…"` — grabbed the separator value as the "query"

Hit repeatedly in interactive use (forced reroutes / premature CHECKs) — the top loop-speed friction.

## Fix

Rewrote with `shlex` tokenization:
- Skip leading flags, including value-taking ones (`-separator`/`-nullvalue`/`-cmd`/`-init`/…).
- Take the query as the arg **right after the db path** (positionals[1]), so a trailing `2>/dev/null` doesn't fool it.
- Allow `WITH` (CTE reads).
- Keep a **write-keyword backstop** (INSERT/UPDATE/DELETE/DROP/… anywhere) that also catches writable CTEs (`WITH … DELETE`).
- File-writing meta (`.output`/`.once`/`.import`/`.backup`/…) and interactive REPL (no query) stay **praxic**.

## Tests

`TestSqliteClassifier` (9 read forms noetic incl. all failing flag cases + CTE + trailing-redirect; 8 write/interactive/meta forms praxic; end-to-end via `is_safe_bash_command`). Full file: 144 passing.

## Deploy note

`sentinel-gate.py` is a **hook deployed as a copy** — after merge it needs `empirica setup-claude-code --force` to take effect on running sessions (won't self-apply, same staleness class as the daemon).