### PR TITLE
fix(serve): /entities accepts org_id as additive alias for parent_org

### DIFF
--- a/empirica/api/routes/entities.py
+++ b/empirica/api/routes/entities.py
@@ -112,6 +112,14 @@ async def list_entities(
         description="Scope to CONTACTS affiliated with this organization id (active affiliation). "
         "Implies a contact scope; an unknown org returns []. Backed by entity_memberships.",
     ),
+    org_id: str | None = Query(
+        None,
+        description="Alias for parent_org (org-membership scoping). Additive/backward-compatible: "
+        "if both are given, parent_org wins. Kills the silent-drop footgun where a caller passing "
+        "?org_id= (an unknown param) got the full unscoped set. The canonical cross-route scoping "
+        "contract is being ratified in the ERM/CRM SER (workspace-owned spine); this is the one "
+        "unambiguous alias landed ahead of it.",
+    ),
     limit: int = Query(100, ge=1, le=500),
 ):
     """List entities from the workspace registry (extension entity-list backing).
@@ -122,6 +130,10 @@ async def list_entities(
     (decision A — promoted to a spine column later only if queried on).
     """
     from empirica.data.repositories.workspace_db import WorkspaceDBRepository
+
+    # org_id is an additive alias for parent_org (org-membership scoping). parent_org
+    # wins when both are supplied; either one feeds the single repo scoping path below.
+    parent_org = parent_org or org_id
 
     out: list[dict] = []
     with WorkspaceDBRepository.open() as repo:

--- a/tests/test_workspace_crm_projection.py
+++ b/tests/test_workspace_crm_projection.py
@@ -276,3 +276,72 @@ def test_practitioner_entity_upsert_and_list_by_practice():
     assert {p["entity_id"] for p in repo.list_practitioner_entities("empirica")} == {"cc-111"}
     assert {p["entity_id"] for p in repo.list_practitioner_entities("empirica-cortex")} == {"cc-222"}
     assert repo.list_practitioner_entities("no-such-practice") == []
+
+
+# ── /entities org_id alias (kills the silent-drop scoping footgun) ─────────────
+
+
+class _AliasSpyRepo:
+    """Minimal fake for list_entities' repo surface. Records the parent_org it
+    receives so we can assert org_id coalesces into the single scoping path.
+    Returns [] so the per-row enrichment/count loop is skipped."""
+
+    def __init__(self):
+        self.seen_parent_org = "UNSET"
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_a):
+        return False
+
+    def get_org_parent_map(self):
+        return {}
+
+    def get_org_detail_map(self):
+        return {}
+
+    def get_contact_org_details_map(self):
+        return {}
+
+    def get_contact_detail_map(self):
+        return {}
+
+    def get_contact_reports_to_map(self):
+        return {}
+
+    def list_entities(self, *, parent_org=None, **_kw):
+        # _kw absorbs entity_type/status/limit — only parent_org is under test here.
+        self.seen_parent_org = parent_org
+        return []
+
+
+async def _call_list_entities(**kw):
+    """Invoke the route fn with a spy repo; return the parent_org it forwarded."""
+    from unittest.mock import patch
+
+    from empirica.api.routes import entities as ent
+
+    spy = _AliasSpyRepo()
+    with patch(
+        "empirica.data.repositories.workspace_db.WorkspaceDBRepository.open",
+        return_value=spy,
+    ):
+        await ent.list_entities(type="contact", status="active", **kw)
+    return spy.seen_parent_org
+
+
+async def test_org_id_aliases_parent_org():
+    # ?org_id= alone forwards as parent_org (the exact silent-drop param extension hit).
+    assert await _call_list_entities(parent_org=None, org_id="o-nle") == "o-nle"
+
+
+async def test_parent_org_still_works_and_wins_over_org_id():
+    # Backward-compatible: ?parent_org= alone unchanged, and it wins when both given.
+    assert await _call_list_entities(parent_org="o-canon", org_id=None) == "o-canon"
+    assert await _call_list_entities(parent_org="o-canon", org_id="o-alias") == "o-canon"
+
+
+async def test_neither_param_is_unscoped():
+    # No scoping param → parent_org stays None (project/registry-wide, prior behavior).
+    assert await _call_list_entities(parent_org=None, org_id=None) is None


### PR DESCRIPTION
## What
`GET /api/v1/entities` now accepts `org_id` as an **additive, backward-compatible alias** for `parent_org` (org-membership scoping). `parent_org` wins if both are supplied.

## Why
Extension's live daemon probe (`prop_pnsikv`) reported the CRM GET routes "ignore scoping params." Investigation found this is **not a within-contract data leak** — each route *does* scope, just under different param names:

| Route | Real scoping param |
|---|---|
| `/entities` | `?parent_org=` (no `org_id`) |
| `/engagements` | `?org=` (no `entity_id`) |
| `/goals` | `?entity=engagement&entity_id=` |

Extension used a uniform `?org_id=`/`?entity_id=` convention that none expose. FastAPI silently drops unknown query params, so a caller passing `?org_id=` got the **full unscoped set thinking they'd scoped** — a fail-open footgun. (`/goals` already has honest-empty anti-leak discipline from #183.)

This lands the one **unambiguous** fix. The full canonical cross-route scoping contract is a workspace-owned decision being ratified in the ERM/CRM SER (`prop_v3lp`) — the routes scope by *different relationships* (entity→owning-org vs engagement→linked-artifacts), so there's no single mechanical uniform param to add. This alias is deliberately scoped ahead of that, not a substitute.

## Tests
3 route-level tests pin the coalesce (org_id aliases → parent_org, parent_org wins over org_id, neither = unscoped). Source pyright-clean; 51 adjacent route/repo tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)