### PR TITLE
fix(sources): --source writes a sourced_from graph edge, not only the column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **`finding-log --source` now writes a canonical `sourced_from` graph edge, not
+  only the `source_refs` column.** Citing a source historically serialized the ids
+  into the `source_refs` column — invisible to the artifact graph (weave-gate,
+  connectivity, traversal) and to `sources-map`. So a practice could cite dozens of
+  sources and still show **0** `sourced_from` edges (empirica's own graph did exactly
+  that: 60 sources, 0 edges). `_attach_sources` now writes the `sourced_from` edge at
+  log time (idempotent, best-effort) so a citation is a first-class graph link; the
+  column stays as the ordered list for backward compatibility.
 - **Weave-gate no longer false-blocks the disciplined goal-per-transaction flow.**
   The gate enforces graph connectivity at CHECK, but the structural `attached_to`
   (artifact→goal) edge was written only at POSTFLIGHT — so an artifact logged under

--- a/empirica/data/repositories/breadcrumbs.py
+++ b/empirica/data/repositories/breadcrumbs.py
@@ -231,11 +231,36 @@ class BreadcrumbRepository(BaseRepository):
             ),
         )
         self._attach_to_goal(finding_id, goal_id)
+        self._attach_sources(finding_id, source_ids)
 
         self.commit()
         logger.info(f"📝 Finding logged: {finding[:50]}...")
 
         return finding_id
+
+    def _attach_sources(self, artifact_id: str, source_ids: list[str] | None) -> None:
+        """Write `sourced_from` edges (artifact → source) for each linked source.
+
+        `--source` historically only serialized the ids into the `source_refs`
+        COLUMN — invisible to the artifact graph (weave-gate, connectivity,
+        traversal) and to `sources-map`. So a practice could cite 60 sources and
+        still show 0 `sourced_from` edges. Writing the canonical edge here makes a
+        citation a real, first-class graph link (the column stays as the ordered
+        list). Idempotent via INSERT OR IGNORE; best-effort — never fails a log.
+        """
+        if not source_ids:
+            return
+        for sid in source_ids:
+            sid = str(sid).strip() if sid else ""
+            if not sid:
+                continue
+            try:
+                self._execute(
+                    "INSERT OR IGNORE INTO artifact_edges (from_id, to_id, relation) VALUES (?, ?, 'sourced_from')",
+                    (artifact_id, sid),
+                )
+            except Exception as e:
+                logger.debug(f"_attach_sources skipped ({artifact_id}→{sid}): {e}")
 
     def _attach_to_goal(self, artifact_id: str, goal_id: str | None) -> None:
         """Materialize the structural `attached_to` edge (artifact → its goal) in

--- a/tests/test_source_edges.py
+++ b/tests/test_source_edges.py
@@ -1,0 +1,61 @@
+"""`--source` now writes a canonical `sourced_from` edge, not only the column.
+
+`finding-log --source <id>` historically serialized the ids into the `source_refs`
+COLUMN — invisible to the artifact graph — so a practice could cite dozens of
+sources and still show 0 `sourced_from` edges. The edge makes a citation a
+first-class graph link; the column remains for the ordered list.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from empirica.data.session_database import SessionDatabase
+
+PROJECT_ID = str(uuid.uuid4())
+SESSION_ID = str(uuid.uuid4())
+
+
+@pytest.fixture
+def db(tmp_path):
+    d = SessionDatabase(db_path=str(tmp_path / "src.db"))
+    yield d
+    d.close()
+
+
+def _sourced_edges(db, fid):
+    return sorted(
+        r[0]
+        for r in db.conn.execute(
+            "SELECT to_id FROM artifact_edges WHERE from_id = ? AND relation = 'sourced_from'", (fid,)
+        ).fetchall()
+    )
+
+
+def test_source_writes_sourced_from_edge(db):
+    fid = db.log_finding(PROJECT_ID, SESSION_ID, "cited finding", source_ids=["src-a", "src-b"])
+    assert _sourced_edges(db, fid) == ["src-a", "src-b"]
+
+
+def test_source_still_populates_column(db):
+    fid = db.log_finding(PROJECT_ID, SESSION_ID, "cited finding", source_ids=["src-a"])
+    col = db.conn.execute("SELECT source_refs FROM project_findings WHERE id = ?", (fid,)).fetchone()[0]
+    assert "src-a" in col
+
+
+def test_no_source_no_edge(db):
+    fid = db.log_finding(PROJECT_ID, SESSION_ID, "uncited finding")
+    assert _sourced_edges(db, fid) == []
+
+
+def test_source_edges_idempotent(db):
+    fid = db.log_finding(PROJECT_ID, SESSION_ID, "cited", source_ids=["src-a"])
+    db.breadcrumbs._attach_sources(fid, ["src-a"])  # re-run must not duplicate
+    assert _sourced_edges(db, fid) == ["src-a"]
+
+
+def test_blank_source_ids_skipped(db):
+    fid = db.log_finding(PROJECT_ID, SESSION_ID, "cited", source_ids=["", "  ", "src-real"])
+    assert _sourced_edges(db, fid) == ["src-real"]


### PR DESCRIPTION
Continuing the connectivity tending-tool work — the **single biggest under-use**: empirica's graph has 60 sources and **0** `sourced_from` edges.

## Root cause
`finding-log --source <id>` serialized the ids into the `source_refs` **column** only — invisible to the artifact graph (weave-gate, connectivity, traversal) and to `sources-map`. So citations never became graph edges.

## Fix
`_attach_sources` (mirrors `_attach_to_goal`) writes the canonical `sourced_from` edge at log time — idempotent `INSERT OR IGNORE`, best-effort. A citation is now a first-class graph link; the `source_refs` column stays as the ordered list for backward compatibility.

Findings are the sourcing case (only `log_finding` takes `source_ids`); extending `--source` to the other artifact types is a noted follow-up.

## Verification
`test_source_edges.py`: edge written, column still set, no-source noop, idempotent, blank ids skipped. `ruff`/`pyright` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qe4uGwYbVtE5CFZdsBwata