### PR TITLE
feat(serve): expose injection measure-view on daemon /profile/status

### DIFF
--- a/empirica/api/serve_app.py
+++ b/empirica/api/serve_app.py
@@ -147,6 +147,10 @@ class ProfileStatusResponse(BaseModel):
     artifact_counts: dict = Field(default_factory=dict)
     total_artifacts: int = 0
     last_sync: str | None = None
+    # 6-field injection measure-view of the active transaction (injected_*/cap_*/
+    # capped_*), persisted at PREFLIGHT. The extension's served source for the
+    # injection-observability panel (prop_o4g6sag). None when unavailable.
+    injection_budget: dict | None = None
 
 
 class SyncResponse(BaseModel):
@@ -669,6 +673,45 @@ def _store_artifacts(artifacts: list[ArtifactPayload]) -> dict:
     }
 
 
+def _read_active_injection_budget() -> dict | None:
+    """The injection measure-view (6-field block) of the served project's active
+    transaction — the extension panel's served source (prop_o4g6sag).
+
+    Persisted at PREFLIGHT into ``.empirica/active_transaction{suffix}.json``.
+    Prefers an OPEN transaction's budget, falling back to the most-recently-updated
+    one. None when unavailable; never raises (the daemon must stay up).
+    """
+    try:
+        import json as _json
+        from pathlib import Path
+
+        from empirica.api.daemon_project import get_cached_daemon_project
+
+        root = (get_cached_daemon_project() or {}).get("project_path")
+        if not root:
+            return None
+        candidates = sorted(
+            (Path(root) / ".empirica").glob("active_transaction*.json"),
+            key=lambda p: p.stat().st_mtime,
+            reverse=True,
+        )
+        # Prefer an OPEN transaction's budget; else the most-recent any-status.
+        for open_only in (True, False):
+            for p in candidates:
+                try:
+                    d = _json.loads(p.read_text())
+                except Exception:
+                    continue
+                if open_only and d.get("status") != "open":
+                    continue
+                budget = d.get("injection_budget")
+                if isinstance(budget, dict):
+                    return budget
+    except Exception:
+        return None
+    return None
+
+
 def _run_profile_status() -> dict:
     """Get profile status — artifact counts from database."""
     from empirica.data.session_database import SessionDatabase
@@ -696,6 +739,7 @@ def _run_profile_status() -> dict:
     return {
         "artifact_counts": counts,
         "total_artifacts": total,
+        "injection_budget": _read_active_injection_budget(),
     }
 
 

--- a/empirica/cli/command_handlers/_workflow_preflight.py
+++ b/empirica/cli/command_handlers/_workflow_preflight.py
@@ -713,7 +713,15 @@ def _preflight_get_last_session_ts(db, project_id, session_id):
 
 
 def _preflight_persist_pattern_count(patterns, resolved_project_path):
-    """Persist pattern count in the transaction file for context evidence. Non-fatal."""
+    """Persist pattern count + injection measure-view in the transaction file.
+
+    The pattern count is context evidence. The ``injection_budget`` (the 6-field
+    measure-view carried on ``patterns["_context_budget"]``) is persisted so the
+    daemon (GET /profile/status) and ``empirica status`` can surface it — it's the
+    extension panel's only served source (prop_o4g6sag). Absent when nothing was
+    injected AND no cap is configured. Non-fatal; active_transaction is
+    workflow-owned (single-writer), so this field survives the sentinel's reads.
+    """
     if not (patterns and resolved_project_path):
         return
     try:
@@ -727,6 +735,9 @@ def _preflight_persist_pattern_count(patterns, resolved_project_path):
             with open(tx_file) as f:
                 tx_d = _pjson.load(f)
             tx_d["preflight_pattern_count"] = pattern_count
+            budget = patterns.get("_context_budget")
+            if isinstance(budget, dict):
+                tx_d["injection_budget"] = budget
             with open(tx_file, "w") as f:
                 _pjson.dump(tx_d, f, indent=2)
     except Exception:

--- a/tests/test_injection_budget_serve.py
+++ b/tests/test_injection_budget_serve.py
@@ -1,0 +1,88 @@
+"""Tests for the injection measure-view served source (B1 persist + B2 daemon).
+
+The extension's injection-observability panel has NO cortex/MCP path — the daemon
+GET /profile/status is its ONLY served source (prop_o4g6sag). PREFLIGHT persists
+the 6-field ``_context_budget`` measure-view into ``active_transaction.json`` (B1);
+the daemon reads it back for /profile/status (B2).
+"""
+
+from __future__ import annotations
+
+import json
+
+import empirica.api.daemon_project as dp
+import empirica.api.serve_app as serve
+import empirica.cli.command_handlers._workflow_preflight as wp
+
+_BUDGET = {
+    "injected_per_category": {"relevant_findings": 3},
+    "injected_total": 3,
+    "cap_per_category": None,
+    "cap_total": None,
+    "capped_per_category": 0,
+    "capped_total": 0,
+}
+
+
+def _tx_file(root, suffix="", status="open", budget=None):
+    emp = root / ".empirica"
+    emp.mkdir(parents=True, exist_ok=True)
+    d = {"transaction_id": "t1", "status": status}
+    if budget is not None:
+        d["injection_budget"] = budget
+    p = emp / f"active_transaction{suffix}.json"
+    p.write_text(json.dumps(d))
+    return p
+
+
+# ── B1: PREFLIGHT persists the measure-view ───────────────────────────────────
+
+
+def test_persist_writes_injection_budget(tmp_path, monkeypatch):
+    monkeypatch.setattr(wp.R, "instance_suffix", lambda: "")
+    p = _tx_file(tmp_path)  # existing tx file, no budget yet
+    patterns = {"_context_budget": _BUDGET, "relevant_findings": [1, 2, 3]}
+    wp._preflight_persist_pattern_count(patterns, str(tmp_path))
+    written = json.loads(p.read_text())
+    assert written["injection_budget"] == _BUDGET
+    assert written["preflight_pattern_count"] == 3  # _context_budget dict not counted
+
+
+def test_persist_omits_budget_when_absent(tmp_path, monkeypatch):
+    monkeypatch.setattr(wp.R, "instance_suffix", lambda: "")
+    p = _tx_file(tmp_path)
+    wp._preflight_persist_pattern_count({"relevant_findings": [1]}, str(tmp_path))
+    assert "injection_budget" not in json.loads(p.read_text())
+
+
+# ── B2: daemon reads the persisted measure-view ───────────────────────────────
+
+
+def test_daemon_reads_persisted_budget(tmp_path, monkeypatch):
+    _tx_file(tmp_path, budget=_BUDGET)
+    monkeypatch.setattr(dp, "get_cached_daemon_project", lambda *a, **k: {"project_path": str(tmp_path)})
+    assert serve._read_active_injection_budget() == _BUDGET
+
+
+def test_daemon_prefers_open_over_closed(tmp_path, monkeypatch):
+    monkeypatch.setattr(dp, "get_cached_daemon_project", lambda *a, **k: {"project_path": str(tmp_path)})
+    _tx_file(tmp_path, suffix="_a", status="closed", budget={**_BUDGET, "injected_total": 99})
+    _tx_file(tmp_path, suffix="_b", status="open", budget=_BUDGET)
+    assert serve._read_active_injection_budget()["injected_total"] == 3  # open wins
+
+
+def test_daemon_falls_back_to_closed_when_no_open(tmp_path, monkeypatch):
+    monkeypatch.setattr(dp, "get_cached_daemon_project", lambda *a, **k: {"project_path": str(tmp_path)})
+    _tx_file(tmp_path, status="closed", budget=_BUDGET)
+    assert serve._read_active_injection_budget() == _BUDGET
+
+
+def test_daemon_honest_none_when_no_budget(tmp_path, monkeypatch):
+    monkeypatch.setattr(dp, "get_cached_daemon_project", lambda *a, **k: {"project_path": str(tmp_path)})
+    _tx_file(tmp_path)  # tx file exists but carries no injection_budget
+    assert serve._read_active_injection_budget() is None
+
+
+def test_daemon_honest_none_when_no_project(monkeypatch):
+    monkeypatch.setattr(dp, "get_cached_daemon_project", lambda *a, **k: {})
+    assert serve._read_active_injection_budget() is None


### PR DESCRIPTION
## What
The 6-field injection measure-view is now a **served source** on the daemon: `GET /api/v1/profile/status` carries an optional `injection_budget` field.

## Why
Extension's injection-observability panel is a pure HTTP client with **no cortex/MCP path** — the daemon is its *only* render source (`prop_o4g6sag`). Extension corrected that this is **hard-blocking**, not a fallback, so it's on the critical path.

## How — two halves, one persistence
- **B1 (persist):** PREFLIGHT's `_preflight_persist_pattern_count` also writes the `_context_budget` measure-view into `active_transaction.json` as `injection_budget`. That file is workflow-owned (single-writer), so the field survives the sentinel's reads. Absent when nothing injected + no cap.
- **B2 (expose):** `_run_profile_status` reads it back (`get_cached_daemon_project` → scan `.empirica/active_transaction*.json`, prefer the OPEN transaction, fall back to most-recent). Added optional `injection_budget` to `ProfileStatusResponse`. Never raises — daemon stays up.

Composes with #309 (which populates the 6 fields); field-agnostic here, so it works independently.

## Deferred
The `empirica status` CLI render (`prop_3por4fwg`'s status line) — routes through cockpit `aggregate_instance_state` + the pretty renderer, a separable follow-up.

## Tests
7 new (persist writes/omits; daemon reads, prefers-open, falls-back, honest-None ×2). serve + preflight suites green; source pyright + ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)