### PR TITLE
fix(sentinel): pipe-receiver trust parity + close mid-pipe mutation hole

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Sentinel no longer over-gates read-only pipe chains — receiver trust
+  brought to parity with standalone trust.** `is_safe_pipe_chain` kept two
+  drifted trust lists: `SAFE_BASH_PREFIXES` (~95 read-only tools trusted as
+  standalone commands) vs `SAFE_PIPE_TARGETS` (~20 trusted as pipe receivers).
+  A tool trusted alone became *untrusted the instant it received a pipe*, so the
+  canonical read-only DB-inspection idiom `sqlite3 db 'SELECT…' | column -t`
+  (and `… | nl`, `… | bat`, `… | gron`, `… | tac`) got false-gated as praxic —
+  the flag-robust sqlite fix (#304) made the *source* noetic but the formatter
+  on the tail re-gated the whole chain. Every pipe segment now runs through the
+  same read-only classifier used for standalone commands (`_matches_safe_prefix`,
+  which applies `_has_dangerous_tool_flags`). This brings receiver trust to
+  parity **and** closes a latent hole: a mutating/exec flag mid-pipe
+  (`| sort -o out`, `| yq -i`, `| awk 'system()'`, `| fd -x`) is now rejected in
+  ANY position, and a redirect on a receiver (`| column > out`) is caught at the
+  segment level too. Executor-ish legacy receivers (`python3 -c`, `xargs`) stay
+  receiver-only — never granted to the pipe *source*, so `python3 -c '…' | cat`
+  remains praxic.
+
 ## [1.12.17] — 2026-07-11
 
 ### Fixed

--- a/empirica/plugins/claude-code-integration/hooks/sentinel-gate.py
+++ b/empirica/plugins/claude-code-integration/hooks/sentinel-gate.py
@@ -2556,6 +2556,46 @@ def _classify_scp(command: str) -> bool:
     return not (":" in dest and not dest.startswith("/"))
 
 
+def _is_safe_pipe_segment(segment_clean: str, *, is_first: bool) -> bool:
+    """Classify one segment of a pipe chain as read-only/noetic.
+
+    A segment is safe if it's a read-only empirica command, a sqlite READ
+    (first segment only — a mid-pipe `sqlite3` receiving stdin is unusual and
+    the read-classifier keys off the query arg), a legacy SAFE_PIPE_TARGET
+    (keeps executor-ish receivers the chain rules already trusted: python3 -c,
+    xargs echo, tee /dev/stderr, base64), OR any standalone read-only tool the
+    Sentinel already trusts as a first-class command (`_matches_safe_prefix`).
+
+    Reusing `_matches_safe_prefix` is the key move: it applies
+    `_has_dangerous_tool_flags`, so a mutating/exec flag on an otherwise-inert
+    tool (`| sort -o out`, `| yq -i`, `| awk 'system()'`, `| fd -x`) is REJECTED
+    even here — closing the mid-pipe mutation hole the old raw prefix/target
+    matching left open — while bringing pipe-receiver trust to parity with the
+    ~95 read-only tools trusted standalone (the `| column`, `| nl`, `| bat`,
+    `| gron`, `| tac` over-gating this fixes).
+    """
+    # A file redirect on any segment is a praxic side effect (`| column > out`),
+    # even though the top-level classifier also guards it before we're called.
+    if _has_dangerous_redirects(segment_clean):
+        return False
+    # A mutating/exec flag on any segment is praxic regardless of position.
+    if _has_dangerous_tool_flags(segment_clean):
+        return False
+    if is_first and segment_clean.startswith("sqlite3 ") and is_safe_sqlite_command(segment_clean):
+        return True
+    if is_safe_empirica_command(segment_clean):
+        return True
+    if _matches_safe_prefix(segment_clean):
+        return True
+    # Legacy explicit pipe-receivers (executor-ish but historically trusted for
+    # JSON parsing / fan-out: python3 -c, xargs echo, tee /dev/stderr, base64).
+    # RECEIVER-ONLY — never granted to the first segment, where they'd be an
+    # arbitrary-exec SOURCE (`python3 -c '…' | cat` must stay praxic).
+    if is_first:
+        return False
+    return any(segment_clean.startswith(target) for target in SAFE_PIPE_TARGETS)
+
+
 def is_safe_pipe_chain(command: str) -> bool:
     """
     Check if a piped command chain is safe (all segments are read-only).
@@ -2563,60 +2603,26 @@ def is_safe_pipe_chain(command: str) -> bool:
     Allows: grep pattern file | head -20 | wc -l
     Allows: echo '...' | empirica preflight-submit -  (empirica CLI)
     Allows: grep "A\\|B\\|C" file | head      (quoted | inside regex)
-    Blocks: grep pattern | xargs rm, cat file | bash
+    Allows: sqlite3 db 'SELECT…' | column -t   (read-only receiver at parity)
+    Blocks: grep pattern | xargs rm, cat file | bash, anything | sort -o out
 
     Splits on `|` *outside* quoted regions — a `|` inside a quoted regex
-    alternation is data, not a shell pipe.
+    alternation is data, not a shell pipe. EVERY segment is validated by the
+    same read-only classifier used for standalone commands, so a read-only tool
+    trusted alone is trusted as a pipe receiver too (parity), and a mutating
+    flag is rejected in any position.
     """
     segments = [s.strip() for s in _split_outside_quotes(command, "|")]
-
     if not segments:
         return False
 
-    # First segment must be a safe command
-    first_cmd = segments[0]
-    first_is_safe = False
-
-    # Check sqlite3 commands first
-    if first_cmd.startswith("sqlite3 ") and is_safe_sqlite_command(first_cmd):
-        first_is_safe = True
-
-    # Check empirica CLI whitelist — Tier 1 commands (loop status, goals-list,
-    # etc.) routinely produce JSON that gets piped to jq. The trailing-segment
-    # rule below already accepts is_safe_empirica_command; matching it for the
-    # first segment removes the asymmetry that blocked cron-body shell idioms.
-    if not first_is_safe and is_safe_empirica_command(first_cmd):
-        first_is_safe = True
-
-    # Check standard safe prefixes
-    if not first_is_safe:
-        for prefix in SAFE_BASH_PREFIXES:
-            if first_cmd.startswith(prefix) or (prefix.endswith(" ") and first_cmd == prefix.rstrip()):
-                first_is_safe = True
-                break
-
-    if not first_is_safe:
-        return False
-
-    # All subsequent segments must start with safe pipe targets OR be safe empirica commands
-    for segment in segments[1:]:
-        segment = segment.strip()
-        # Strip heredoc suffix for matching (e.g., "empirica preflight-submit - << 'EOF'")
-        segment_clean = segment.split("<<")[0].strip() if "<<" in segment else segment
-        segment_safe = False
-
-        # Check empirica CLI whitelist (tiered)
-        if is_safe_empirica_command(segment_clean):
-            segment_safe = True
-
-        # Check standard safe pipe targets
-        if not segment_safe:
-            for target in SAFE_PIPE_TARGETS:
-                if segment.startswith(target):
-                    segment_safe = True
-                    break
-
-        if not segment_safe:
+    for idx, segment in enumerate(segments):
+        # Strip heredoc suffix for matching (e.g., "… << 'EOF'") — the body is
+        # validated separately by the chain/heredoc handling upstream.
+        segment_clean = segment.split("<<")[0].strip() if "<<" in segment else segment.strip()
+        if not segment_clean:
+            return False
+        if not _is_safe_pipe_segment(segment_clean, is_first=(idx == 0)):
             return False
 
     return True

--- a/tests/test_sentinel_shell_constructs.py
+++ b/tests/test_sentinel_shell_constructs.py
@@ -590,3 +590,57 @@ class TestNoeticCompoundAndBootstrap:
         # The security invariant behind the fix: segment-classification means a
         # safe leading `cd` can't launder an unsafe tail past the gate.
         assert gate.is_safe_bash_command({"command": cmd}) is False
+
+
+# ─── pipe-target parity (read-only receivers) ───────────────────────────────
+
+
+class TestPipeTargetParity:
+    """A read-only tool the Sentinel trusts as a standalone command must be
+    trusted as a pipe RECEIVER too. Pre-fix, SAFE_PIPE_TARGETS (~20 entries)
+    was a fraction of SAFE_BASH_PREFIXES (~95), so `sqlite3 db 'SELECT…' |
+    column -t` and friends got false-gated the moment a read-only formatter sat
+    on the tail. The unified classifier reuses _matches_safe_prefix (which
+    applies _has_dangerous_tool_flags), bringing receiver trust to parity while
+    keeping mutation flags praxic in ANY pipe position.
+    """
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "sqlite3 /x/.empirica/sessions.db \"SELECT * FROM goals\" | column -t -s '|'",
+            "grep foo file.py | nl",
+            "cat data.json | gron",
+            "git log --oneline | tac",
+            "rg pattern src/ | bat",
+            "cat f.bin | xxd | head",
+            "git log | head | column -t",  # 3-stage read chain
+            "cat f | wc -l",  # regression: previously-safe target
+            "echo '{}' | jq .",  # regression: previously-safe target
+        ],
+    )
+    def test_read_only_receivers_are_noetic(self, gate, cmd):
+        assert gate.is_safe_pipe_chain(cmd) is True
+        assert gate.is_safe_bash_command({"command": cmd}) is True
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "find . -delete | cat",  # mutating SOURCE
+            "cat f | sort -o out.txt",  # -o write flag mid-pipe (hole closed)
+            "cat f | yq -i '.x=1'",  # in-place edit mid-pipe
+            "cat f | awk 'system(\"rm x\")'",  # awk exec mid-pipe
+            "python3 -c 'import os; os.system(\"x\")' | cat",  # exec SOURCE stays gated
+            "grep x file | xargs rm",  # destructive fan-out
+            "cat f | sh",  # shell executor
+            "grep x file | column > out.txt",  # redirect on receiver
+        ],
+    )
+    def test_mutating_or_exec_segments_stay_gated(self, gate, cmd):
+        assert gate.is_safe_pipe_chain(cmd) is False
+
+    def test_executor_receiver_stays_receiver_only(self, gate):
+        # python3 -c is a legacy SAFE_PIPE_TARGET — trusted as a RECEIVER of
+        # already-vetted data, but never as a pipe SOURCE (arbitrary exec).
+        assert gate.is_safe_pipe_chain("cat f.json | python3 -c 'import sys; print(len(sys.stdin.read()))'") is True
+        assert gate.is_safe_pipe_chain("python3 -c 'print(1)' | cat") is False


### PR DESCRIPTION
Addresses the over-gating goal (c7e9d0c6). Follows up #304 (flag-robust sqlite).

## Problem

`is_safe_pipe_chain` maintained **two** trust lists that had drifted apart:

| List | Trusts | Size |
|---|---|---|
| `SAFE_BASH_PREFIXES` | standalone read-only commands | ~95 (`sqlite3`-read, `fd`, `column`, `nl`, `bat`, `gron`, `tac`, `xxd`, `yq`, …) |
| `SAFE_PIPE_TARGETS` | pipe receivers | ~20 (`head`, `wc`, `grep`, `jq`, `cut`, `sort`, …) |

A tool trusted as a standalone command became **untrusted the instant it received a pipe**. So the canonical read-only DB-inspection idiom `sqlite3 db 'SELECT…' | column -t -s '|'` got gated praxic — #304 made the *source* noetic, but the formatter on the tail re-gated the whole chain. Same for `… | nl`, `… | bat`, `… | gron`, `… | tac`.

## Fix

Every pipe segment now runs through the **same** read-only classifier used for standalone commands. Extracted `_is_safe_pipe_segment(segment, is_first=…)`:

- read-only empirica command, OR sqlite READ (first segment), OR `_matches_safe_prefix` (the ~95-tool list, which applies `_has_dangerous_tool_flags`), OR — **for non-first segments only** — a legacy `SAFE_PIPE_TARGET`.

### What this fixes
- **Parity**: `| column`, `| nl`, `| bat`, `| gron`, `| tac`, `| xxd`, … are noetic as receivers, matching their standalone trust.
- **Closes a latent mutation hole**: the old raw `startswith` match against `SAFE_PIPE_TARGETS`/`SAFE_BASH_PREFIXES` skipped `_has_dangerous_tool_flags`, so `… | sort -o out`, `… | yq -i`, `… | awk 'system()'`, `… | fd -x` slipped through. Now rejected in **any** pipe position.
- **Redirect on a receiver** (`| column > out`) rejected at the segment level too (defense-in-depth; top-level already guards it).

### What stays praxic (the slippery-slope guard David flagged)
- File redirects, `python3 -c`/`node -e` as pipe **sources**, every `-i`/`-o`/`-x`/`--rewrite` mutation flag, sqlite writes, `| xargs rm`, `| sh`.
- Executor-ish legacy receivers (`python3 -c`, `xargs`) stay **receiver-only** — `python3 -c '…' | cat` remains gated.

## Verification
- `TestPipeTargetParity`: 9 read-only receiver chains noetic, 8 mutating/exec/redirect chains gated, executor-receiver-only invariant.
- Full sentinel suite green: **305 passed**, no regression. `ruff` / `pyright` clean on the classifier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qe4uGwYbVtE5CFZdsBwata