### PR TITLE
feat(findings): finding-resolve verb + drop resolved findings from live retrieval (#307)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`finding-resolve` — the resolve/prune verb findings never had (#307).**
+  Findings were the only artifact type with no way to close them: unknowns,
+  assumptions, and goals all have resolve verbs, but a stale or superseded
+  finding could only *passively decay*. Recency-decay detects age, not
+  supersession — a two-month-old finding still semantically strong keeps
+  resurfacing high in PREFLIGHT/CHECK, and a superseded one never sinks fast
+  enough. `empirica finding-resolve <id> --resolution <why> [--superseded-by
+  <id>]` marks a finding resolved (kept for history, dropped from live
+  retrieval), mirroring `project_unknowns.is_resolved`; `--superseded-by` links
+  it to the finding that replaced it. `resolve-artifacts` batch gains a
+  `type="finding"` branch. New columns (`is_resolved`, `resolution`,
+  `resolved_timestamp`, `superseded_by`) land via migration 057 — additive,
+  nullable, idempotent.
+- **Resolved findings are dropped from both attention-injection surfaces.**
+  (1) The Qdrant PREFLIGHT/CHECK `relevant_findings` teaser reconciles against
+  live SQLite at read time (`_reconcile_findings_against_sqlite`) — Qdrant's
+  `is_resolved` payload is frozen at embed time, so a finding resolved *after*
+  embedding still reads unresolved there; the read-time reconcile is the fix
+  (same pattern as goal reconciliation), matching by `artifact_id` with a
+  text-prefix fallback for pre-#307 embeds. (2) The breadcrumbs post-compact
+  `EPISTEMIC FOCUS` block's `recent_findings` query gained an `is_resolved`
+  filter (the sibling unknowns query already had one), schema-guarded for DBs
+  predating migration 057. Both paths are best-effort — any failure returns the
+  raw set, never breaking the retrieval hot-path.
+
 ## [1.12.17] — 2026-07-11
 
 ### Fixed

--- a/docs/human/developers/CLI_COMMANDS_UNIFIED.md
+++ b/docs/human/developers/CLI_COMMANDS_UNIFIED.md
@@ -23,8 +23,8 @@
 > dictionary, then running this script.
 
 **Framework version:** 1.12.17
-**Generated:** 2026-07-11 13:11:25 UTC
-**Total commands:** 266 (across 26 categories)
+**Generated:** 2026-07-12 09:42:42 UTC
+**Total commands:** 267 (across 26 categories)
 
 For the most up-to-date detail on any single command, prefer
 `empirica <command> --help` — the generator extracts the same `help`
@@ -65,7 +65,7 @@ require `--session-id` (`project-bootstrap`, `sessions-show`,
 | [session](#session) | 8 | `session-create`, `sessions-list`, `sessions-show`, … |
 | [workflow](#workflow) | 4 | `preflight-submit`, `check`, `check-submit`, … |
 | [goals](#goals) | 16 | `goals-create`, `goals-list`, `goals-search`, … |
-| [logging](#logging) | 30 | `finding-log`, `unknown-log`, `unknown-list`, … |
+| [logging](#logging) | 31 | `finding-log`, `finding-resolve`, `unknown-log`, … |
 | [project](#project) | 18 | `project-init`, `project-update`, `project-create`, … |
 | [workspace](#workspace) | 21 | `workspace-init`, `workspace-map`, `workspace-list`, … |
 | [checkpoint](#checkpoint) | 7 | `checkpoint-create`, `checkpoint-load`, `checkpoint-list`, … |
@@ -677,6 +677,23 @@ Log a discovery — something concrete you NOW know that wasn't obvious before. 
   How this artifact was arrived at: intuition (training data + loaded context, no external retrieval since goal opened), search (external retrieval this session), or mixed.
 - `--output` — optional · type=`choice` · choices={human, json} · default=`human`
   Output format
+- `--verbose` — optional · flag
+  Show detailed operation info
+
+#### `empirica finding-resolve`
+
+Resolve/supersede a finding — kept for history, dropped from live retrieval (PREFLIGHT/CHECK relevant_findings). Findings are the fruit that must be pluckable: recency-decay only knows 'old', never 'superseded'. Run to stop a stale/superseded finding resurfacing.
+
+**Arguments:**
+
+- `finding_id` — **required**
+  Finding UUID (full or 8+ char prefix)
+- `--resolution` — **required**
+  Why resolved (e.g. stale, superseded, invalidated)
+- `--superseded-by` — optional
+  Finding ID that replaced it (superseded finding → its replacement)
+- `--output` — optional · type=`choice` · choices={human, json} · default=`json`
+  Output format (default: json)
 - `--verbose` — optional · flag
   Show detailed operation info
 

--- a/empirica/cli/cli_core.py
+++ b/empirica/cli/cli_core.py
@@ -377,6 +377,7 @@ _HELP_CATEGORIES = {
     ],
     "logging": [
         "finding-log",
+        "finding-resolve",
         "unknown-log",
         "unknown-list",
         "unknown-resolve",
@@ -893,6 +894,7 @@ def main(args=None):
             # Finding/unknown/deadend/assumption/decision logging
             "note": handle_note_command,
             "finding-log": handle_finding_log_command,
+            "finding-resolve": handle_finding_resolve_command,
             "unknown-log": handle_unknown_log_command,
             "unknown-resolve": handle_unknown_resolve_command,
             "unknown-list": handle_unknown_list_command,

--- a/empirica/cli/command_handlers/__init__.py
+++ b/empirica/cli/command_handlers/__init__.py
@@ -14,6 +14,7 @@ from .artifact_log_commands import (
     handle_decision_log_command,
     handle_engagement_focus_command,
     handle_finding_log_command,
+    handle_finding_resolve_command,
     handle_mistake_log_command,
     handle_mistake_query_command,
     handle_source_add_command,
@@ -356,6 +357,7 @@ __all__ = [  # noqa: RUF022
     "handle_epistemics_stats_command",
     "handle_epp_activate_command",
     "handle_finding_log_command",
+    "handle_finding_resolve_command",
     "handle_note_command",
     "handle_forgejo_publish_command",
     "handle_goals_activate_command",  # Activate planned goal → in_progress

--- a/empirica/cli/command_handlers/artifact_log_commands.py
+++ b/empirica/cli/command_handlers/artifact_log_commands.py
@@ -1278,6 +1278,53 @@ def handle_unknown_resolve_command(args):
         return 1
 
 
+def handle_finding_resolve_command(args):
+    """Handle finding-resolve command (#307 — the prune primitive).
+
+    Marks a finding resolved/superseded: kept for history, dropped from live
+    retrieval. Findings are the fruit that must be pluckable — recency-decay only
+    knows 'old', never 'superseded'.
+    """
+    try:
+        from empirica.data.session_database import SessionDatabase
+
+        finding_id = getattr(args, "finding_id", None)
+        resolution = getattr(args, "resolution", None)
+        superseded_by = getattr(args, "superseded_by", None)
+        output_format = getattr(args, "output", "json")
+
+        if not finding_id or not resolution:
+            print(json.dumps({"ok": False, "error": "finding_id and --resolution are required"}))
+            return 1
+
+        db = SessionDatabase()
+        updated = db.resolve_finding(finding_id, resolution, superseded_by=superseded_by)
+        db.close()
+
+        if not updated:
+            print(json.dumps({"ok": False, "error": f"no finding matched {finding_id!r} (full id or 8+ char prefix)"}))
+            return 1
+
+        result = {
+            "ok": True,
+            "finding_id": finding_id,
+            "resolution": resolution,
+            "superseded_by": superseded_by,
+            "message": "Finding resolved (kept for history, dropped from live retrieval)",
+        }
+        if output_format == "json":
+            print(json.dumps(result, indent=2))
+        else:
+            print(f"✅ Finding resolved: {finding_id[:8]}... ({resolution})")
+            if superseded_by:
+                print(f"   superseded by: {superseded_by[:8]}...")
+        return 0
+
+    except Exception as e:
+        handle_cli_error(e, "Finding resolve", getattr(args, "verbose", False))
+        return 1
+
+
 def _resolve_project_id_from_context(cursor, session_id, project_id):
     """Auto-derive project_id from session_id or active context."""
     if project_id:

--- a/empirica/cli/command_handlers/graph_commands.py
+++ b/empirica/cli/command_handlers/graph_commands.py
@@ -72,10 +72,11 @@ LOG_ARTIFACTS_SCHEMA = {
 RESOLVE_ARTIFACTS_SCHEMA = {
     "resolutions": [
         {
-            "type": "unknown | assumption | goal",
+            "type": "unknown | assumption | goal | finding",
             "id": "<UUID of the artifact to resolve>",
             "resolution": "<resolution text or status — semantics depend on type>",
             "verified": "<true/false, optional, for assumption→finding>",
+            "superseded_by": "<optional finding UUID that replaced this one — finding type only>",
         },
     ],
 }
@@ -773,6 +774,22 @@ def handle_resolve_artifacts_command(args):  # noqa: C901 — batch dispatcher f
                         resolved_count += 1
                     else:
                         resolution_errors.append(f"Unknown '{artifact_id}' not found")
+
+                elif artifact_type == "finding":
+                    # #307: resolve/supersede a finding — keep for history, drop
+                    # from live retrieval. superseded_by optionally links the replacement.
+                    import time as _tf
+
+                    cursor = db.conn.cursor()
+                    cursor.execute(
+                        "UPDATE project_findings SET is_resolved = 1, resolution = ?, "
+                        "resolved_timestamp = ?, superseded_by = ? WHERE id LIKE ?",
+                        (resolution, _tf.time(), item.get("superseded_by"), f"{artifact_id}%"),
+                    )
+                    if cursor.rowcount > 0:
+                        resolved_count += 1
+                    else:
+                        resolution_errors.append(f"Finding '{artifact_id}' not found")
 
                 elif artifact_type == "assumption":
                     cursor = db.conn.cursor()

--- a/empirica/cli/parsers/checkpoint_parsers.py
+++ b/empirica/cli/parsers/checkpoint_parsers.py
@@ -1100,6 +1100,30 @@ def add_checkpoint_parsers(subparsers):
     )
     unknown_resolve_parser.add_argument("--verbose", action="store_true", help="Show detailed operation info")
 
+    # Finding resolve command (#307 — the prune primitive)
+    finding_resolve_parser = subparsers.add_parser(
+        "finding-resolve",
+        help=(
+            "Resolve/supersede a finding — kept for history, dropped from live "
+            "retrieval (PREFLIGHT/CHECK relevant_findings). Findings are the fruit "
+            "that must be pluckable: recency-decay only knows 'old', never "
+            "'superseded'. Run to stop a stale/superseded finding resurfacing."
+        ),
+    )
+    finding_resolve_parser.add_argument("finding_id", help="Finding UUID (full or 8+ char prefix)")
+    finding_resolve_parser.add_argument(
+        "--resolution", required=True, help="Why resolved (e.g. stale, superseded, invalidated)"
+    )
+    finding_resolve_parser.add_argument(
+        "--superseded-by",
+        dest="superseded_by",
+        help="Finding ID that replaced it (superseded finding → its replacement)",
+    )
+    finding_resolve_parser.add_argument(
+        "--output", choices=["human", "json"], default="json", help="Output format (default: json)"
+    )
+    finding_resolve_parser.add_argument("--verbose", action="store_true", help="Show detailed operation info")
+
     # Unknown list command
     unknown_list_parser = subparsers.add_parser(
         "unknown-list",

--- a/empirica/core/qdrant/memory.py
+++ b/empirica/core/qdrant/memory.py
@@ -203,6 +203,7 @@ def upsert_memory(project_id: str, items: list[dict], qdrant_url: str | None = N
                 pass
 
             payload = {
+                "artifact_id": it.get("id"),
                 "type": it.get("type", "unknown"),
                 "text": text[:500] if text else None,
                 "text_full": text if len(text) <= 500 else None,

--- a/empirica/core/qdrant/pattern_retrieval.py
+++ b/empirica/core/qdrant/pattern_retrieval.py
@@ -372,6 +372,70 @@ def _reconcile_goals_against_sqlite(raw_goals):
         return raw_goals
 
 
+def _reconcile_findings_against_sqlite(raw_findings):
+    """Drop findings resolved/superseded in the local SQLite (#307 retrieval hygiene).
+
+    Qdrant's ``is_resolved`` payload is frozen at embed time, so a finding resolved
+    AFTER it was embedded still reads unresolved in the vector store and keeps
+    resurfacing in PREFLIGHT/CHECK relevant_findings. Read-time reconcile against the
+    authoritative SQLite is the fix (same pattern as goal reconciliation).
+
+    Matches by ``artifact_id`` (present on findings embedded after #307) with a
+    text-prefix fallback for older embeds that predate the id-in-payload change —
+    the Qdrant ``text`` field is truncated to 500 chars, so we compare on that prefix.
+
+    Best-effort: on ANY failure returns ``raw_findings`` unchanged — this runs in the
+    PREFLIGHT/CHECK hot-path and must never break retrieval.
+    """
+    if not raw_findings:
+        return raw_findings
+    try:
+        import sqlite3
+        from pathlib import Path
+
+        from empirica.data.session_database import _resolve_canonical_project_root
+
+        root = _resolve_canonical_project_root()
+        if not root:
+            return raw_findings
+        db_path = Path(root) / ".empirica" / "sessions" / "sessions.db"
+        if not db_path.is_file():
+            return raw_findings
+        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+        try:
+            # Column may be absent on DBs predating migration_057 — bail to raw if so.
+            cols = {r[1] for r in conn.execute("PRAGMA table_info(project_findings)").fetchall()}
+            if "is_resolved" not in cols:
+                return raw_findings
+            cur = conn.execute("SELECT id, finding FROM project_findings WHERE is_resolved = 1")
+            resolved_ids: set[str] = set()
+            resolved_text_prefixes: set[str] = set()
+            for row in cur.fetchall():
+                if row[0]:
+                    resolved_ids.add(row[0])
+                if row[1]:
+                    resolved_text_prefixes.add(row[1][:500])
+        finally:
+            conn.close()
+        if not resolved_ids and not resolved_text_prefixes:
+            return raw_findings
+
+        out = []
+        for f in raw_findings:
+            aid = f.get("artifact_id")
+            if aid and aid in resolved_ids:
+                continue  # drop: resolved by id
+            if not aid:
+                text = f.get("text_full") or f.get("text") or ""
+                if text and text[:500] in resolved_text_prefixes:
+                    continue  # drop: resolved by text-prefix (pre-#307 embed)
+            out.append(f)
+        return out
+    except Exception as e:
+        logger.debug(f"finding reconciliation skipped (keeping raw): {e}")
+        return raw_findings
+
+
 def _enrich_knowledge_graph(
     result,
     project_id,
@@ -969,6 +1033,7 @@ def retrieve_task_patterns(
     findings_raw = _search_memory_by_type(
         project_id, task_context, "finding", limits["findings"] * _RECENCY_OVERFETCH, threshold
     )
+    findings_raw = _reconcile_findings_against_sqlite(findings_raw)  # #307: drop resolved/superseded
     findings_ranked = _apply_recency_rerank(
         findings_raw, limits["findings"], modulator_key="impact", ts_key="timestamp"
     )

--- a/empirica/data/migrations/migrations.py
+++ b/empirica/data/migrations/migrations.py
@@ -1496,6 +1496,11 @@ ALL_MIGRATIONS: list[tuple[str, str, Callable]] = [
         "Add archived/archived_at columns to goals — goal-lifecycle archive-after-X (mirrors source-archive). A completed goal older than N days can be archived (hidden from the completed list unless --include-archived) so the completed view doesn't grow unbounded; goals-reopen un-archives. Indexed. Additive + idempotent via add_column_if_missing.",
         lambda cursor: migration_056_goals_archived(cursor),
     ),
+    (
+        "057_finding_resolution",
+        "Add resolution state (is_resolved, resolution, resolved_timestamp, superseded_by) to project_findings — the finding-resolve/prune primitive (#307). Findings were the only artifact type with no resolve verb, so stale/superseded findings could only passively decay and kept resurfacing high in PREFLIGHT/CHECK. A resolved finding is kept for history but dropped from live retrieval (read-time SQLite reconcile), mirroring project_unknowns.is_resolved. superseded_by links a superseded finding → its replacement. Additive + idempotent via add_column_if_missing.",
+        lambda cursor: migration_057_finding_resolution(cursor),
+    ),
 ]
 
 
@@ -2089,6 +2094,29 @@ def migration_056_goals_archived(cursor: sqlite3.Cursor):
     add_column_if_missing(cursor, "goals", "archived_at", "REAL", "NULL")
     cursor.execute("CREATE INDEX IF NOT EXISTS idx_goals_archived ON goals(archived)")
     logger.info("✅ Migration 056 complete: archived/archived_at columns added to goals")
+
+
+def migration_057_finding_resolution(cursor: sqlite3.Cursor):
+    """Add resolution state to project_findings — the finding-resolve/prune
+    primitive (#307).
+
+    Findings were the only artifact type with no resolve verb: they could only
+    passively decay, so stale/superseded findings kept resurfacing high in
+    PREFLIGHT/CHECK's relevant_findings (recency-decay can't detect *supersession*,
+    only age). A resolved finding is kept for history but dropped from live
+    retrieval (read-time SQLite reconcile), mirroring project_unknowns.is_resolved.
+    ``superseded_by`` links the resolved finding to the finding that replaced it.
+
+    Fresh DBs get these columns inline from projects_schema.py; this backfills
+    long-lived DBs (the migration_042 pattern). Nullable, additive, idempotent
+    via add_column_if_missing; indexed for the resolved-filter.
+    """
+    add_column_if_missing(cursor, "project_findings", "is_resolved", "BOOLEAN", "0")
+    add_column_if_missing(cursor, "project_findings", "resolution", "TEXT", "NULL")
+    add_column_if_missing(cursor, "project_findings", "resolved_timestamp", "REAL", "NULL")
+    add_column_if_missing(cursor, "project_findings", "superseded_by", "TEXT", "NULL")
+    cursor.execute("CREATE INDEX IF NOT EXISTS idx_project_findings_resolved ON project_findings(is_resolved)")
+    logger.info("✅ Migration 057 complete: resolution state added to project_findings")
 
 
 def migration_051_goals_engagement_id(cursor: sqlite3.Cursor):

--- a/empirica/data/repositories/breadcrumbs.py
+++ b/empirica/data/repositories/breadcrumbs.py
@@ -371,6 +371,35 @@ class BreadcrumbRepository(BaseRepository):
         self.commit()
         logger.info(f"✅ Unknown resolved: {unknown_id[:8]}...")
 
+    def resolve_finding(self, finding_id: str, resolution: str, superseded_by: str | None = None) -> bool:
+        """Mark a finding as resolved/superseded — kept for history, dropped from
+        live retrieval (#307, the prune primitive). Mirrors resolve_unknown.
+
+        Recency-decay only knows a finding is *old*, never that it's *superseded*;
+        this is the explicit lever. Returns True if a row was updated.
+
+        Args:
+            finding_id: Full or partial UUID (minimum 8 chars)
+            resolution: Why it's resolved/superseded (e.g. 'stale', 'superseded', 'invalidated')
+            superseded_by: Optional finding ID that replaced it (fruit → its replacement)
+        """
+        where = "id LIKE ?" if len(finding_id) < 36 else "id = ?"
+        match = f"{finding_id}%" if len(finding_id) < 36 else finding_id
+        cur = self._execute(
+            f"""
+            UPDATE project_findings
+            SET is_resolved = TRUE, resolution = ?, resolved_timestamp = ?, superseded_by = ?
+            WHERE {where}
+            """,
+            (resolution, time.time(), superseded_by, match),
+        )
+        self.commit()
+        updated = bool(getattr(cur, "rowcount", 0))
+        logger.info(
+            f"{'✅' if updated else '⚠️'} Finding resolve {finding_id[:8]}...: {'updated' if updated else 'no match'}"
+        )
+        return updated
+
     def log_dead_end(
         self,
         project_id: str,

--- a/empirica/data/schema/projects_schema.py
+++ b/empirica/data/schema/projects_schema.py
@@ -92,6 +92,10 @@ SCHEMAS = [
                     subject TEXT,
                     impact REAL DEFAULT 0.5,
                     transaction_id TEXT,
+                    is_resolved BOOLEAN DEFAULT FALSE,
+                    resolution TEXT,
+                    resolved_timestamp REAL,
+                    superseded_by TEXT,
 
                     FOREIGN KEY (project_id) REFERENCES projects(id),
                     FOREIGN KEY (session_id) REFERENCES sessions(session_id),

--- a/empirica/data/session_database.py
+++ b/empirica/data/session_database.py
@@ -2659,6 +2659,10 @@ class SessionDatabase:
         """Mark an unknown as resolved (delegates to BreadcrumbRepository)"""
         return self.breadcrumbs.resolve_unknown(unknown_id, resolved_by, resolution_finding_id=resolution_finding_id)
 
+    def resolve_finding(self, finding_id: str, resolution: str, superseded_by: str | None = None) -> bool:
+        """Mark a finding as resolved/superseded (#307; delegates to BreadcrumbRepository)"""
+        return self.breadcrumbs.resolve_finding(finding_id, resolution, superseded_by=superseded_by)
+
     def log_dead_end(
         self,
         project_id: str,

--- a/empirica/plugins/claude-code-integration/hooks/post-compact.py
+++ b/empirica/plugins/claude-code-integration/hooks/post-compact.py
@@ -834,12 +834,20 @@ def _load_dynamic_context(session_id: str, ai_id: str, pre_snapshot: dict) -> di
                 context["pending_subtasks"].append(subtask)
             goal["subtasks"] = subtasks
 
-        # 2. Recent findings (broader retrieval — epistemic_summarizer handles ranking)
+        # 2. Recent findings (broader retrieval — epistemic_summarizer handles ranking).
+        #    Drop resolved/superseded findings (#307) so they don't re-inject into
+        #    EPISTEMIC FOCUS — mirrors the unknowns is_resolved filter below. The
+        #    is_resolved column is absent on very old DBs pre-migration_057, so guard
+        #    the WHERE with a schema check to stay backward-compatible.
+        _findings_has_resolved = any(
+            r[1] == "is_resolved" for r in cursor.execute("PRAGMA table_info(project_findings)").fetchall()
+        )
+        _resolved_clause = " AND (is_resolved IS NULL OR is_resolved = 0)" if _findings_has_resolved else ""
         cursor.execute(
-            """
+            f"""
             SELECT finding, impact, created_timestamp
             FROM project_findings
-            WHERE project_id = ?
+            WHERE project_id = ?{_resolved_clause}
             ORDER BY created_timestamp DESC LIMIT 10
         """,
             (project_id,),

--- a/tests/test_finding_resolve.py
+++ b/tests/test_finding_resolve.py
@@ -26,7 +26,9 @@ def fresh_db(tmp_path):
 
 def _row(db, fid):
     cur = db.conn.cursor()
-    cur.execute("SELECT is_resolved, resolution, resolved_timestamp, superseded_by FROM project_findings WHERE id = ?", (fid,))
+    cur.execute(
+        "SELECT is_resolved, resolution, resolved_timestamp, superseded_by FROM project_findings WHERE id = ?", (fid,)
+    )
     return cur.fetchone()
 
 

--- a/tests/test_finding_resolve.py
+++ b/tests/test_finding_resolve.py
@@ -1,0 +1,65 @@
+"""Test the finding-resolve primitive (#307) at the repository layer.
+
+``resolve_finding`` marks a finding resolved (kept for history, dropped from
+live retrieval) — the resolve verb findings previously lacked. Mirrors
+``resolve_unknown``. Prefix-matching lets a caller pass an 8+ char id fragment.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from empirica.data.session_database import SessionDatabase
+
+PROJECT_ID = str(uuid.uuid4())
+SESSION_ID = str(uuid.uuid4())
+
+
+@pytest.fixture
+def fresh_db(tmp_path):
+    db = SessionDatabase(db_path=str(tmp_path / "resolve.db"))
+    yield db
+    db.close()
+
+
+def _row(db, fid):
+    cur = db.conn.cursor()
+    cur.execute("SELECT is_resolved, resolution, resolved_timestamp, superseded_by FROM project_findings WHERE id = ?", (fid,))
+    return cur.fetchone()
+
+
+def test_resolve_finding_flips_flag_and_stores_resolution(fresh_db):
+    fid = fresh_db.log_finding(PROJECT_ID, SESSION_ID, "a stale finding")
+    assert fresh_db.resolve_finding(fid, "stale") is True
+    is_resolved, resolution, ts, superseded = _row(fresh_db, fid)
+    assert is_resolved == 1
+    assert resolution == "stale"
+    assert ts is not None  # resolved_timestamp stamped
+    assert superseded is None
+
+
+def test_resolve_finding_records_superseded_by(fresh_db):
+    old = fresh_db.log_finding(PROJECT_ID, SESSION_ID, "old belief")
+    new = fresh_db.log_finding(PROJECT_ID, SESSION_ID, "corrected belief")
+    assert fresh_db.resolve_finding(old, "superseded", superseded_by=new) is True
+    assert _row(fresh_db, old)[3] == new  # superseded_by links to the replacement
+
+
+def test_resolve_finding_prefix_match(fresh_db):
+    fid = fresh_db.log_finding(PROJECT_ID, SESSION_ID, "prefix-resolvable finding")
+    assert fresh_db.resolve_finding(fid[:8], "stale") is True  # 8-char prefix resolves
+    assert _row(fresh_db, fid)[0] == 1
+
+
+def test_resolve_finding_no_match_returns_false(fresh_db):
+    assert fresh_db.resolve_finding("does-not-exist-00000000", "stale") is False
+
+
+def test_resolve_finding_leaves_others_untouched(fresh_db):
+    keep = fresh_db.log_finding(PROJECT_ID, SESSION_ID, "keep me live")
+    drop = fresh_db.log_finding(PROJECT_ID, SESSION_ID, "resolve me")
+    fresh_db.resolve_finding(drop, "stale")
+    assert _row(fresh_db, keep)[0] in (0, None)  # untouched finding stays unresolved
+    assert _row(fresh_db, drop)[0] == 1

--- a/tests/test_migration_057_finding_resolution.py
+++ b/tests/test_migration_057_finding_resolution.py
@@ -1,0 +1,63 @@
+"""Test migration 057 — resolution state on project_findings (#307).
+
+Findings were the only artifact type with no resolve verb; this adds
+is_resolved/resolution/resolved_timestamp/superseded_by so a stale or superseded
+finding can be dropped from live retrieval while kept for history. Additive,
+nullable, idempotent — mirrors project_unknowns.is_resolved.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+from empirica.data.migrations.migrations import migration_057_finding_resolution
+
+
+def _findings_db() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE project_findings (id TEXT PRIMARY KEY, finding TEXT NOT NULL)")
+    return conn
+
+
+def _cols(conn: sqlite3.Connection) -> set[str]:
+    return {r[1] for r in conn.execute("PRAGMA table_info(project_findings)").fetchall()}
+
+
+def test_adds_resolution_columns():
+    conn = _findings_db()
+    migration_057_finding_resolution(conn.cursor())
+    conn.commit()
+    cols = _cols(conn)
+    assert {"is_resolved", "resolution", "resolved_timestamp", "superseded_by"} <= cols
+
+
+def test_columns_are_nullable():
+    conn = _findings_db()
+    migration_057_finding_resolution(conn.cursor())
+    conn.commit()
+    conn.execute("INSERT INTO project_findings (id, finding) VALUES ('f1', 'x')")
+    row = conn.execute(
+        "SELECT resolution, resolved_timestamp, superseded_by FROM project_findings WHERE id='f1'"
+    ).fetchone()
+    assert row == (None, None, None)
+
+
+def test_creates_resolved_index():
+    conn = _findings_db()
+    migration_057_finding_resolution(conn.cursor())
+    conn.commit()
+    indexes = {r[1] for r in conn.execute("PRAGMA index_list(project_findings)").fetchall()}
+    assert "idx_project_findings_resolved" in indexes
+
+
+def test_idempotent():
+    conn = _findings_db()
+    cur = conn.cursor()
+    migration_057_finding_resolution(cur)
+    migration_057_finding_resolution(cur)  # second run must not raise
+    conn.commit()
+    assert "is_resolved" in _cols(conn)
+    conn.execute(
+        "INSERT INTO project_findings (id, finding, is_resolved, resolution) VALUES ('f2', 'y', 1, 'stale')"
+    )
+    assert conn.execute("SELECT is_resolved FROM project_findings WHERE id='f2'").fetchone()[0] == 1

--- a/tests/test_migration_057_finding_resolution.py
+++ b/tests/test_migration_057_finding_resolution.py
@@ -57,7 +57,5 @@ def test_idempotent():
     migration_057_finding_resolution(cur)  # second run must not raise
     conn.commit()
     assert "is_resolved" in _cols(conn)
-    conn.execute(
-        "INSERT INTO project_findings (id, finding, is_resolved, resolution) VALUES ('f2', 'y', 1, 'stale')"
-    )
+    conn.execute("INSERT INTO project_findings (id, finding, is_resolved, resolution) VALUES ('f2', 'y', 1, 'stale')")
     assert conn.execute("SELECT is_resolved FROM project_findings WHERE id='f2'").fetchone()[0] == 1

--- a/tests/test_retrieval_hygiene.py
+++ b/tests/test_retrieval_hygiene.py
@@ -12,6 +12,7 @@ import sqlite3
 
 from empirica.core.qdrant.pattern_retrieval import (
     _apply_goal_reconciliation,
+    _reconcile_findings_against_sqlite,
     _reconcile_goals_against_sqlite,
 )
 
@@ -102,3 +103,83 @@ def test_reconcile_fail_open_when_db_absent(tmp_path, monkeypatch):
 
 def test_reconcile_empty_is_noop():
     assert _reconcile_goals_against_sqlite([]) == []
+
+
+# ── finding reconciliation (#307) ─────────────────────────────────────────────
+
+
+def _make_findings_db(tmp_path, rows):
+    """Build a temp project sessions.db with a minimal project_findings table.
+
+    ``rows`` is a list of (id, finding, is_resolved) tuples.
+    """
+    root = tmp_path / "proj"
+    db_dir = root / ".empirica" / "sessions"
+    db_dir.mkdir(parents=True)
+    conn = sqlite3.connect(str(db_dir / "sessions.db"))
+    conn.execute("CREATE TABLE project_findings (id TEXT PRIMARY KEY, finding TEXT, is_resolved INTEGER)")
+    conn.executemany("INSERT INTO project_findings VALUES (?,?,?)", rows)
+    conn.commit()
+    conn.close()
+    return root
+
+
+def test_finding_reconcile_drops_resolved_by_id(tmp_path, monkeypatch):
+    root = _make_findings_db(tmp_path, [("r1", "resolved body", 1), ("l1", "live body", 0)])
+    import empirica.data.session_database as sdb
+
+    monkeypatch.setattr(sdb, "_resolve_canonical_project_root", lambda: str(root))
+    raw = [{"artifact_id": "r1", "text": "resolved body"}, {"artifact_id": "l1", "text": "live body"}]
+    out = _reconcile_findings_against_sqlite(raw)
+    assert [f["artifact_id"] for f in out] == ["l1"]  # resolved dropped by id
+
+
+def test_finding_reconcile_text_prefix_fallback(tmp_path, monkeypatch):
+    # A finding embedded before #307 has no artifact_id in payload → match on text prefix.
+    root = _make_findings_db(tmp_path, [("r1", "resolved body", 1)])
+    import empirica.data.session_database as sdb
+
+    monkeypatch.setattr(sdb, "_resolve_canonical_project_root", lambda: str(root))
+    raw = [{"text": "resolved body"}, {"text": "some unrelated live finding"}]
+    out = _reconcile_findings_against_sqlite(raw)
+    assert [f["text"] for f in out] == ["some unrelated live finding"]  # resolved dropped by text prefix
+
+
+def test_finding_reconcile_id_wins_over_text(tmp_path, monkeypatch):
+    # A finding WITH an id that isn't resolved is kept even if its text collides with
+    # a resolved finding's text — id is authoritative, text-fallback only when id absent.
+    root = _make_findings_db(tmp_path, [("r1", "shared body", 1)])
+    import empirica.data.session_database as sdb
+
+    monkeypatch.setattr(sdb, "_resolve_canonical_project_root", lambda: str(root))
+    raw = [{"artifact_id": "l1", "text": "shared body"}]  # different id, not resolved
+    out = _reconcile_findings_against_sqlite(raw)
+    assert [f["artifact_id"] for f in out] == ["l1"]  # kept: id not in resolved set
+
+
+def test_finding_reconcile_fail_open_when_db_absent(tmp_path, monkeypatch):
+    import empirica.data.session_database as sdb
+
+    monkeypatch.setattr(sdb, "_resolve_canonical_project_root", lambda: str(tmp_path / "nope"))
+    raw = [{"artifact_id": "f1", "text": "x"}]
+    assert _reconcile_findings_against_sqlite(raw) == raw  # unchanged, never raises
+
+
+def test_finding_reconcile_fail_open_when_column_absent(tmp_path, monkeypatch):
+    # A DB predating migration_057 has no is_resolved column → keep raw, never raise.
+    root = tmp_path / "proj"
+    db_dir = root / ".empirica" / "sessions"
+    db_dir.mkdir(parents=True)
+    conn = sqlite3.connect(str(db_dir / "sessions.db"))
+    conn.execute("CREATE TABLE project_findings (id TEXT PRIMARY KEY, finding TEXT)")  # no is_resolved
+    conn.commit()
+    conn.close()
+    import empirica.data.session_database as sdb
+
+    monkeypatch.setattr(sdb, "_resolve_canonical_project_root", lambda: str(root))
+    raw = [{"artifact_id": "f1", "text": "x"}]
+    assert _reconcile_findings_against_sqlite(raw) == raw
+
+
+def test_finding_reconcile_empty_is_noop():
+    assert _reconcile_findings_against_sqlite([]) == []


### PR DESCRIPTION
Closes #307.

## Problem

Findings were the **only** artifact type with no resolve verb. Unknowns, assumptions, and goals all have one; a stale or superseded finding could only *passively decay*. But recency-decay detects **age, not supersession** — a two-month-old finding that's still semantically strong keeps resurfacing high in PREFLIGHT/CHECK, and a superseded one never sinks fast enough. Findings are the fruit that must be pluckable.

## What this does — 3 slices

**Slice 1 — the verb + storage** (`7fa7e8d8c`)
- `migration_057`: `is_resolved` / `resolution` / `resolved_timestamp` / `superseded_by` on `project_findings` (+ index). Additive, nullable, idempotent. Fresh DBs get the columns inline from `projects_schema.py`; migration backfills long-lived DBs.
- `breadcrumbs.resolve_finding()` + `session_database` delegate.
- `empirica finding-resolve <id> --resolution <why> [--superseded-by <id>]`.
- `resolve-artifacts` batch: `type="finding"` branch (+ schema enum/field).

**Slice 2 — suppression from both injection surfaces** (`b521c36dc`)
- **Qdrant PREFLIGHT/CHECK** (`relevant_findings`): `_reconcile_findings_against_sqlite` drops resolved findings at read time. Qdrant's `is_resolved` payload is frozen at embed time, so a finding resolved *after* embedding still reads unresolved there — read-time reconcile against authoritative SQLite is the fix (same pattern as goal reconciliation). Matches by `artifact_id`, text-prefix fallback for pre-#307 embeds. `memory.py` now carries `artifact_id` on the batch-embed payload too.
- **Breadcrumbs post-compact `EPISTEMIC FOCUS`**: the `recent_findings` query had no `is_resolved` filter (the sibling unknowns query already did) — added one, schema-guarded for DBs predating migration 057.
- Both paths best-effort: any failure returns the raw set, never breaks the hot-path.

**Slice 3 — tests + docs** (`354966927`)
- Migration test (columns/nullability/index/idempotency), repo-method test (flag flip, superseded_by, prefix match, no-match, isolation), reconcile tests (drop-by-id, text-prefix fallback, id-wins-over-text, fail-open ×2, empty noop).
- CHANGELOG `[Unreleased]`; regenerated `CLI_COMMANDS_UNIFIED.md`.

## Verification
- New + adjacent suite green: `43 passed`.
- Manual e2e: single verb, batch resolve-artifacts, and both reconcile fallbacks confirmed against the live DB.
- `ruff check` / `ruff format --check` / `pyright` clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qe4uGwYbVtE5CFZdsBwata