### PR TITLE
feat(qdrant): ERM §6.2 entity-row points — writer + search (PR-a)

### DIFF
--- a/empirica/core/qdrant/workspace_index.py
+++ b/empirica/core/qdrant/workspace_index.py
@@ -127,9 +127,168 @@ def embed_to_workspace_index(
         return False
 
 
-def _format_point(point, score: float) -> dict:
-    """Extract payload fields from a Qdrant point into a result dict."""
+# ── ERM §6.2 — entity-row points (point_kind="entity") ────────────────────────
+#
+# An entity_registry ROW (contact / org / engagement) embedded as its OWN
+# searchable point, coexisting with artifact pointers in the same collection under
+# the shared entity-filter contract (decision V-1). Legacy artifact points simply
+# lack `point_kind`, so `must_not(point_kind=="entity")` retains them with no
+# migration.
+
+# entity_type → the *_ids field the row self-tags into (mirrors the artifact
+# field_map, so an entity row lands in the SAME filter bucket as its artifacts).
+_ENTITY_TYPE_FIELD = {
+    "contact": "contact_ids",
+    "client": "contact_ids",
+    "org": "org_ids",
+    "organization": "org_ids",
+    "engagement": "engagement_ids",
+}
+
+# Alias → canonical entity_type stored/matched on entity points (org → organization).
+_CANONICAL_ENTITY_TYPE = {
+    "contact": "contact",
+    "client": "contact",
+    "org": "organization",
+    "organization": "organization",
+    "engagement": "engagement",
+}
+
+
+def _canon_entity_type(entity_type: str | None) -> str:
+    """Canonicalize an entity_type (org → organization); unknown passes through."""
+    et = (entity_type or "").lower()
+    return _CANONICAL_ENTITY_TYPE.get(et, et)
+
+
+def _compose_entity_text(
+    entity_type: str,
+    display_name: str,
+    description: str = "",
+    metadata: dict | None = None,
+    domain: str | None = None,
+    stage: str | None = None,
+) -> str:
+    """Compose the searchable vector text for an entity row, per §4 (ordered
+    most→least identifying). Empty parts are dropped; parts joined by ' · '."""
+    md = metadata or {}
+    et = _canon_entity_type(entity_type)
+    parts: list[str] = [display_name or ""]
+    if et == "contact":
+        parts += [md.get("company"), md.get("role") or md.get("title"), description]
+    elif et == "organization":
+        parts += [description, md.get("industry") or md.get("sector")]
+    elif et == "engagement":
+        parts += [domain, stage, md.get("outcome"), md.get("symptom"), md.get("resolution"), description]
+    else:
+        parts += [description, *(str(v) for v in md.values() if v)]
+    return " · ".join(p for p in parts if p)
+
+
+def _entity_self_refs(entity_type: str, entity_id: str) -> dict[str, list[str]]:
+    """The self-referential entity tag: the row's own id in its type's *_ids field
+    (empty for the other two), so unified retrieval finds row + artifacts together."""
+    refs: dict[str, list[str]] = {"contact_ids": [], "org_ids": [], "engagement_ids": []}
+    field = _ENTITY_TYPE_FIELD.get((entity_type or "").lower())
+    if field and entity_id:
+        refs[field] = [entity_id]
+    return refs
+
+
+def _entity_point_id(entity_type: str, entity_id: str) -> int:
+    """Stable, distinct-namespace point id for an entity row (re-embed = upsert)."""
+    return int(hashlib.md5(f"wsidx_entity:{entity_type}:{entity_id}".encode()).hexdigest()[:15], 16)
+
+
+def embed_entity_to_workspace_index(
+    entity_type: str,
+    entity_id: str,
+    display_name: str,
+    description: str = "",
+    status: str = "active",
+    metadata: dict | None = None,
+    domain: str | None = None,
+    stage: str | None = None,
+    emoji_state: str | None = None,
+    project_id: str = "workspace",
+    timestamp: float | None = None,
+) -> bool:
+    """Embed an entity_registry ROW as its own searchable point (point_kind='entity').
+
+    Idempotent — the stable point id means any re-embed on update upserts the same
+    point. Returns True on success, False if Qdrant unavailable or embedding failed
+    (never raises — mirrors the artifact writer's best-effort contract).
+    """
+    if not _check_qdrant_available():
+        return False
+
+    try:
+        _, Distance, VectorParams, PointStruct = _get_qdrant_imports()
+        client = _get_qdrant_client()
+        if client is None:
+            return False
+
+        _ensure_collection(client, Distance, VectorParams)
+
+        text = _compose_entity_text(entity_type, display_name, description, metadata, domain, stage)
+        vector = _get_embedding_safe(text)
+        if vector is None:
+            return False
+
+        refs = _entity_self_refs(entity_type, entity_id)
+        payload = {
+            "point_kind": "entity",
+            "entity_type": _canon_entity_type(entity_type),
+            "entity_id": entity_id,
+            "display_name": display_name or "",
+            "text": text[:300],
+            "status": status or "active",
+            "project_id": project_id,
+            "contact_ids": refs["contact_ids"],
+            "org_ids": refs["org_ids"],
+            "engagement_ids": refs["engagement_ids"],
+            "domain_tags": [domain] if domain else [],
+            "emoji_state": emoji_state or "",
+            "timestamp": timestamp or time.time(),
+        }
+
+        point = PointStruct(id=_entity_point_id(entity_type, entity_id), vector=vector, payload=payload)
+        client.upsert(collection_name=_workspace_index_collection(), points=[point])
+        return True
+    except Exception as e:
+        logger.warning(f"Failed to embed entity to workspace_index: {e}")
+        return False
+
+
+def _format_entity_point(point, score: float) -> dict:
+    """Project an entity-row point's payload (point_kind='entity') for callers."""
     p = point.payload or {}
+    return {
+        "score": score,
+        "point_kind": "entity",
+        "entity_type": p.get("entity_type", ""),
+        "entity_id": p.get("entity_id", ""),
+        "display_name": p.get("display_name", ""),
+        "status": p.get("status", ""),
+        "text": p.get("text", ""),
+        "project_id": p.get("project_id", ""),
+        "contact_ids": p.get("contact_ids", []),
+        "org_ids": p.get("org_ids", []),
+        "engagement_ids": p.get("engagement_ids", []),
+        "domain_tags": p.get("domain_tags", []),
+        "emoji_state": p.get("emoji_state", ""),
+        "timestamp": p.get("timestamp", 0),
+    }
+
+
+def _format_point(point, score: float) -> dict:
+    """Extract payload fields from a Qdrant point into a result dict.
+
+    Routes entity-row points (point_kind='entity') to their own projection; every
+    other point is a legacy artifact pointer (the field is absent)."""
+    p = point.payload or {}
+    if p.get("point_kind") == "entity":
+        return _format_entity_point(point, score)
     return {
         "score": score,
         "artifact_id": p.get("artifact_id", ""),
@@ -145,6 +304,52 @@ def _format_point(point, score: float) -> dict:
     }
 
 
+def _build_search_filter(entity_type, entity_id, entity_filter, project_id, point_kind, status):
+    """Assemble the Qdrant must/must_not filter for a workspace_index search.
+
+    Extracted from ``search_workspace_index`` to keep it under the complexity limit
+    and to make the §3 point_kind / status / entity-type branch logic unit-testable.
+    Returns a ``Filter`` or ``None`` when no conditions apply.
+    """
+    from qdrant_client.models import FieldCondition, Filter, MatchAny, MatchValue
+
+    conditions, must_not = [], []
+
+    # point_kind discriminator (§3): entity → must; artifact → must_not(entity) so
+    # legacy points (field absent) pass; None → both kinds.
+    if point_kind == "entity":
+        conditions.append(FieldCondition(key="point_kind", match=MatchValue(value="entity")))
+    elif point_kind == "artifact":
+        must_not.append(FieldCondition(key="point_kind", match=MatchValue(value="entity")))
+
+    # Entity type/id shorthand → *_ids filter (works for both kinds via self-ref).
+    if entity_type and entity_id:
+        field = _ENTITY_TYPE_FIELD.get(entity_type.lower())
+        if field:
+            conditions.append(FieldCondition(key=field, match=MatchAny(any=[entity_id])))
+    elif point_kind == "entity" and entity_type:
+        # entity-type-only filter: entity rows carry their own canonical entity_type.
+        conditions.append(FieldCondition(key="entity_type", match=MatchValue(value=_canon_entity_type(entity_type))))
+
+    # Status filter — entity points only (artifact points lack the field, so a status
+    # must would wrongly exclude them). None includes archived.
+    if point_kind == "entity" and status is not None:
+        conditions.append(FieldCondition(key="status", match=MatchValue(value=status)))
+
+    # Explicit entity_filter dict
+    if entity_filter:
+        for key in ("contact_ids", "org_ids", "engagement_ids"):
+            ids = entity_filter.get(key, [])
+            if ids:
+                conditions.append(FieldCondition(key=key, match=MatchAny(any=ids)))
+
+    # Project scope
+    if project_id:
+        conditions.append(FieldCondition(key="project_id", match=MatchValue(value=project_id)))
+
+    return Filter(must=conditions or None, must_not=must_not or None) if (conditions or must_not) else None
+
+
 def search_workspace_index(
     query_text: str | None = None,
     entity_type: str | None = None,
@@ -152,19 +357,28 @@ def search_workspace_index(
     entity_filter: dict[str, list[str]] | None = None,
     project_id: str | None = None,
     limit: int = 20,
+    point_kind: str | None = None,
+    status: str | None = "active",
 ) -> list[dict]:
     """Search workspace_index with semantic query and/or entity filters.
 
     Args:
         query_text: Semantic search query (required if no entity filter)
-        entity_type: Shorthand filter — "contact", "org", "engagement"
+        entity_type: Shorthand filter — "contact", "org", "engagement". When
+            ``point_kind='entity'`` and no ``entity_id``, filters entity ROWS by type.
         entity_id: Used with entity_type for simple filtering
         entity_filter: Dict of {"contact_ids": [...], "org_ids": [...], ...}
         project_id: Optional project scope filter
         limit: Maximum results
+        point_kind: ``"entity"`` → entity rows only; ``"artifact"`` → artifact
+            pointers only (legacy points, field absent, via must_not); ``None`` →
+            both, unified (§3).
+        status: entity-point status filter (``active``|``inactive``|``archived``),
+            applied ONLY when ``point_kind='entity'`` — artifact points lack the
+            field. Pass ``None`` to include archived.
 
     Returns:
-        List of matching artifact pointers with scores and metadata
+        List of matching points (artifact pointers and/or entity rows) with scores.
     """
     if not _check_qdrant_available():
         return []
@@ -178,36 +392,7 @@ def search_workspace_index(
         if not client.collection_exists(coll):
             return []
 
-        # Build Qdrant filter
-        from qdrant_client.models import FieldCondition, Filter, MatchAny, MatchValue
-
-        conditions = []
-
-        # Entity type/id shorthand → filter
-        if entity_type and entity_id:
-            field_map = {
-                "contact": "contact_ids",
-                "client": "contact_ids",
-                "org": "org_ids",
-                "organization": "org_ids",
-                "engagement": "engagement_ids",
-            }
-            field = field_map.get(entity_type.lower())
-            if field:
-                conditions.append(FieldCondition(key=field, match=MatchAny(any=[entity_id])))
-
-        # Explicit entity_filter dict
-        if entity_filter:
-            for key in ("contact_ids", "org_ids", "engagement_ids"):
-                ids = entity_filter.get(key, [])
-                if ids:
-                    conditions.append(FieldCondition(key=key, match=MatchAny(any=ids)))
-
-        # Project scope
-        if project_id:
-            conditions.append(FieldCondition(key="project_id", match=MatchValue(value=project_id)))
-
-        query_filter = Filter(must=conditions) if conditions else None
+        query_filter = _build_search_filter(entity_type, entity_id, entity_filter, project_id, point_kind, status)
 
         # Semantic search if query_text provided
         if query_text:

--- a/tests/test_workspace_index_entity.py
+++ b/tests/test_workspace_index_entity.py
@@ -1,0 +1,191 @@
+"""Tests for ERM §6.2 entity-row points in workspace_index (PR-a: writer + search).
+
+Pure helpers (text composition §4, self-ref tags, stable id, format routing) are
+tested directly. The writer + search integration is covered with a mocked Qdrant
+stack (no live server) — capturing the upserted point payload and the query filter.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import empirica.core.qdrant.workspace_index as wi
+
+# ── pure: text composition (§4) ───────────────────────────────────────────────
+
+
+def test_compose_contact_text_order():
+    t = wi._compose_entity_text(
+        "contact", "Carly", "runs the foundation", {"company": "Empirica Foundation", "role": "Admiral"}
+    )
+    assert t == "Carly · Empirica Foundation · Admiral · runs the foundation"
+
+
+def test_compose_org_text_uses_industry():
+    t = wi._compose_entity_text("organization", "NLE", "Live events co", {"industry": "Live Entertainment"})
+    assert t == "NLE · Live events co · Live Entertainment"
+
+
+def test_compose_engagement_text_domain_stage_outcome():
+    t = wi._compose_entity_text(
+        "engagement", "Carly onboarding", "the onboarding", {"symptom": "seat stall"}, domain="onboarding", stage="live"
+    )
+    assert t == "Carly onboarding · onboarding · live · seat stall · the onboarding"
+
+
+def test_compose_drops_empty_parts():
+    assert wi._compose_entity_text("contact", "Solo", "") == "Solo"
+
+
+def test_compose_role_falls_back_to_title():
+    t = wi._compose_entity_text("contact", "X", "", {"title": "CTO"})
+    assert "CTO" in t
+
+
+# ── pure: canonicalization, self-ref, stable id ───────────────────────────────
+
+
+def test_canon_org_to_organization():
+    assert wi._canon_entity_type("org") == "organization"
+    assert wi._canon_entity_type("organization") == "organization"
+    assert wi._canon_entity_type("contact") == "contact"
+    assert wi._canon_entity_type("weird") == "weird"
+
+
+def test_self_refs_tag_own_field_only():
+    assert wi._entity_self_refs("engagement", "e-1") == {"contact_ids": [], "org_ids": [], "engagement_ids": ["e-1"]}
+    assert wi._entity_self_refs("org", "o-1")["org_ids"] == ["o-1"]
+    assert wi._entity_self_refs("contact", "c-1")["contact_ids"] == ["c-1"]
+
+
+def test_point_id_stable_and_distinct():
+    a = wi._entity_point_id("engagement", "e-1")
+    assert a == wi._entity_point_id("engagement", "e-1")  # stable → upsert, not dup
+    assert a != wi._entity_point_id("engagement", "e-2")
+    assert a != wi._entity_point_id("contact", "e-1")  # type namespaced
+
+
+# ── pure: format routing ──────────────────────────────────────────────────────
+
+
+def test_format_point_routes_entity():
+    pt = SimpleNamespace(
+        payload={"point_kind": "entity", "entity_type": "contact", "entity_id": "c-1", "status": "active"}
+    )
+    out = wi._format_point(pt, 0.9)
+    assert out["point_kind"] == "entity" and out["entity_id"] == "c-1" and out["status"] == "active"
+    assert "artifact_id" not in out
+
+
+def test_format_point_routes_legacy_artifact():
+    pt = SimpleNamespace(payload={"artifact_type": "finding", "artifact_id": "f-1"})  # no point_kind
+    out = wi._format_point(pt, 0.7)
+    assert out["artifact_id"] == "f-1" and "point_kind" not in out
+
+
+# ── mocked Qdrant: writer ─────────────────────────────────────────────────────
+
+
+def _patches(client):
+    def _point(id, vector, payload):
+        return SimpleNamespace(id=id, vector=vector, payload=payload)
+
+    return [
+        patch.object(wi, "_check_qdrant_available", return_value=True),
+        patch.object(wi, "_get_qdrant_client", return_value=client),
+        patch.object(wi, "_get_embedding_safe", return_value=[0.1] * 8),
+        patch.object(wi, "_ensure_collection", return_value=True),
+        patch.object(wi, "_get_qdrant_imports", return_value=(None, MagicMock(), MagicMock(), _point)),
+    ]
+
+
+def test_writer_upserts_entity_payload():
+    client = MagicMock()
+    with contextlib.ExitStack() as stack:
+        for p in _patches(client):
+            stack.enter_context(p)
+        ok = wi.embed_entity_to_workspace_index(
+            "org",
+            "empirica-foundation",
+            "Empirica Foundation",
+            "the foundation",
+            metadata={"industry": "AI"},
+            emoji_state="🟢",
+        )
+    assert ok is True
+    point = client.upsert.call_args.kwargs["points"][0]
+    pl = point.payload
+    assert pl["point_kind"] == "entity"
+    assert pl["entity_type"] == "organization"  # canonicalized from "org"
+    assert pl["org_ids"] == ["empirica-foundation"] and pl["contact_ids"] == []  # self-ref
+    assert pl["status"] == "active" and pl["project_id"] == "workspace"
+    assert point.id == wi._entity_point_id("org", "empirica-foundation")  # stable
+
+
+def test_writer_returns_false_when_qdrant_unavailable():
+    with patch.object(wi, "_check_qdrant_available", return_value=False):
+        assert wi.embed_entity_to_workspace_index("contact", "c-1", "X") is False
+
+
+def test_writer_returns_false_when_embedding_none():
+    client = MagicMock()
+    with contextlib.ExitStack() as stack:
+        for p in _patches(client):
+            stack.enter_context(p)
+        with patch.object(wi, "_get_embedding_safe", return_value=None):
+            assert wi.embed_entity_to_workspace_index("contact", "c-1", "X") is False
+        client.upsert.assert_not_called()
+
+
+# ── mocked Qdrant: search filter construction ─────────────────────────────────
+
+
+def _run_search(**kwargs):
+    """Run search with a mocked client; return the query_filter it built."""
+    client = MagicMock()
+    client.collection_exists.return_value = True
+    client.query_points.return_value = SimpleNamespace(points=[])
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(patch.object(wi, "_check_qdrant_available", return_value=True))
+        stack.enter_context(patch.object(wi, "_get_qdrant_client", return_value=client))
+        stack.enter_context(patch.object(wi, "_get_embedding_safe", return_value=[0.1] * 8))
+        wi.search_workspace_index(query_text="q", **kwargs)
+    return client.query_points.call_args.kwargs["query_filter"]
+
+
+def _keys(conds):
+    return [c.key for c in (conds or [])]
+
+
+def test_search_entity_kind_adds_must():
+    f = _run_search(point_kind="entity")
+    assert "point_kind" in _keys(f.must)
+    assert "status" in _keys(f.must)  # default status=active applied for entity
+
+
+def test_search_artifact_kind_uses_must_not():
+    f = _run_search(point_kind="artifact")
+    assert "point_kind" in _keys(f.must_not)
+    # status NOT applied for artifact points (they lack the field)
+    assert "status" not in _keys(f.must)
+
+
+def test_search_status_none_omits_status_filter():
+    f = _run_search(point_kind="entity", status=None)
+    assert "status" not in _keys(f.must)
+
+
+def test_search_entity_type_only_filters_by_type():
+    f = _run_search(point_kind="entity", entity_type="org")
+    keys = _keys(f.must)
+    assert "entity_type" in keys
+    et_cond = next(c for c in f.must if c.key == "entity_type")
+    assert et_cond.match.value == "organization"  # canonicalized
+
+
+def test_search_both_kinds_no_point_kind_condition():
+    # point_kind=None (unified) → no point_kind must/must_not, no status filter
+    f = _run_search(point_kind=None)
+    assert f is None or ("point_kind" not in _keys(f.must) and "point_kind" not in _keys(f.must_not))


### PR DESCRIPTION
## What (PR-a of 3 — the foundation)
Adds a **second point kind** (`point_kind="entity"`) to the existing `workspace_index` collection so `entity_registry` **rows** (contact/org/engagement) become their own searchable points — semantic entity retrieval, zero-artifact-entity visibility, and unified "row + its artifacts" retrieval under the shared entity-filter contract.

Implements the workspace-ratified spec (`empirica-workspace/docs/erm-vector-embed-spec.md`, SER `ser_6bddba4d`; decisions **V-1..V-4 locked**).

## Writer (§4/§5)
- `embed_entity_to_workspace_index` — sibling to the artifact writer, same best-effort qdrant guard + stable-id upsert.
- Pure helpers: `_compose_entity_text` (§4 per-type text), `_entity_self_refs` (**the self-referential `*_ids` tag** — lands a row in the same filter bucket as its artifacts, the key trick for unified retrieval), `_entity_point_id` (distinct namespace, stable → re-embed = upsert), `_canon_entity_type` (org → organization).
- Payload: `point_kind="entity"` + `status` + `project_id="workspace"` (V-2).

## Search (§3/§7)
- `search_workspace_index` gains `point_kind` ("entity" must / "artifact" `must_not(entity)` so legacy points pass **with zero migration** / None = both) and `status` (entity-points-only; None includes archived, V-3).
- `_build_search_filter` extracted (keeps search under the complexity limit); `_format_point` routes entity points to `_format_entity_point`.

## Deferred (PR-b / PR-c)
§6 write hooks + backfill verb · §7 CLI/daemon surfaces · §8 Carly acceptance (live-Qdrant integration).

## Tests
18 — text composition, self-ref, stable id, format routing, mocked-Qdrant writer payload + search filter construction. Source pyright + ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)