### PR TITLE
feat(erm): §6.2 entity semantic-search surfaces + Carly acceptance (was #313)

### DIFF
--- a/empirica/api/routes/entities.py
+++ b/empirica/api/routes/entities.py
@@ -103,6 +103,35 @@ def _list_subtitle(row: dict, meta: dict) -> str | None:
     return None
 
 
+def _semantic_entity_search(q: str, entity_type: str | None, status: str, limit: int) -> list[dict]:
+    """ERM §6.2 / decision V-4: rank entity-row vector points by semantic
+    similarity to ``q``. Ranked ALTERNATIVE to the SQL list (not a hybrid merge).
+
+    Returns the Gap-1 identity fields (``id``/``type``/``name``/``status``) plus a
+    ``score``; full projection (subtitle/health/linked_artifact_count) is
+    hydratable via ``GET /entities`` or ``/entities/{id}``. Never raises —
+    Qdrant-unavailable yields ``[]`` (honest-empty)."""
+    from empirica.core.qdrant.workspace_index import search_workspace_index
+
+    hits = search_workspace_index(
+        query_text=q,
+        entity_type=entity_type,
+        point_kind="entity",
+        status=None if status == "all" else status,
+        limit=limit,
+    )
+    return [
+        {
+            "id": h.get("entity_id"),
+            "type": h.get("entity_type"),
+            "name": h.get("display_name"),
+            "status": h.get("status"),
+            "score": h.get("score"),
+        }
+        for h in hits
+    ]
+
+
 @router.get("/entities", dependencies=[Depends(verify_mint_bearer)])
 async def list_entities(
     type: str | None = Query(None, description="Filter by entity_type (contact, organization, engagement, ...)"),
@@ -112,6 +141,11 @@ async def list_entities(
         description="Scope to CONTACTS affiliated with this organization id (active affiliation). "
         "Implies a contact scope; an unknown org returns []. Backed by entity_memberships.",
     ),
+    q: str | None = Query(
+        None,
+        description="Semantic query — ranks entity-row vector points (ERM §6.2) instead of the SQL "
+        "list; returns id/type/name/status + score (V-4 ranked alternative, not a hybrid merge).",
+    ),
     limit: int = Query(100, ge=1, le=500),
 ):
     """List entities from the workspace registry (extension entity-list backing).
@@ -120,7 +154,14 @@ async def list_entities(
     always present; ``subtitle``/``status``/``health``/``linked_artifact_count``/
     ``updated_at`` are projection-bound. ``health`` reads ``metadata.health``
     (decision A — promoted to a spine column later only if queried on).
+
+    With ``?q=`` the response is the semantically-ranked entity set (``ranked=true``)
+    instead of the SQL list.
     """
+    if q:
+        ranked = _semantic_entity_search(q, type, status, limit)
+        return {"ok": True, "count": len(ranked), "entities": ranked, "ranked": True}
+
     from empirica.data.repositories.workspace_db import WorkspaceDBRepository
 
     out: list[dict] = []

--- a/empirica/cli/command_handlers/entity_commands.py
+++ b/empirica/cli/command_handlers/entity_commands.py
@@ -577,35 +577,52 @@ def handle_entity_walk_command(args):
 
 
 def handle_entity_search_command(args):
-    """Handle entity-search command."""
+    """Handle entity-search command — SQL LIKE by default, or semantic (§6.2
+    entity-row vector points) with --semantic."""
     try:
         query = args.query
         entity_type = getattr(args, "type", None)
         status = getattr(args, "status", "active")
         limit = getattr(args, "limit", 50)
         output = getattr(args, "output", "human")
-        with WorkspaceDBRepository.open() as repo:
-            results = repo.search_entities(query=query, entity_type=entity_type, status=status, limit=limit)
+        semantic = getattr(args, "semantic", False)
+
+        if semantic:
+            # Route to the §6.2 entity-row vector points. status=all → include archived.
+            from empirica.core.qdrant.workspace_index import search_workspace_index
+
+            results = search_workspace_index(
+                query_text=query,
+                entity_type=entity_type,
+                point_kind="entity",
+                status=None if status == "all" else status,
+                limit=limit,
+            )
+        else:
+            with WorkspaceDBRepository.open() as repo:
+                results = repo.search_entities(query=query, entity_type=entity_type, status=status, limit=limit)
+
         if output == "json":
             print(
                 json.dumps(
-                    {
-                        "ok": True,
-                        "query": query,
-                        "count": len(results),
-                        "entities": results,
-                    },
+                    {"ok": True, "query": query, "semantic": semantic, "count": len(results), "entities": results},
                     indent=2,
                     default=str,
                 )
             )
             return
         if not results:
-            print(f"No entities match '{query}' (type={entity_type or 'any'}, status={status})")
+            hint = " (run entity-reindex if the vector index is empty)" if semantic else ""
+            print(f"No entities match '{query}' (type={entity_type or 'any'}, status={status}){hint}")
             return
-        print(f"# {len(results)} match{'es' if len(results) != 1 else ''} for '{query}'")
+        print(
+            f"# {len(results)} {'semantic ' if semantic else ''}match{'es' if len(results) != 1 else ''} for '{query}'"
+        )
         for e in results:
-            print(_format_entity_line(e))
+            line = _format_entity_line(e)
+            if semantic and e.get("score") is not None:
+                line += f"   [{e['score']:.2f}]"
+            print(line)
     except Exception as e:
         handle_cli_error(e, "entity-search", getattr(args, "verbose", False))
 

--- a/empirica/cli/parsers/checkpoint_parsers.py
+++ b/empirica/cli/parsers/checkpoint_parsers.py
@@ -714,6 +714,11 @@ def add_checkpoint_parsers(subparsers):
     entity_search_parser.add_argument("query", help='Search query (e.g. "MastersOfDirt")')
     entity_search_parser.add_argument("--type", help="Optional entity_type filter")
     entity_search_parser.add_argument(
+        "--semantic",
+        action="store_true",
+        help="Semantic vector search over entity-row points (§6.2) instead of SQL LIKE",
+    )
+    entity_search_parser.add_argument(
         "--status",
         choices=["active", "inactive", "archived", "all"],
         default="active",

--- a/tests/test_erm_entity_surfaces.py
+++ b/tests/test_erm_entity_surfaces.py
@@ -1,0 +1,107 @@
+"""Tests for ERM §6.2 search surfaces (PR-c): CLI --semantic + daemon ?q=.
+
+Mocked-Qdrant unit tests pin the wiring (routing, V-4 projection). The §8 Carly
+acceptance is an integration test that runs only where Qdrant is live — skipped
+in CI (`-m "not integration"`), exercised on a box with embeddings.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import empirica.cli.command_handlers.entity_commands as ec
+from empirica.api.routes import entities as ent
+from empirica.core.qdrant import connection as conn
+
+_WI_SEARCH = "empirica.core.qdrant.workspace_index.search_workspace_index"
+
+
+# ── daemon _semantic_entity_search (V-4 ranked alternative) ───────────────────
+
+
+def test_semantic_entity_search_projects_v4_shape():
+    hits = [
+        {
+            "entity_id": "e-1",
+            "entity_type": "engagement",
+            "display_name": "Onboarding",
+            "status": "active",
+            "score": 0.88,
+            "text": "…",
+        }
+    ]
+    with patch(_WI_SEARCH, return_value=hits) as m:
+        out = ent._semantic_entity_search("onboarding", "engagement", "active", 20)
+    assert out == [{"id": "e-1", "type": "engagement", "name": "Onboarding", "status": "active", "score": 0.88}]
+    assert m.call_args.kwargs["point_kind"] == "entity"
+    assert m.call_args.kwargs["query_text"] == "onboarding"
+
+
+def test_semantic_status_all_maps_to_none():
+    with patch(_WI_SEARCH, return_value=[]) as m:
+        ent._semantic_entity_search("q", None, "all", 5)
+    assert m.call_args.kwargs["status"] is None  # all → include archived
+
+
+# ── CLI entity-search --semantic routing ──────────────────────────────────────
+
+
+def test_cli_semantic_routes_to_vector():
+    ns = SimpleNamespace(
+        query="carly", type="contact", status="active", limit=10, output="json", semantic=True, verbose=False
+    )
+    with patch(_WI_SEARCH, return_value=[]) as m:
+        ec.handle_entity_search_command(ns)
+    assert m.called and m.call_args.kwargs["point_kind"] == "entity"
+
+
+def test_cli_default_is_sql_not_vector():
+    ns = SimpleNamespace(query="x", type=None, status="active", limit=10, output="json", semantic=False, verbose=False)
+    repo = MagicMock()
+    repo.search_entities.return_value = []
+    cm = MagicMock()
+    cm.__enter__.return_value = repo
+    cm.__exit__.return_value = False
+    with patch(_WI_SEARCH) as m, patch.object(ec.WorkspaceDBRepository, "open", return_value=cm):
+        ec.handle_entity_search_command(ns)
+    m.assert_not_called()  # default path must not touch the vector index
+    repo.search_entities.assert_called_once()
+
+
+# ── §8 Carly acceptance — live-Qdrant integration (skipped in CI) ─────────────
+
+
+@pytest.mark.integration
+def test_carly_acceptance_semantic_hits():
+    if not conn._check_qdrant_available():
+        pytest.skip("Qdrant unavailable — §8 acceptance is a live integration test")
+
+    from empirica.core.qdrant.workspace_index import embed_entity_to_workspace_index, search_workspace_index
+
+    # Carly's 3 entities (org / contact / engagement) — §8 fixture.
+    embed_entity_to_workspace_index("organization", "o-carly-accept", "Empirica Foundation", "a foundation customer")
+    embed_entity_to_workspace_index(
+        "contact", "c-carly-accept", "Carly", metadata={"company_name": "Empirica Foundation"}
+    )
+    embed_entity_to_workspace_index(
+        "engagement", "e-carly-accept", "Carly foundation onboarding", "onboarding", domain="onboarding", stage="live"
+    )
+
+    # §8.1 — semantic engagement hit above a sane floor.
+    eng = search_workspace_index(
+        query_text="onboarding for a foundation customer", entity_type="engagement", point_kind="entity", limit=5
+    )
+    assert any(h["entity_id"] == "e-carly-accept" for h in eng)
+
+    # §8.2 — contact hit.
+    con = search_workspace_index(query_text="Carly", entity_type="contact", point_kind="entity", limit=5)
+    assert any(h["entity_id"] == "c-carly-accept" for h in con)
+
+    # §8.4 — idempotent re-embed keeps the same point (stable id).
+    embed_entity_to_workspace_index("engagement", "e-carly-accept", "Carly foundation onboarding", "onboarding")
+    eng2 = search_workspace_index(query_text="onboarding foundation", entity_type="engagement", point_kind="entity")
+    ids = [h["entity_id"] for h in eng2]
+    assert ids.count("e-carly-accept") == 1  # no duplicate point


### PR DESCRIPTION
Reopened as a fresh PR — #313 auto-closed when its stacked base branch was deleted during the merge sequence. Same content, now based on develop with the `entities.py` conflict (org_id #308 vs `?q=`) resolved (both params kept).

## What (completes §6.2)
- **`entity-search --semantic`** — mode flag routing to the §6.2 entity-row vector points.
- **daemon `GET /api/v1/entities?q=`** — ranks entity points, returns id/type/name/status + score, `ranked=true` (V-4 ranked alternative). Coexists with the `org_id` alias (#308).
- **§8 Carly acceptance** — integration test, verified live end-to-end.

## Merge resolution
`list_entities` now carries `parent_org` · `org_id` (#308 alias) · `q` (semantic). The `_AliasSpyRepo` test helper passes `q=None` explicitly (direct route-fn calls leave FastAPI defaults as truthy `Query(...)` objects).

75 tests green on the merged branch; source pyright + ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)