### PR TITLE
fix(retrieval): reconcile PREFLIGHT/CHECK goal teaser against live SQLite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Retrieval hygiene: PREFLIGHT/CHECK goal teaser reconciled against live SQLite.**
+  The Qdrant-backed goals teaser served `status` straight from the point payload
+  (embedded at index time), so a goal completed/reopened in SQLite kept surfacing as
+  `in_progress` until its point was re-embedded — retrieval drifting from reality
+  (retrieval-as-pollution). Retrieved goals are now reconciled against the
+  authoritative local `goals` table before display: **completed goals are dropped,
+  stale status is corrected, and cross-project goals (absent locally) are kept
+  unchanged**. Best-effort + fail-open (returns the raw list on any error — the
+  hot-path never breaks). Wired at both build points (preflight `related_goals` +
+  check `active_goals`). Cross-project *status* correction is deferred (needs the
+  owning project's DB).
 - **Sentinel: flag-robust read-only `sqlite3` classification.** `is_safe_sqlite_command`
   assumed the db path was the first arg after `sqlite3`, so any flag before it
   (`-header`, `-separator ' | '`, `-json`, `-line`) broke the regex match and fell

--- a/empirica/core/qdrant/pattern_retrieval.py
+++ b/empirica/core/qdrant/pattern_retrieval.py
@@ -310,6 +310,68 @@ def _enrich_memory_types(result, project_id, task_context, limits, include_eidet
         logger.debug(f"Global dead-ends retrieval failed: {e}")
 
 
+def _apply_goal_reconciliation(raw_goals, live_map):
+    """Reconcile retrieved goals against authoritative live status (retrieval hygiene).
+
+    ``live_map`` maps ``goal_id -> (status, is_completed)`` from the local SQLite.
+    Drops goals completed in SQLite (a stale Qdrant payload still reading
+    ``in_progress``), corrects stale status on open goals, and keeps goals absent
+    from the map (cross-project or subtask) unchanged. Pure function — unit-testable.
+    """
+    out = []
+    for g in raw_goals:
+        gid = g.get("goal_id")
+        if gid and gid in live_map:
+            status, is_completed = live_map[gid]
+            if is_completed or status == "completed":
+                continue  # drop: completed in SQLite, stale-in_progress in Qdrant
+            if status and status != g.get("status"):
+                g = {**g, "status": status}  # correct stale status in place
+        out.append(g)
+    return out
+
+
+def _reconcile_goals_against_sqlite(raw_goals):
+    """Look up live goal status from the local project SQLite and reconcile.
+
+    Best-effort: on ANY failure returns ``raw_goals`` unchanged — this runs in the
+    PREFLIGHT/CHECK hot-path and must never break retrieval. Cross-project goals
+    (``goal_id`` absent from the local ``goals`` table) are kept as-is; correcting
+    their status would need the owning project's DB (deferred to v2).
+    """
+    if not raw_goals:
+        return raw_goals
+    try:
+        ids = [g.get("goal_id") for g in raw_goals if g.get("goal_id")]
+        if not ids:
+            return raw_goals
+        import sqlite3
+        from pathlib import Path
+
+        from empirica.data.session_database import _resolve_canonical_project_root
+
+        root = _resolve_canonical_project_root()
+        if not root:
+            return raw_goals
+        db_path = Path(root) / ".empirica" / "sessions" / "sessions.db"
+        if not db_path.is_file():
+            return raw_goals
+        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+        try:
+            placeholders = ",".join("?" for _ in ids)
+            cur = conn.execute(
+                f"SELECT id, status, COALESCE(is_completed, 0) FROM goals WHERE id IN ({placeholders})",
+                ids,
+            )
+            live_map = {row[0]: (row[1], bool(row[2])) for row in cur.fetchall()}
+        finally:
+            conn.close()
+        return _apply_goal_reconciliation(raw_goals, live_map)
+    except Exception as e:
+        logger.debug(f"goal reconciliation skipped (keeping raw): {e}")
+        return raw_goals
+
+
 def _enrich_knowledge_graph(
     result,
     project_id,
@@ -327,6 +389,7 @@ def _enrich_knowledge_graph(
             from .vector_store import search_goals
 
             raw = search_goals(project_id, task_context, include_subtasks=True, limit=limits["goals"])
+            raw = _reconcile_goals_against_sqlite(raw)  # retrieval hygiene: drop completed, correct stale
             if raw:
                 result["related_goals"] = [
                     {
@@ -868,6 +931,7 @@ def _enrich_check_warnings(
             raw = search_goals(
                 project_id, current_approach or "current work", status="in_progress", include_subtasks=True, limit=limit
             )
+            raw = _reconcile_goals_against_sqlite(raw)  # retrieval hygiene: drop completed, correct stale
             if raw:
                 warnings["active_goals"] = [
                     {

--- a/tests/test_retrieval_hygiene.py
+++ b/tests/test_retrieval_hygiene.py
@@ -1,0 +1,104 @@
+"""Tests for retrieval-hygiene goal reconciliation (pattern_retrieval).
+
+The PREFLIGHT/CHECK teaser served goal ``status`` straight from the Qdrant point
+payload (embedded at index time), so a goal completed in SQLite kept surfacing as
+``in_progress``. The reconciliation drops live-completed goals, corrects stale
+status on open goals, and keeps cross-project goals (absent locally) unchanged.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+from empirica.core.qdrant.pattern_retrieval import (
+    _apply_goal_reconciliation,
+    _reconcile_goals_against_sqlite,
+)
+
+# ── pure reconciliation ───────────────────────────────────────────────────────
+
+
+def test_drops_completed_by_is_completed():
+    raw = [{"goal_id": "g1", "status": "in_progress"}]  # stale Qdrant payload
+    assert _apply_goal_reconciliation(raw, {"g1": ("completed", True)}) == []
+
+
+def test_drops_completed_by_status_even_if_flag_zero():
+    raw = [{"goal_id": "g1", "status": "in_progress"}]
+    assert _apply_goal_reconciliation(raw, {"g1": ("completed", False)}) == []
+
+
+def test_corrects_stale_status_in_place():
+    raw = [{"goal_id": "g1", "status": "in_progress"}]  # payload stale
+    assert _apply_goal_reconciliation(raw, {"g1": ("planned", False)}) == [{"goal_id": "g1", "status": "planned"}]
+
+
+def test_keeps_open_unchanged():
+    raw = [{"goal_id": "g1", "status": "in_progress"}]
+    assert _apply_goal_reconciliation(raw, {"g1": ("in_progress", False)}) == raw
+
+
+def test_keeps_cross_project_absent_from_map():
+    raw = [{"goal_id": "gX", "status": "in_progress"}]
+    assert _apply_goal_reconciliation(raw, {}) == raw  # not local → keep (cross-project)
+
+
+def test_keeps_row_without_goal_id():
+    raw = [{"status": "in_progress"}]  # e.g. a subtask row missing goal_id
+    assert _apply_goal_reconciliation(raw, {"g1": ("completed", True)}) == raw
+
+
+def test_mixed_batch():
+    raw = [
+        {"goal_id": "done", "status": "in_progress"},
+        {"goal_id": "open", "status": "in_progress"},
+        {"goal_id": "stale", "status": "in_progress"},
+        {"goal_id": "other", "status": "in_progress"},  # not in live map
+    ]
+    live = {"done": ("completed", True), "open": ("in_progress", False), "stale": ("blocked", False)}
+    out = _apply_goal_reconciliation(raw, live)
+    assert [g["goal_id"] for g in out] == ["open", "stale", "other"]  # 'done' dropped
+    assert next(g for g in out if g["goal_id"] == "stale")["status"] == "blocked"  # corrected
+    assert next(g for g in out if g["goal_id"] == "other")["status"] == "in_progress"  # cross-project kept
+
+
+# ── sqlite wrapper (end-to-end against a temp project db) ─────────────────────
+
+
+def test_reconcile_against_sqlite(tmp_path, monkeypatch):
+    root = tmp_path / "proj"
+    db_dir = root / ".empirica" / "sessions"
+    db_dir.mkdir(parents=True)
+    conn = sqlite3.connect(str(db_dir / "sessions.db"))
+    conn.execute("CREATE TABLE goals (id TEXT PRIMARY KEY, status TEXT, is_completed INTEGER)")
+    conn.executemany(
+        "INSERT INTO goals VALUES (?,?,?)",
+        [("done", "completed", 1), ("open", "in_progress", 0), ("stale", "blocked", 0)],
+    )
+    conn.commit()
+    conn.close()
+
+    import empirica.data.session_database as sdb
+
+    monkeypatch.setattr(sdb, "_resolve_canonical_project_root", lambda: str(root))
+
+    raw = [
+        {"goal_id": "done", "status": "in_progress"},  # completed in db → drop
+        {"goal_id": "stale", "status": "in_progress"},  # correct → blocked
+        {"goal_id": "other", "status": "in_progress"},  # absent → keep
+    ]
+    out = _reconcile_goals_against_sqlite(raw)
+    assert [g["goal_id"] for g in out] == ["stale", "other"]
+    assert out[0]["status"] == "blocked"
+
+
+def test_reconcile_fail_open_when_db_absent(tmp_path, monkeypatch):
+    import empirica.data.session_database as sdb
+
+    monkeypatch.setattr(sdb, "_resolve_canonical_project_root", lambda: str(tmp_path / "nope"))
+    raw = [{"goal_id": "g1", "status": "in_progress"}]
+    assert _reconcile_goals_against_sqlite(raw) == raw  # unchanged, never raises
+
+
+def test_reconcile_empty_is_noop():
+    assert _reconcile_goals_against_sqlite([]) == []


### PR DESCRIPTION
## Problem (retrieval-as-pollution)

The Qdrant-backed goals teaser in PREFLIGHT/CHECK served goal `status` straight from the **point payload** (embedded at index time). When a goal is completed/reopened/reassigned in SQLite, the Qdrant point is stale until re-embedded — so **completed goals kept surfacing as `in_progress`**, and retrieval drifted from authoritative reality. This bit us repeatedly (goals shown `in_progress` that were actually completed or in another project).

Root cause: `search_goals` (`core/qdrant/goals.py`) returns `status` from the payload; the enrich path (`pattern_retrieval.py`) mapped it through verbatim — no read-time reconciliation.

## Fix (David-directed behavior: drop completed, keep cross-project corrected)

- **`_apply_goal_reconciliation(raw, live_map)`** (pure, unit-testable): drop goals whose live status is completed (`is_completed` is source-of-truth), correct stale status on open goals, keep goals absent from the map (cross-project / subtask) unchanged.
- **`_reconcile_goals_against_sqlite(raw)`**: builds `live_map` from the local project `goals` table via `_resolve_canonical_project_root` + raw **read-only** `sqlite3` (the #302 pattern — no migrations). **Best-effort + fail-open**: returns the raw list on any error, so the PREFLIGHT/CHECK hot-path can never break.
- Wired at **both** build points on the raw `search_goals` result — preflight `related_goals` + check `active_goals`.

## Verification

- 10 unit tests (`test_retrieval_hygiene.py`) — drop-by-flag, drop-by-status, correct-stale, keep-open, keep-cross-project, no-goal-id, mixed batch, sqlite end-to-end, fail-open, empty.
- **Live-verified** against the real project DB: a completed goal drops, an open goal keeps its live status, teaser shrank 2→1.

## Scope / deferred

Cross-project **status correction** (opening the owning project's DB, `_enrich_source_artifacts`-style) is deferred to v2 — cross-project goals are kept as-is for now. The batch-prune backstop (`profile-prune` reconcile rule) is a separate follow-up.