### PR TITLE
fix(sentinel): classifier parity across all positions + workflow-verb tier completeness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Sentinel classifier parity + workflow-verb completeness** (four over-gating
+  gaps surfaced by the first `/epistemic-gardening` pass — all the same "read-only
+  op trusted in one syntactic position but not another" class as the pipe-parity
+  fix). (1) **Help/version queries** now classify noetic regardless of verb — a
+  non-tiered verb like `goals-archive --help` no longer gates just because the
+  verb mutates when actually run (quote-aware via shlex, so a `--help` inside a
+  quoted argument can't wave a mutating command through). (2) **`_is_segment_safe`
+  reached parity with the single-command path** — a read-only `sqlite3` query or
+  `python3 -c` inspection as a *chain segment* (`echo x && sqlite3 db "SELECT …"`,
+  newline-chained surveys) is now noetic, not just when standalone or piped;
+  extracted the shared `_is_readonly_command_form` so both paths classify
+  identically. (3) The **single-command path** now excuses inert shell shapes
+  (bare `VAR=value`, `[ test ]`, `exit N`) like the chain-segment path already
+  did. (4) **`finding-resolve`, `goals-archive`, `goals-reopen`, `goals-activate`
+  added to the TIER2 workflow whitelist** — epistemic-hygiene verbs whose siblings
+  (`unknown-resolve`, `goals-complete`, `goals-prune`) were already there, so
+  gardening no longer needs a CHECK to resolve a finding or archive a goal. All
+  mutating forms (sqlite writes, `rm` in a chain, mutating python) stay gated.
+
 ## [1.12.18] — 2026-07-12
 
 ### Added

--- a/empirica/plugins/claude-code-integration/hooks/sentinel-gate.py
+++ b/empirica/plugins/claude-code-integration/hooks/sentinel-gate.py
@@ -768,6 +768,7 @@ EMPIRICA_TIER2_PREFIXES = (
     "empirica create-handoff",
     "empirica resume-goal",
     "empirica unknown-resolve",
+    "empirica finding-resolve",  # Resolve/supersede a finding (#307) — analog of unknown-resolve
     "empirica issue-handoff",
     "empirica project-init",
     "empirica project-embed",
@@ -792,6 +793,9 @@ EMPIRICA_TIER2_PREFIXES = (
     "empirica goals-mark-stale",
     "empirica goals-refresh",  # Goal staleness management
     "empirica goals-prune",  # Bulk close stale/duplicate/planned goals (dry-run default)
+    "empirica goals-archive",  # Archive completed goals (dry-run default; --apply mutates) — goal-lifecycle hygiene
+    "empirica goals-reopen",  # Un-archive / reopen a goal — the inverse of archive/complete
+    "empirica goals-activate",  # planned → in_progress — goal-lifecycle workflow
     "empirica profile-sync",
     "empirica profile-prune",  # Profile management - state-changing
     "empirica release",  # Release pipeline — mechanical, no PREFLIGHT needed
@@ -815,6 +819,22 @@ def is_safe_empirica_command(command: str) -> bool:
     cmd = command.lstrip()
     if not cmd.startswith("empirica "):
         return False
+
+    # Help / version queries are inert regardless of verb — they print usage and
+    # never execute the verb's action. A non-tiered (or future) verb like
+    # `goals-archive --help` should NOT gate just because the verb mutates when
+    # actually run. Tokenized quote-aware via shlex so a literal `--help` INSIDE a
+    # quoted argument (e.g. `goals-archive --apply --reason "see --help"`) is part
+    # of a larger token and does NOT false-match — that would wave a mutating
+    # command through. On malformed quoting, skip this shortcut and fall through.
+    import shlex as _shlex
+
+    try:
+        _toks = _shlex.split(cmd)
+    except ValueError:
+        _toks = []
+    if {"--help", "-h", "--version"} & set(_toks):
+        return True
 
     # Tier 1: Read-only - always safe
     for prefix in EMPIRICA_TIER1_PREFIXES:
@@ -1853,16 +1873,35 @@ def _is_segment_safe(segment: str) -> bool:
         return is_safe_pipe_chain(stripped)
     if is_safe_empirica_command(stripped):
         return True
-    _rcmd = _remote_prefix(stripped)
-    if _rcmd is not None:
-        return is_safe_remote_command(_rcmd)
-    if _matches_safe_prefix(stripped):
+    # 5. Read-only single-command forms (remote read / sqlite read / python -c /
+    # safe-prefixed tool) — shared with is_safe_bash_command's single-command path
+    # so a segment classifies identically whether it stands alone or sits in a
+    # chain (the parity that stops `echo x && sqlite3 db "SELECT …"` false-gating).
+    if _is_readonly_command_form(stripped):
         return True
 
-    # 5. Inert shell shapes (control-flow keywords, tests, assignments,
+    # 6. Inert shell shapes (control-flow keywords, tests, assignments,
     # exit/return). All embedded commands have already been validated
     # in step 1; this only excuses the structural shell text.
     return _is_inert_shape(stripped)
+
+
+def _is_readonly_command_form(cmd: str) -> bool:
+    """Read-only single-command forms shared by the standalone and chain-segment
+    classifiers, so a command is judged identically regardless of syntactic
+    position: a remote read (ssh/scp/rsync), a sqlite read, a `python3 -c`
+    inspection, or a safe-prefixed tool (`_matches_safe_prefix`, which applies the
+    mutation-flag guard). The pipe-segment path mirrors this via `_matches_safe_prefix`.
+    Callers layer their own extras (empirica tiers, inert shapes) around this core."""
+    rcmd = _remote_prefix(cmd)
+    if rcmd is not None:
+        _maybe_nudge_remote_ops(rcmd)
+        return is_safe_remote_command(rcmd)
+    if cmd.startswith("sqlite3 ") and is_safe_sqlite_command(cmd):
+        return True
+    if cmd.startswith(("python3 -c ", "python -c ")) and is_safe_python_command(cmd):
+        return True
+    return _matches_safe_prefix(cmd)
 
 
 def _is_command_text_safe(cmd: str) -> bool:
@@ -2002,17 +2041,11 @@ def is_safe_bash_command(tool_input: dict) -> bool:
 
     cmd = command.lstrip()
 
-    # Special cases: remote, sqlite, python
-    _rcmd = _remote_prefix(cmd)
-    if _rcmd is not None:
-        _maybe_nudge_remote_ops(_rcmd)
-        return is_safe_remote_command(_rcmd)
-    if cmd.startswith("sqlite3 ") and is_safe_sqlite_command(cmd):
-        return True
-    if cmd.startswith(("python3 -c ", "python -c ")) and is_safe_python_command(cmd):
-        return True
-
-    return _matches_safe_prefix(cmd)
+    # Read-only single-command forms (remote / sqlite / python -c / safe-prefix),
+    # shared with _is_segment_safe so standalone and in-chain classify identically.
+    # Plus inert shell shapes (bare `VAR=value`, `[ test ]`, `exit N`) — parity
+    # with the chain-segment path, which already excuses those.
+    return _is_readonly_command_form(cmd) or _is_inert_shape(cmd)
 
 
 def is_safe_sqlite_command(command: str) -> bool:

--- a/tests/test_sentinel_shell_constructs.py
+++ b/tests/test_sentinel_shell_constructs.py
@@ -644,3 +644,86 @@ class TestPipeTargetParity:
         # already-vetted data, but never as a pipe SOURCE (arbitrary exec).
         assert gate.is_safe_pipe_chain("cat f.json | python3 -c 'import sys; print(len(sys.stdin.read()))'") is True
         assert gate.is_safe_pipe_chain("python3 -c 'print(1)' | cat") is False
+
+
+# ─── classifier parity + tier completeness (gardening-pass follow-ups) ───────
+
+
+class TestClassifierParity:
+    """Four over-gating gaps surfaced by the first epistemic-gardening pass, all
+    the same 'read-only op trusted in one syntactic position but not another'
+    class as the pipe-parity fix (#319):
+
+      1. Help/version queries gate on non-tiered verbs (verb, not --help, decided).
+      2. _is_segment_safe omitted sqlite + python -c (chain segments false-gated).
+      3. Single-command path omitted inert shapes (bare `VAR=value` gated).
+      4. finding-resolve / goals-archive / goals-reopen / goals-activate missing
+         from the TIER2 workflow whitelist.
+    """
+
+    # 1. Help / version — inert regardless of verb, quote-aware.
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "empirica goals-archive --help",
+            "empirica finding-resolve --help",
+            "empirica entity-delete X --help",  # non-tiered mutating verb + --help
+            "empirica sync-push --version",
+        ],
+    )
+    def test_help_version_queries_are_noetic(self, gate, cmd):
+        assert gate.is_safe_empirica_command(cmd) is True
+        assert gate.is_safe_bash_command({"command": cmd}) is True
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            'empirica entity-delete X --reason "run --help first"',  # --help INSIDE a quoted arg
+            'empirica sync-push --force --note "--version bump"',  # --version inside a quote
+        ],
+    )
+    def test_help_flag_in_quoted_arg_does_not_leak(self, gate, cmd):
+        # A mutating, non-tiered verb must still gate — the help/version token is
+        # inside a quoted argument, so shlex keeps it in a larger token (no match).
+        assert gate.is_safe_empirica_command(cmd) is False
+
+    # 2. sqlite + python -c as CHAIN SEGMENTS (no pipe).
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            'echo hi && sqlite3 db.db "SELECT 1"',
+            'sqlite3 db.db "SELECT 1"; sqlite3 db.db "SELECT date(x,\'unixepoch\') FROM t"',
+            "echo a && python3 -c 'print(1)'",
+        ],
+    )
+    def test_readonly_sqlite_python_in_chain_segments_noetic(self, gate, cmd):
+        assert gate.is_safe_bash_command({"command": cmd}) is True
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            'echo x && sqlite3 db.db "DELETE FROM t"',  # sqlite write in chain
+            'echo x && sqlite3 db.db "DROP TABLE t"',
+            "echo x && python3 -c 'import os; os.remove(\"f\")'",  # mutating python in chain
+        ],
+    )
+    def test_mutating_sqlite_python_in_chain_still_gated(self, gate, cmd):
+        assert gate.is_safe_bash_command({"command": cmd}) is False
+
+    # 3. Inert shapes standalone (parity with chain-segment path).
+    @pytest.mark.parametrize("cmd", ["DB=.empirica/x.db", "[ -f foo ]", "exit 0"])
+    def test_inert_shapes_standalone_noetic(self, gate, cmd):
+        assert gate.is_safe_bash_command({"command": cmd}) is True
+
+    def test_assignment_then_mutation_still_gated(self, gate):
+        assert gate.is_safe_bash_command({"command": "DB=x && rm file"}) is False
+
+    # 4. TIER2 workflow-verb completeness.
+    @pytest.mark.parametrize(
+        "verb",
+        ["finding-resolve", "goals-archive", "goals-reopen", "goals-activate"],
+    )
+    def test_lifecycle_verbs_are_tiered(self, gate, verb):
+        # These are epistemic-workflow verbs (siblings unknown-resolve / goals-complete
+        # / goals-prune are all TIER2) — they flow without a CHECK like the rest.
+        assert gate.is_safe_empirica_command(f"empirica {verb} --older-than 30") is True


### PR DESCRIPTION
Four over-gating gaps surfaced by the **first real `/epistemic-gardening` pass** — all the same *"a read-only op trusted in one syntactic position but not another"* class as the pipe-parity fix (#319). The garden framing is apt: hygiene is irreducibly probabilistic, so the deterministic gate underneath — what's even safe to survey — has to be rock-solid first.

## The four gaps

| # | Gap | Fix |
|---|---|---|
| 1 | Help/version queries gated on non-tiered verbs (the **verb** decided, not `--help`) — so `goals-archive --help` gated | `--help`/`-h`/`--version` on any empirica verb → noetic, **quote-aware via shlex** (a `--help` inside a quoted arg can't wave a mutating command through) |
| 2 | `_is_segment_safe` omitted `sqlite3` + `python3 -c` — a bare read-only sqlite/python in a **chain segment** (`echo x && sqlite3 db "SELECT …"`) false-gated, though the standalone AND pipe paths handled them | Extracted shared **`_is_readonly_command_form`** (remote/sqlite/python/safe-prefix) used by *both* the standalone and chain-segment classifiers — they agree by construction now |
| 3 | Single-command path omitted inert shapes — a bare `VAR=value` / `[ test ]` / `exit N` gated standalone though the chain path excused them | single-command path now layers `_is_inert_shape` |
| 4 | `finding-resolve`, `goals-archive`, `goals-reopen`, `goals-activate` missing from the **TIER2 workflow whitelist** (siblings `unknown-resolve` / `goals-complete` / `goals-prune` were in) | added — `finding-resolve` was the #307 omission; gardening no longer needs a CHECK to resolve a finding or archive a goal |

## Security preserved
sqlite writes, mutating python, `rm` in a chain, and a mutating non-tiered verb with `--help` **in a quoted arg** all still gate — verified explicitly.

## Verification
- `TestClassifierParity`: 20 new assertions (help/version + quote-leak guard, sqlite/python in chains + their mutating forms, inert shapes, tier completeness).
- Full sentinel suite green: **324 passed**, no regression. `ruff`/`pyright` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qe4uGwYbVtE5CFZdsBwata