### PR TITLE
feat(skills): /epistemic-gardening — the graph-hygiene pass

### DIFF
--- a/docs/architecture/ARTIFACT_HYGIENE.md
+++ b/docs/architecture/ARTIFACT_HYGIENE.md
@@ -1,10 +1,13 @@
 # Artifact Hygiene — the cross-transaction, per-practice sweep
 
-> **Status: design spec.** Companion to [GATED_ARTIFACT_GRAPH.md](GATED_ARTIFACT_GRAPH.md).
-> That map governs *within-transaction* connectivity at POSTFLIGHT; this one
-> governs the *whole-practice, cross-transaction* upkeep POSTFLIGHT structurally
-> can't see. The primitives already exist — this is an **orchestration + policy**
-> problem, not a build-from-scratch.
+> **Status: design spec + operational skill.** Companion to
+> [GATED_ARTIFACT_GRAPH.md](GATED_ARTIFACT_GRAPH.md). That map governs
+> *within-transaction* connectivity at POSTFLIGHT; this one governs the
+> *whole-practice, cross-transaction* upkeep POSTFLIGHT structurally can't see. The
+> primitives already exist — this is an **orchestration + policy** problem, not a
+> build-from-scratch. The orchestration now ships as the **`/epistemic-gardening`
+> skill** — this doc is the *policy*, the skill is the *procedure* (the six-phase
+> pass + the cross-practice mesh propagation).
 
 ## 1. The problem
 
@@ -17,7 +20,9 @@ observe:
 - **Sources** whose URLs 404 or moved (link-rot), or whose *content* drifted.
 - **Edges** — orphan artifacts (0 edges), or artifacts wired to a weaker edge
   than the graph now warrants.
-- **Noise** — test-run artifacts, exact duplicates, superseded findings.
+- **Noise** — test-run artifacts, exact duplicates. (Superseded findings are
+  *resolved*, not deleted — `finding-resolve --superseded-by` keeps the trail;
+  delete is reserved for true noise with no epistemic value.)
 
 POSTFLIGHT already does the *within-transaction* half — weave-gate (orphans /
 connectivity), breadth, edge-density, sources-discipline, deferred-proposals.
@@ -29,7 +34,8 @@ cross-goal dedup, long-open-unknown triage, orphan re-wiring across transactions
 | Primitive | Does |
 |---|---|
 | `empirica goals-get-stale` | detect stale goals (dry-run detection) |
-| `empirica resolve-artifacts -` | batch-resolve unknowns / assumptions / goals |
+| `empirica finding-resolve` | resolve/supersede a **finding** (kept for history, dropped from live retrieval via read-time reconcile — #307). Findings were previously the one artifact type with no resolve verb; superseded findings are now *resolved*, not *deleted*. |
+| `empirica resolve-artifacts -` | batch-resolve unknowns / assumptions / goals / **findings** |
 | `empirica delete-artifacts -` | batch delete — **dry-run default + receipt logged as a decision for audit** |
 | `empirica log-artifacts -` | node + edge writes (edge re-wiring) |
 | `empirica sources-reconcile` | source-identity dedup vs the catalogue (`--apply`, dry-run default) |

--- a/empirica/plugins/claude-code-integration/skills/epistemic-gardening/SKILL.md
+++ b/empirica/plugins/claude-code-integration/skills/epistemic-gardening/SKILL.md
@@ -1,0 +1,283 @@
+---
+name: epistemic-gardening
+description: "Use when the user says '/epistemic-gardening', 'garden the graph', 'de-weed', 'prune artifacts', 'epistemic hygiene', 'clean up findings/goals/sources', 'graph hygiene pass', or 'pre-release cleanup'. A PRAXIC pass that de-weeds a practice's epistemic graph — resolve stale/superseded findings, close answered unknowns, verify or drop assumptions, archive done goals and stale sources, prune dangling edges — so retrieval surfaces what's live, not what's rotted. Includes the mesh-wide propagation pattern for getting every practice to garden."
+version: 1.0.0
+---
+
+# Epistemic Gardening 🌱
+
+**De-weed the epistemic graph so retrieval surfaces what's live, not what's rotted.**
+
+The knowledge layer accretes. Findings that were true get superseded. Unknowns get
+answered. Goals finish. Sources go stale. Assumptions get verified — or falsified.
+None of that decay is self-cleaning: a two-month-old finding that's been *superseded*
+still scores high on impact, so it keeps resurfacing in PREFLIGHT/CHECK and crowds out
+what's current. Recency-decay knows *age*, not *wrongness*. Gardening is the deliberate
+pass that tells the graph what's dead.
+
+> **This skill is PRAXIC, not noetic.** Unlike `/code-audit` (which only investigates),
+> gardening *mutates* the graph — it resolves, archives, and deletes. So it runs inside a
+> real epistemic transaction: PREFLIGHT → CHECK → act → POSTFLIGHT. Open the window before
+> you prune.
+
+> **Why it matters now.** Before finding-resolve + read-time reconciliation (#307),
+> resolving a finding was nearly cosmetic — the Qdrant payload stayed stale and the
+> finding kept surfacing. Now a resolved finding is genuinely dropped from live retrieval
+> (Qdrant reconcile + the breadcrumbs `EPISTEMIC FOCUS` filter). **Resolution finally
+> lands.** That's what makes a hygiene pass worth running.
+
+---
+
+## When to run
+
+| Trigger | Depth |
+|---|---|
+| **Before a release** | Full pass — a clean graph is part of the release artifact |
+| **Periodically** (e.g. every N sessions, or when a bootstrap feels noisy) | Standard pass on the loudest artifact types |
+| **After a big investigation** that spawned many exploratory findings/unknowns | Scoped pass on that session's artifacts |
+| **When PREFLIGHT/EPISTEMIC FOCUS surfaces something you *know* is stale** | Spot-resolve inline (one verb, no full pass) |
+
+Don't garden *mid-investigation* — you'll prune branches you're still standing on. Garden
+at a coherent break, not while the question is open.
+
+---
+
+## The core discipline: resolve ▸ archive ▸ delete (in that preference order)
+
+The single most important call in gardening is **which lever** an artifact gets. Default
+toward the *least* destructive one that removes it from live retrieval:
+
+| Lever | What it does | Use when | Reverses? |
+|---|---|---|---|
+| **resolve** | keeps the artifact for history, drops it from live retrieval | the artifact *was* true/open and is now stale, answered, superseded, or verified — **the common case** | yes (`goals-reopen`; re-log) |
+| **archive** | hides from default lists, kept fully | a *completed* goal or a *stale-but-real* source you may cite later | yes (`goals-reopen`) |
+| **delete** | removes it entirely, no history | test-noise, duplicates, mistaken logs — artifacts with **no epistemic value** | no |
+
+**The bias is resolve-over-delete.** Epistemic history is an asset: a superseded finding
+plus its `superseded_by` link is a *record of how understanding changed* — that's the
+practice's calibration trajectory. Delete only what was never knowledge: a `TEST` finding,
+an accidental double-log, a goal you created then immediately abandoned. When unsure,
+resolve — it's reversible and keeps the trail.
+
+**Never resolve or delete dead-ends and mistakes.** They are the cognitive immune system —
+"we tried X, it failed" is *supposed* to resurface so nobody re-walks it. Prune those only
+if they're literal duplicates or test noise.
+
+---
+
+## The pass — six phases
+
+### Phase 0 — PREFLIGHT (open the window)
+
+```bash
+empirica preflight-submit - << 'EOF'
+{"work_type": "audit", "criticality": "medium",
+ "task_context": "Epistemic gardening pass on <practice>",
+ "vectors": {"know": 0.7, "do": 0.9, "context": 0.75, "clarity": 0.7,
+   "coherence": 0.7, "signal": 0.6, "density": 0.5, "state": 0.7,
+   "change": 0.1, "completion": 0.0, "impact": 0.5, "engagement": 0.9,
+   "uncertainty": 0.3},
+ "current_phase": "noetic"}
+EOF
+```
+
+Create a goal so the pass is a tracked unit:
+
+```bash
+empirica goals-create --objective "Epistemic gardening pass" \
+  --description "De-weed the graph: resolve stale/superseded findings, close answered
+unknowns, verify/drop assumptions, archive done goals + stale sources, prune dangling
+edges. Success: bootstrap/EPISTEMIC FOCUS surfaces only live artifacts."
+```
+
+### Phase 1 — Survey (noetic: what's in the graph)
+
+Read the current state before touching anything. `log-artifacts -` with an empty payload
+is not how you read — use these:
+
+```bash
+empirica goals-list                              # open/planned/in_progress + stale candidates
+empirica goals-get-stale                         # goals past their freshness window
+empirica project-search --task "<recent theme>"  # what retrieval actually surfaces
+empirica sources-map                             # source inventory (add --global for shared)
+empirica sources-check                           # unreviewed / stale-review sources
+```
+
+For findings/unknowns/assumptions, inspect the practice DB read-only (this is noetic —
+a plain SELECT):
+
+```bash
+sqlite3 .empirica/sessions/sessions.db \
+  "SELECT id, substr(finding,1,60), impact FROM project_findings \
+   WHERE is_resolved IS NULL OR is_resolved=0 ORDER BY impact DESC LIMIT 40" | column -t -s '|'
+sqlite3 .empirica/sessions/sessions.db \
+  "SELECT id, substr(unknown,1,60) FROM project_unknowns WHERE is_resolved=0"
+```
+
+Note the counts and the loudest items. You're building a triage list, not acting yet.
+
+### Phase 2 — CHECK (gate the transition)
+
+You've surveyed; now you know what to prune. CHECK with honest vectors, then act.
+
+```bash
+empirica check-submit - << 'EOF'
+{"vectors": {"know": 0.8, "uncertainty": 0.2, "context": 0.8, "clarity": 0.8},
+ "current_phase": "noetic",
+ "reasoning": "Surveyed the graph — N stale findings, M answered unknowns, K done goals, J stale sources identified for the pass."}
+EOF
+```
+
+### Phase 3 — Triage + act (per artifact type)
+
+Prefer the **batch verbs** — one call, connected, auditable — over N single verbs.
+
+**Findings** — resolve stale/superseded; link the replacement:
+```bash
+# Single, with supersession link:
+empirica finding-resolve <old-id> --resolution "superseded" --superseded-by <new-id>
+# Batch (mixed types in one call):
+empirica resolve-artifacts - << 'EOF'
+{"resolutions": [
+  {"type": "finding",   "id": "<id>", "resolution": "stale — subsystem removed"},
+  {"type": "finding",   "id": "<id>", "resolution": "superseded", "superseded_by": "<new-id>"},
+  {"type": "unknown",   "id": "<id>", "resolution": "answered: see finding <id>"},
+  {"type": "assumption","id": "<id>", "resolution": "verified", "verified": true},
+  {"type": "goal",      "id": "<id>", "resolution": "done"}
+]}
+EOF
+```
+
+**Goals** — close, archive, or mark stale:
+```bash
+empirica goals-complete --goal-id <id> --reason "<evidence>"
+empirica goals-archive  --goal-id <id>          # completed + old → out of the default list
+empirica goals-mark-stale --goal-id <id>        # abandoned but worth recording
+```
+
+**Sources** — archive stale, or refresh:
+```bash
+empirica source-archive <id>                    # stale but may cite later
+empirica source-update <id> ...                 # content moved / refreshed
+```
+
+**Delete — only true noise** (dry-run is the default; review the receipt, then `--apply`):
+```bash
+empirica delete-artifacts - << 'EOF'
+{"deletions": [
+  {"type": "finding", "id": "<test-noise-id>"},
+  {"type": "unknown", "id": "<accidental-dup-id>"}
+],
+ "prune_dangling": true,
+ "reason": "test artifacts + edges left dangling by resolved nodes"}
+EOF
+```
+`prune_dangling` sweeps edges whose endpoints no longer exist (with `repair` rewiring
+recoverable prefixes by default). Deletions log a decision receipt for audit.
+
+### Phase 4 — Verify (did the pruning land?)
+
+Resolution is only real if retrieval reflects it. Confirm:
+
+```bash
+empirica project-search --task "<theme you just pruned>"   # resolved items gone?
+empirica goals-list                                        # closed/archived gone from active?
+```
+
+If a resolved finding still surfaces, its Qdrant payload predates #307 — the read-time
+reconcile drops it by `artifact_id` or text-prefix, so it should vanish from
+PREFLIGHT/CHECK regardless; a `rebuild` refreshes the embedded payload if you want the
+vector store itself clean.
+
+### Phase 5 — POSTFLIGHT (close the window)
+
+Complete the goal *before* POSTFLIGHT (the window closes there). Log a finding recording
+the pass's scope (what was resolved/archived/deleted, counts) so the *next* gardener sees
+the last pass.
+
+```bash
+empirica goals-complete --goal-id <pass-goal> --reason "Resolved N findings, closed M unknowns, archived K goals + J sources, pruned E edges."
+empirica postflight-submit - << 'EOF'
+{"work_type": "audit", "vectors": {"...": "..."}, "current_phase": "praxic",
+ "reasoning": "Gardening pass complete: <counts>."}
+EOF
+```
+
+---
+
+## Cross-practice: garden the whole mesh 🌐
+
+A single clean practice is local hygiene. The value compounds when **every** practice
+gardens — the shared/global retrieval surfaces (`project-search --global`, `sources-map
+--global`, the `global_learnings` collection) are only as clean as the messiest
+contributor. Propagating the discipline is part of the pass.
+
+**1. Register this skill's discipline as a shared reference** so peers pull it rather than
+re-derive it:
+```bash
+empirica source-add --title "Epistemic gardening pass — hygiene discipline" \
+  --visibility shared --noetic
+```
+
+**2. Collab the mesh when you finish a pass** (noetic — auto-accepted, no ECO gate). FYI
+peers that you gardened, and nudge them to run their own:
+> Use `/cortex-mailbox-send` (Flavor 1, `cortex_collab`). Lead with substance: *"Ran an
+> epistemic-gardening pass on `<practice>` — resolved N stale/superseded findings + closed
+> M unknowns; shared-visibility retrieval should be cleaner. Recommend each practice run
+> `/epistemic-gardening` before the next release — resolution now lands in retrieval
+> (#307)."* Target the canonical 3-form (`empirica.<tenant>.<practice>`).
+
+**3. For a coordinated fleet-wide sweep** — when it's not one FYI but sustained
+multi-practice work with named owners — graduate to an **SER** (Shared Epistemic Record)
+via `cortex_propose(payload.action='create_ser')`:
+> Participants = the practices that must garden (role `required`), coordination state
+> tracks the sweep (`open → in_progress → closed`). This is the right primitive when
+> "get every practice clean before 1.30" needs shared, persistent, cross-session state
+> rather than a thread. See `/cortex-mailbox-send` Flavor 3.
+
+**4. Don't garden a peer's graph for them.** Resolution/deletion is a *practice-owned*
+judgment — only the practitioner inhabiting a practice knows whether a finding is truly
+superseded. Propose (ECO-gated) that they run the pass; never reach into their DB with
+`--project-id` to prune. Sharing the *discipline* is collab; pruning *their* artifacts is
+overreach.
+
+---
+
+## Anti-patterns
+
+| Smell | Why it's wrong |
+|---|---|
+| Deleting a finding that should be resolved | Throws away the calibration trail. Resolve keeps history + drops from retrieval — that's the point. |
+| Resolving/deleting dead-ends or mistakes | They're the immune system — they're *meant* to resurface. Prune only literal dupes/noise. |
+| Gardening mid-investigation | You'll prune branches you're still on. Garden at a coherent break. |
+| A pass with no POSTFLIGHT | The window never closes; the counts and the summary finding are invisible to calibration. |
+| N single `*-resolve` calls when they're related | Use `resolve-artifacts -` — one batch, connected, auditable. |
+| Deleting straight to `--apply` without reading the dry-run | The receipt is there to catch a mis-scoped prune before it's irreversible. |
+| Reaching into a peer practice's DB to prune | Practice-owned judgment. Propose the pass; don't execute it on their graph. |
+
+---
+
+## Output contract
+
+After a pass, the graph has: resolved findings/unknowns/assumptions (kept, out of
+retrieval), archived goals + sources, pruned dangling edges, deleted noise (with an audit
+receipt), and **one summary finding** recording the pass so the next gardener has a
+baseline. Re-running is idempotent — the second pass on an already-clean graph resolves
+nothing and says so.
+
+---
+
+## See also
+
+- **`docs/architecture/ARTIFACT_HYGIENE.md`** — the design spec this skill
+  operationalizes (the cross-transaction, whole-practice sweep). That doc governs
+  *policy* (what decays, which primitive addresses it); this skill is the *procedure*.
+- **`docs/architecture/GATED_ARTIFACT_GRAPH.md`** — the *within-transaction* half
+  (weave-gate + connectivity at POSTFLIGHT). Gardening handles what a single POSTFLIGHT
+  structurally can't see.
+- **`/epistemic-transaction`** — the transaction discipline the pass runs inside.
+- **`/cortex-mailbox-send`** — the collab / propose / SER mechanics for the mesh-wide
+  propagation in the cross-practice section.
+
+🌱 *A practice that gardens surfaces its best current knowledge. A practice that doesn't
+drowns its present in its past.*

--- a/empirica/plugins/claude-code-integration/templates/empirica-system-prompt-lean.md
+++ b/empirica/plugins/claude-code-integration/templates/empirica-system-prompt-lean.md
@@ -366,6 +366,7 @@ compound — every "I'll just do it from memory" call is a calibration gap.
 {% endif %}
 | `/empirica-commands` | Need a specific CLI flag and `--help` isn't enough |
 | `/code-audit`, `/code-docs-align` | Pre-release pass OR after a refactor sweep that may have left drift |
+| `/epistemic-gardening` | Pre-release, periodically, or when PREFLIGHT/EPISTEMIC FOCUS surfaces stale artifacts — a PRAXIC pass to resolve/archive/prune the epistemic graph so retrieval surfaces what's live. Includes the mesh-wide propagation pattern. |
 | `/epistemic-persistence-protocol` | User pushes back on your position — load BEFORE responding to classify the pushback type |
 
 **Anti-pattern:** "I remember roughly what that skill says, I'll skip


### PR DESCRIPTION
The operational skill for epistemic hygiene — David's ask: *"instructions on how to do that effectively that might need to become a skill."*

## Why now
#307 (`finding-resolve` + read-time reconcile) closed the last gap in the resolve-verb surface **and** made resolution actually land in retrieval — before it, resolving a finding was near-cosmetic. A coherent hygiene skill is now expressible end-to-end.

## What it is
A **PRAXIC** pass (it mutates the graph — stated explicitly, unlike the noetic `/code-audit`) that de-weeds a practice's epistemic graph so retrieval surfaces what's live, not what's rotted.

- **The resolve ▸ archive ▸ delete preference order** — bias resolve-over-delete (epistemic history is an asset); never prune dead-ends/mistakes (the immune system).
- **Six-phase pass**: PREFLIGHT → survey → CHECK → triage+act (batch verbs) → verify retrieval → POSTFLIGHT.
- **Per-artifact-type playbook** (findings / unknowns / assumptions / goals / sources / edges).
- **Cross-practice mesh propagation** (v1, per the scope call): collab the pass, propose peers run it, SER for a fleet-wide sweep — and *never* prune a peer's graph for them (practice-owned judgment).
- Anti-patterns + output contract.

## Also
- Registered in the `WHEN TO LOAD SKILLS` table (lean prompt template).
- `ARTIFACT_HYGIENE.md`: marked operationalized-by-skill; added `finding-resolve` to the primitives table; corrected §1 (superseded findings **resolve**, not delete). The design spec explicitly framed this as "an orchestration + policy problem, not build-from-scratch" — this skill is that orchestration.

## Validation
- Frontmatter valid; survey commands run clean against a live graph.
- Dogfood survey of empirica's own graph: **4005 open findings, 114 open unknowns** — a heavily overgrown graph, concrete proof of the thesis and the first target for the mesh-wide sweep. (A full prune pass is dedicated follow-on work per the skill's own "don't rush a pass" discipline, not bundled here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qe4uGwYbVtE5CFZdsBwata