### PR TITLE
docs(guidance): batch artifact verbs first; surgical/batch/mass-policy registers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   gates in any position, while a read-only inner (`$(date)`, `$(git log)`,
   `$(whoami)`) still passes. Surfaced while closing over-gating gaps during the
   gardening work.
->>>>>>> origin/develop
 
 ### Fixed
 - **Quoted variable assignments with spaces no longer over-gate.** `PAT="a b c"`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Batch artifact verbs are now the documented default for multi-artifact work.**
+  The collaborative-mode guidance shifts from a "≥3 related artifacts" threshold to
+  batch-first: default to `log-artifacts` / `resolve-artifacts` / `delete-artifacts`
+  for any 2+ artifacts or graph-connected cluster; single `*-log`/`*-resolve` verbs
+  are for genuinely-single artifacts. The `/epistemic-gardening` skill gains the
+  three-register distinction — **surgical** (per-artifact judgment, the human-facing
+  default), **batch-by-graph** (an AI resolving a connected cluster in one call), and
+  **mass-policy** (filter-and-bulk, a deliberate backlog tool used only with explicit
+  human sign-off on the policy, never routine).
+
 ### Fixed
 - **Sentinel classifier parity + workflow-verb completeness** (four over-gating
   gaps surfaced by the first `/epistemic-gardening` pass — all the same "read-only

--- a/empirica/plugins/claude-code-integration/skills/epistemic-gardening/SKILL.md
+++ b/empirica/plugins/claude-code-integration/skills/epistemic-gardening/SKILL.md
@@ -26,6 +26,30 @@ pass that tells the graph what's dead.
 > (Qdrant reconcile + the breadcrumbs `EPISTEMIC FOCUS` filter). **Resolution finally
 > lands.** That's what makes a hygiene pass worth running.
 
+## Surgical by default; batch by graph; mass-policy only with sign-off
+
+Three registers — don't confuse them:
+
+- **Surgical (the default for human-facing gardening).** Resolution is per-artifact
+  *judgment* — "is THIS finding stale / superseded / still load-bearing?". A human (or an
+  AI acting on a human's behalf) gardens one artifact, or one small cluster, at a time,
+  reading each. This is the routine, careful register. Reach for the single verbs
+  (`finding-resolve`, `unknown-resolve`) here when it's genuinely one artifact.
+- **Batch-by-graph (how an AI handles a connected cluster in regular work).** When several
+  artifacts are related through the knowledge graph — a finding and the two unknowns it
+  answered, a dead-end and the decision that replaced it — resolve them together in one
+  `resolve-artifacts -` call rather than N single verbs. The batch verbs
+  (`log-artifacts` / `resolve-artifacts` / `delete-artifacts`) are the *default* for
+  multi-artifact work; singles are the exception. This is efficiency, still grounded in
+  per-cluster judgment.
+- **Mass-policy (a deliberate backlog tool, NOT routine).** A filter-and-bulk-resolve
+  (e.g. "resolve all >4mo low-impact findings as stale, protect the keepers") clears an
+  accumulated backlog fast, but it trades per-artifact judgment for a *policy*. It is
+  irreducibly probabilistic — you accept a small, reversible error rate. **Use it only
+  deliberately, with explicit human sign-off on the policy** (which age gate, which
+  keepers protected), not as the everyday hygiene move. The everyday move is surgical +
+  batch-by-graph.
+
 ---
 
 ## When to run

--- a/empirica/plugins/claude-code-integration/templates/empirica-system-prompt-lean.md
+++ b/empirica/plugins/claude-code-integration/templates/empirica-system-prompt-lean.md
@@ -448,9 +448,9 @@ Infer epistemic actions from conversation naturally:
 | Choice point | `decision-log --choice "..." --rationale "..." --reversibility <exploratory\|committal\|forced>` |
 | Something to check on later, but not worth a full artifact yet (a doubt, a follow-up, "this smells off", "ask peer X") | `empirica note "..."` (optionally `--tag followup\|doubt\|idea`) — a fast scratchpad note-to-self. Pure metadata, not shared, survives compaction; surfaces at POSTFLIGHT for triage (`note --list`, then promote to an artifact/goal or `note --clear`). Capture now, classify later. |
 | External material cited (URL, doc, paper, transcript) | `source-add` then link via `sourced_from` in `log-artifacts` |
-| Logging ≥3 related artifacts in one breath, or any artifact with edges to others | `log-artifacts -` (one batch with `nodes` + `edges` JSON) instead of N individual `*-log` calls |
-| Closing several open unknowns / verifying assumptions at once (typically pre-POSTFLIGHT cleanup) | `resolve-artifacts -` batch JSON, not N individual `unknown-resolve` calls |
-| Triaging stale, duplicate, or test-noise artifacts | `delete-artifacts -` batch JSON (dry-run by default; receipt logged as decision for audit) |
+| Logging 2+ artifacts, or any artifact with an edge to another | **Default to `log-artifacts -`** (one batch: `nodes` + `edges` JSON). The batch verbs are the primary path — reach for a single `finding-log`/`unknown-log`/etc. only when it's genuinely ONE standalone artifact. Batching keeps the sub-graph connected in one call. |
+| Resolving/closing 2+ artifacts (unknowns, assumptions, goals, findings) | **Default to `resolve-artifacts -`** batch JSON, not N single `*-resolve` calls. Single `unknown-resolve`/`finding-resolve` only for one artifact. |
+| Triaging stale, duplicate, or test-noise artifacts | **Default to `delete-artifacts -`** batch JSON (dry-run by default; receipt logged as decision for audit). |
 | Logging an artifact you generated without external retrieval | `--epistemic-source intuition` — be honest, don't paper it as `search` |
 | Logging an artifact shaped by reads/greps/web/MCP this session | `--epistemic-source search` |
 | Finding/decision/etc. could help a future Claude working in ANY project (cross-codebase pattern, ecosystem-wide lesson, security note) | `--visibility shared` (within-org) or `--visibility public` (anyone). Default `local` keeps it project-scoped. |


### PR DESCRIPTION
Per David's direction: AIs should default to the batch verbs for regular multi-artifact work; human-facing gardening stays surgical; mass-filter bulk resolution is a deliberate backlog tool, not the routine.

**No code change — guidance only.**

## Changes
- **Lean prompt template** — collaborative-mode rows shift from a "≥3 related artifacts" threshold to **batch-first-default**: 2+ artifacts or any graph edge → `log-artifacts`/`resolve-artifacts`/`delete-artifacts`; single `*-log`/`*-resolve` only for a genuinely-single artifact.
- **`/epistemic-gardening` skill** — adds the **three-register distinction**, so the one-time 883-finding bulk pass isn't mistaken for the everyday move:
  - **Surgical** — per-artifact judgment, the human-facing default.
  - **Batch-by-graph** — an AI resolving a graph-connected cluster in one call (efficiency, still judgment-grounded).
  - **Mass-policy** — filter-and-bulk (age-hybrid etc.), a deliberate backlog tool used *only with explicit human sign-off on the policy*, never routine.

Context: the recent gardening pass validated the mechanism at scale, but the mass-policy pattern shouldn't become the default — this pins the registers so it doesn't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qe4uGwYbVtE5CFZdsBwata