### PR TITLE
feat(retrieval): user-configurable artifact-injection cap (per-category + total)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`.output`/`.import`/…), and interactive REPL stay praxic.
 
 ### Added
+- **User-configurable artifact-injection cap (`artifact_injection.max_per_category` / `max_total`).**
+  The PREFLIGHT/CHECK teaser's per-category injection volume is now tunable + observable.
+  Set `.empirica/config.yaml` → `artifact_injection: {max_per_category: N, max_total: M}`
+  (or env `EMPIRICA_MAX_ARTIFACTS_PER_CATEGORY` / `EMPIRICA_MAX_ARTIFACTS_TOTAL`; env wins,
+  precedence env > config.yaml > default) to cap how many items per category — and combined —
+  get injected. Lists are score-ranked so the dropped tail is lowest-ranked; the drop counts
+  surface in `_context_budget.capped_per_category` / `capped_total` for observability.
+  **Default is uncapped — behaviour unchanged.** Applied in `_apply_context_budget` (before the
+  char-budget elision), so practices with heavy artifact graphs can right-size injection. POSTFLIGHT
+  + post-compact bootstrap injection have separate budget builders (deferred follow-up).
 - **Daemon org-entity projection surfaces org detail (industry/description/domain/org_type/tags).**
   `GET /api/v1/entities?type=organization` projected only `id/name/status`, while the
   **contact** projection already surfaced rich detail — an asymmetry that left

--- a/empirica/core/qdrant/pattern_retrieval.py
+++ b/empirica/core/qdrant/pattern_retrieval.py
@@ -698,6 +698,99 @@ def _enforce_total_budget(result: dict, max_total: int) -> int:
     return dropped
 
 
+# Per-category list keys eligible for the user-configurable injection cap.
+_INJECTION_CATEGORY_KEYS = (
+    "lessons",
+    "dead_ends",
+    "mistakes",
+    "prior_mistakes",
+    "relevant_findings",
+    "related_findings",
+    "eidetic_facts",
+    "eidetic_context",
+    "episodic_narratives",
+    "related_goals",
+    "active_goals",
+    "unverified_assumptions",
+    "prior_decisions",
+    "related_docs",
+    "global_dead_ends",
+)
+
+
+def _resolve_injection_caps() -> dict:
+    """Resolve the user-configurable artifact-injection caps.
+
+    Precedence: env var > ``.empirica/config.yaml`` ``artifact_injection`` block >
+    default (``None`` = uncapped, preserving prior behaviour). Keys:
+
+    - ``max_per_category`` (env ``EMPIRICA_MAX_ARTIFACTS_PER_CATEGORY``) — bounds
+      each category list.
+    - ``max_total`` (env ``EMPIRICA_MAX_ARTIFACTS_TOTAL``) — bounds the combined set.
+
+    Never raises — a bad value is ignored (falls back to uncapped for that key).
+    """
+    caps: dict = {"max_per_category": None, "max_total": None}
+    cfg: dict = {}
+    try:
+        from empirica.config.path_resolver import load_empirica_config
+
+        block = (load_empirica_config() or {}).get("artifact_injection")
+        if isinstance(block, dict):
+            cfg = block
+    except Exception:
+        cfg = {}
+    for key, env in (
+        ("max_per_category", "EMPIRICA_MAX_ARTIFACTS_PER_CATEGORY"),
+        ("max_total", "EMPIRICA_MAX_ARTIFACTS_TOTAL"),
+    ):
+        raw = os.getenv(env)
+        if raw is None:
+            raw = cfg.get(key)
+        if raw is None:
+            continue
+        try:
+            val = int(raw)
+        except (TypeError, ValueError):
+            continue
+        if val > 0:
+            caps[key] = val
+    return caps
+
+
+def _apply_injection_caps(result: dict, caps: dict | None = None) -> tuple[int, int]:
+    """Truncate per-category injection lists to ``max_per_category`` and the combined
+    set to ``max_total``. Lists are already score-ranked (highest first), so the
+    dropped tail is the lowest-ranked. Mutates ``result`` in place; returns
+    ``(capped_per_category, capped_total)`` drop counts. No-op when both caps are
+    ``None`` (default) — preserves prior behaviour exactly.
+    """
+    if caps is None:
+        caps = _resolve_injection_caps()
+    mpc = caps.get("max_per_category")
+    mt = caps.get("max_total")
+    capped_pc = 0
+    capped_total = 0
+    if mpc:
+        for key in _INJECTION_CATEGORY_KEYS:
+            items = result.get(key)
+            if isinstance(items, list) and len(items) > mpc:
+                capped_pc += len(items) - mpc
+                result[key] = items[:mpc]
+    if mt:
+        lists = {k: result[k] for k in _INJECTION_CATEGORY_KEYS if isinstance(result.get(k), list)}
+        current = sum(len(v) for v in lists.values())
+        while current > mt:
+            # drop the lowest-ranked (tail) item of the currently-largest category
+            biggest = max(lists, key=lambda k: len(lists[k]))
+            if not lists[biggest]:
+                break
+            lists[biggest].pop()
+            capped_total += 1
+            current -= 1
+    return capped_pc, capped_total
+
+
 def _apply_context_budget(result: dict, apply_budget: bool = True) -> dict:
     """Lean-by-default post-pass over an assembled patterns/warnings dict:
     dedup across sections (B2) → truncate long item text (B1) → enforce a total
@@ -708,11 +801,12 @@ def _apply_context_budget(result: dict, apply_budget: bool = True) -> dict:
     if not apply_budget or os.getenv("EMPIRICA_PATTERN_BUDGET_OFF") == "1":
         return result
     try:
+        capped_pc, capped_total = _apply_injection_caps(result)  # user cap first (config/env)
         deduped = _dedup_sections(result)
         _truncate_sections(result, MAX_ITEM_CHARS)
         elided = _enforce_total_budget(result, MAX_TOTAL_CHARS)
-        if deduped or elided:
-            result["_context_budget"] = {
+        if deduped or elided or capped_pc or capped_total:
+            budget = {
                 "deduped": deduped,
                 "elided_for_budget": elided,
                 "note": (
@@ -721,6 +815,11 @@ def _apply_context_budget(result: dict, apply_budget: bool = True) -> dict:
                     "`empirica investigate` / `project-search` / `commit-context`."
                 ),
             }
+            if capped_pc or capped_total:
+                # Observability for the user-configurable injection cap (mesh-support ask).
+                budget["capped_per_category"] = capped_pc
+                budget["capped_total"] = capped_total
+            result["_context_budget"] = budget
     except Exception as e:  # never let budgeting break retrieval
         logger.debug(f"_apply_context_budget failed; returning full result: {e}")
     return result

--- a/tests/test_injection_cap.py
+++ b/tests/test_injection_cap.py
@@ -1,0 +1,106 @@
+"""Tests for the user-configurable artifact-injection cap (pattern_retrieval).
+
+Caps how many items per category (and in total) get injected into the
+PREFLIGHT/CHECK teaser. Default is uncapped (preserves prior behaviour); tunable
+via ``.empirica/config.yaml`` ``artifact_injection`` block or
+``EMPIRICA_MAX_ARTIFACTS_*`` env vars (env wins).
+"""
+
+from __future__ import annotations
+
+from empirica.core.qdrant.pattern_retrieval import (
+    _apply_injection_caps,
+    _resolve_injection_caps,
+)
+
+
+def _sample():
+    return {
+        "related_goals": [{"n": i} for i in range(5)],
+        "relevant_findings": [{"n": i} for i in range(4)],
+        "dead_ends": [{"n": i} for i in range(2)],
+        "_context_budget": {"deduped": 0},  # non-category dict — must stay untouched
+        "scalar": 3,
+    }
+
+
+# ── cap application ───────────────────────────────────────────────────────────
+
+
+def test_no_caps_is_noop():
+    r = _sample()
+    assert _apply_injection_caps(r, {"max_per_category": None, "max_total": None}) == (0, 0)
+    assert len(r["related_goals"]) == 5
+
+
+def test_max_per_category_truncates_each_list():
+    r = _sample()
+    pc, total = _apply_injection_caps(r, {"max_per_category": 3, "max_total": None})
+    assert len(r["related_goals"]) == 3  # 5 -> 3
+    assert len(r["relevant_findings"]) == 3  # 4 -> 3
+    assert len(r["dead_ends"]) == 2  # under cap, unchanged
+    assert pc == (5 - 3) + (4 - 3)
+    assert total == 0
+
+
+def test_keeps_highest_ranked_prefix():
+    r = _sample()
+    _apply_injection_caps(r, {"max_per_category": 2, "max_total": None})
+    assert r["related_goals"] == [{"n": 0}, {"n": 1}]  # top-2 kept, tail dropped
+
+
+def test_max_total_trims_largest_first():
+    r = _sample()  # 5 + 4 + 2 = 11
+    pc, total = _apply_injection_caps(r, {"max_per_category": None, "max_total": 6})
+    remaining = len(r["related_goals"]) + len(r["relevant_findings"]) + len(r["dead_ends"])
+    assert remaining == 6
+    assert total == 5
+    assert pc == 0
+
+
+def test_non_category_keys_untouched():
+    r = _sample()
+    _apply_injection_caps(r, {"max_per_category": 1, "max_total": None})
+    assert r["_context_budget"] == {"deduped": 0}
+    assert r["scalar"] == 3
+
+
+# ── config/env resolution (precedence: env > config.yaml > default) ───────────
+
+
+def _patch_cfg(monkeypatch, cfg):
+    import empirica.config.path_resolver as pr
+
+    monkeypatch.setattr(pr, "load_empirica_config", lambda: cfg)
+
+
+def test_resolve_default_uncapped(monkeypatch):
+    monkeypatch.delenv("EMPIRICA_MAX_ARTIFACTS_PER_CATEGORY", raising=False)
+    monkeypatch.delenv("EMPIRICA_MAX_ARTIFACTS_TOTAL", raising=False)
+    _patch_cfg(monkeypatch, {})
+    assert _resolve_injection_caps() == {"max_per_category": None, "max_total": None}
+
+
+def test_resolve_env_override(monkeypatch):
+    monkeypatch.setenv("EMPIRICA_MAX_ARTIFACTS_PER_CATEGORY", "4")
+    _patch_cfg(monkeypatch, {})
+    assert _resolve_injection_caps()["max_per_category"] == 4
+
+
+def test_resolve_config_yaml_block(monkeypatch):
+    monkeypatch.delenv("EMPIRICA_MAX_ARTIFACTS_PER_CATEGORY", raising=False)
+    monkeypatch.delenv("EMPIRICA_MAX_ARTIFACTS_TOTAL", raising=False)
+    _patch_cfg(monkeypatch, {"artifact_injection": {"max_per_category": 2, "max_total": 10}})
+    assert _resolve_injection_caps() == {"max_per_category": 2, "max_total": 10}
+
+
+def test_resolve_env_wins_over_config(monkeypatch):
+    monkeypatch.setenv("EMPIRICA_MAX_ARTIFACTS_PER_CATEGORY", "7")
+    _patch_cfg(monkeypatch, {"artifact_injection": {"max_per_category": 2}})
+    assert _resolve_injection_caps()["max_per_category"] == 7
+
+
+def test_resolve_bad_value_ignored(monkeypatch):
+    monkeypatch.setenv("EMPIRICA_MAX_ARTIFACTS_PER_CATEGORY", "notanint")
+    _patch_cfg(monkeypatch, {})
+    assert _resolve_injection_caps()["max_per_category"] is None


### PR DESCRIPTION
## What (mesh-support `prop_kjqyebqr`)

Makes the PREFLIGHT/CHECK teaser's artifact-injection volume **tunable + observable** — a measurement/hygiene knob so injection can be right-sized per practice (heavy artifact graphs), independent of any spend investigation. Not a claim about the spend anomaly; the Sentinel + git-notes discipline stay net-positive.

## Config (precedence: env > config.yaml > default)

```yaml
# .empirica/config.yaml
artifact_injection:
  max_per_category: 3   # cap each category list
  max_total: 20         # cap the combined set
```
Env overrides: `EMPIRICA_MAX_ARTIFACTS_PER_CATEGORY`, `EMPIRICA_MAX_ARTIFACTS_TOTAL` (env wins).

**Default is uncapped — behaviour unchanged.**

## How

- `_resolve_injection_caps()` — mirrors the established gate-scalar precedence (env > `.empirica/config.yaml` block > default).
- `_apply_injection_caps(result)` — truncates each **score-ranked** category list to `max_per_category` (drops lowest-ranked tail), then the combined set to `max_total` (trims the currently-largest category). Fail-safe.
- Wired into `_apply_context_budget` **before** the existing char-budget elision, so both `retrieve_task_patterns` (PREFLIGHT) and `check_against_patterns` (CHECK) get it.
- Drop counts surface in `_context_budget.capped_per_category` / `capped_total` (observability — mesh-support's core ask).

## Verification

- 10 unit tests (`test_injection_cap.py`) — per-category truncation, keep-highest-ranked, max_total trim-largest-first, non-category keys untouched, and full config/env precedence (default/env/config.yaml/env-wins/bad-value).
- **Live-verified**: `EMPIRICA_MAX_ARTIFACTS_PER_CATEGORY=2` → 5→2 + `capped_per_category=5`; no env → unchanged, no `capped_*` key.

## Scope / deferred

v1 covers the `pattern_retrieval` teaser (PREFLIGHT/CHECK). POSTFLIGHT + post-compact bootstrap have separate budget builders (`session-init` `_init_context_budget`, the #187-follow-up unbudgeted bootstrap injection). The bigger arc — **decay-driven relevance ranking** (there's a `context_budget.py` manager with `recency_decay` scoring) + mesh-message capping + git offload — is the direction, tracked separately.