### PR TITLE
feat(sources): inline citation — finding-log --cite creates + links a source in one call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Inline source citation: `finding-log --cite "<title>" [--cite-url <url>] [--cite-type <type>]`.**
+  Creates the source AND links it (`sourced_from` edge) in one call — killing the
+  two-step `source-add` → `--source <id>` dance that kept sources under-logged
+  (60-for-9000). `breadcrumbs.create_source` writes a minimal source row (title/url/
+  type/visibility; file-identity columns stay NULL — that's the `source-add --path`
+  path's job), and the fresh id links like any `--source`. Combined with the
+  `sourced_from` edge fix (previous release), a cited finding is now a first-class,
+  connected, one-command act.
+
 ### Fixed
 - **`finding-log --source` now writes a canonical `sourced_from` graph edge, not
   only the `source_refs` column.** Citing a source historically serialized the ids

--- a/empirica/cli/command_handlers/artifact_log_commands.py
+++ b/empirica/cli/command_handlers/artifact_log_commands.py
@@ -960,7 +960,24 @@ def handle_finding_log_command(args):
             print_project_context(quiet=True)
 
         # Extract source IDs (from --source flags or config)
-        source_ids = (config_data or {}).get("source_ids") or getattr(args, "source_ids", None)
+        source_ids = list((config_data or {}).get("source_ids") or getattr(args, "source_ids", None) or [])
+        # Inline citation: --cite creates the source AND links it in one call (no
+        # separate source-add step). Prepend the fresh id so it links like any --source.
+        cite_title = (config_data or {}).get("cite_title") or getattr(args, "cite_title", None)
+        if cite_title:
+            try:
+                new_sid = db.breadcrumbs.create_source(
+                    project_id=ctx["project_id"],
+                    session_id=ctx["session_id"],
+                    title=cite_title,
+                    url=(config_data or {}).get("cite_url") or getattr(args, "cite_url", None),
+                    source_type=(config_data or {}).get("cite_type") or getattr(args, "cite_type", None) or "reference",
+                    visibility=ctx["visibility"],
+                    transaction_id=ctx["transaction_id"],
+                )
+                source_ids.insert(0, new_sid)
+            except Exception as e:
+                logger.debug(f"inline --cite create_source failed (non-fatal): {e}")
         # Source-aware Sentinel substrate: optional intuition|search|mixed tag
         epistemic_source = (config_data or {}).get("epistemic_source") or getattr(args, "epistemic_source", None)
 

--- a/empirica/cli/parsers/checkpoint_parsers.py
+++ b/empirica/cli/parsers/checkpoint_parsers.py
@@ -978,6 +978,19 @@ def add_checkpoint_parsers(subparsers):
         dest="source_ids",
         help="Source ID (from source-add). Repeatable for multiple sources.",
     )
+    finding_log_parser.add_argument(
+        "--cite",
+        dest="cite_title",
+        help="Inline source: create + link a source in one call (kills the source-add→--source two-step). "
+        "Value is the source title; pair with --cite-url / --cite-type.",
+    )
+    finding_log_parser.add_argument("--cite-url", dest="cite_url", help="URL/path for the --cite inline source.")
+    finding_log_parser.add_argument(
+        "--cite-type",
+        dest="cite_type",
+        default="reference",
+        help="Source type for --cite (reference, doc, paper, url, design, …). Default: reference.",
+    )
     _add_entity_flags(finding_log_parser)
     _add_edge_flags(finding_log_parser)
     finding_log_parser.add_argument(

--- a/empirica/data/repositories/breadcrumbs.py
+++ b/empirica/data/repositories/breadcrumbs.py
@@ -262,6 +262,57 @@ class BreadcrumbRepository(BaseRepository):
             except Exception as e:
                 logger.debug(f"_attach_sources skipped ({artifact_id}→{sid}): {e}")
 
+    def create_source(
+        self,
+        project_id: str,
+        session_id: str | None,
+        title: str,
+        url: str | None = None,
+        source_type: str = "reference",
+        description: str | None = None,
+        confidence: float = 0.7,
+        visibility: str | None = None,
+        transaction_id: str | None = None,
+    ) -> str:
+        """Create a minimal epistemic source row and return its id — the creation
+        half behind inline citing (`*-log --cite`).
+
+        The full `source-add` path also computes file content-identity (hash/size/
+        mime) for `--path` sources; a quick citation carries only title + optional
+        url + type, so those file columns stay NULL. This exists so an artifact can
+        create + link its source in ONE call (the two-step `source-add` → `--source`
+        is the friction that kept sources under-logged). Best-effort commit.
+        """
+        source_id = str(uuid.uuid4())
+        metadata = {"source_url": url, "transaction_id": transaction_id, "inline_cite": True}
+        self._execute(
+            """
+            INSERT INTO epistemic_sources (
+                id, project_id, session_id, source_type, source_url,
+                title, description, confidence, epistemic_layer,
+                discovered_by_ai, discovered_at, source_metadata,
+                entity_type, entity_id, visibility
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'noetic', 'claude-code', ?, ?, 'project', ?, ?)
+            """,
+            (
+                source_id,
+                project_id,
+                session_id,
+                source_type,
+                url,
+                title,
+                description,
+                confidence,
+                time.time(),
+                json.dumps(metadata),
+                project_id,
+                normalize_visibility(visibility),
+            ),
+        )
+        self.commit()
+        logger.info(f"📎 Source created (inline cite): {title[:50]}")
+        return source_id
+
     def _attach_to_goal(self, artifact_id: str, goal_id: str | None) -> None:
         """Materialize the structural `attached_to` edge (artifact → its goal) in
         artifact_edges AT LOG TIME, not only at POSTFLIGHT.

--- a/tests/test_source_edges.py
+++ b/tests/test_source_edges.py
@@ -59,3 +59,30 @@ def test_source_edges_idempotent(db):
 def test_blank_source_ids_skipped(db):
     fid = db.log_finding(PROJECT_ID, SESSION_ID, "cited", source_ids=["", "  ", "src-real"])
     assert _sourced_edges(db, fid) == ["src-real"]
+
+
+# ─── inline source creation (--cite) ─────────────────────────────────────────
+
+
+def test_create_source_minimal(db):
+    sid = db.breadcrumbs.create_source(PROJECT_ID, SESSION_ID, "RFC 7519", url="https://x/rfc", source_type="paper")
+    row = db.conn.execute(
+        "SELECT title, source_url, source_type FROM epistemic_sources WHERE id = ?", (sid,)
+    ).fetchone()
+    assert tuple(row) == ("RFC 7519", "https://x/rfc", "paper")
+
+
+def test_create_source_then_attach_is_a_full_citation(db):
+    # The inline-cite flow: create the source, then link it — the finding ends up
+    # with a sourced_from edge to a real source row, in one logical step.
+    sid = db.breadcrumbs.create_source(PROJECT_ID, SESSION_ID, "cited paper")
+    fid = db.log_finding(PROJECT_ID, SESSION_ID, "a finding", source_ids=[sid])
+    assert _sourced_edges(db, fid) == [sid]
+    title = db.conn.execute("SELECT title FROM epistemic_sources WHERE id = ?", (sid,)).fetchone()[0]
+    assert title == "cited paper"
+
+
+def test_create_source_defaults_type_reference(db):
+    sid = db.breadcrumbs.create_source(PROJECT_ID, SESSION_ID, "untyped")
+    t = db.conn.execute("SELECT source_type FROM epistemic_sources WHERE id = ?", (sid,)).fetchone()[0]
+    assert t == "reference"


### PR DESCRIPTION
Finishing the source substrate (David's pick) — the friction-kill half. Sourcing sat at **60-for-9000** because it was a two-step dance: `source-add` (get id) → `finding-log --source <id>`. Path of least resistance = skip it.

## `--cite` collapses it to one call
```
empirica finding-log --finding "JWTs are signed not encrypted" \
  --cite "RFC 7519" --cite-url https://datatracker.ietf.org/doc/html/rfc7519 --cite-type paper
```
Creates the source **and** writes the `sourced_from` edge in one command.

- `breadcrumbs.create_source(title, url, source_type, visibility, …)` — minimal source row (file-identity columns stay NULL; that's `source-add --path`'s job). Returns the id.
- finding-log handler: `--cite` → `create_source` → prepend id to `source_ids` → links via the existing column + `sourced_from` edge path. Best-effort, non-fatal.
- Combined with the `sourced_from` edge fix (prev release), a cited finding is now first-class, connected, one-command.

## Verification
Live e2e: `--cite` created a typed source with url + a `sourced_from` edge in one call. `test_source_edges.py`: `create_source` minimal/defaults + full-citation flow — 8 green. `ruff`/`pyright` clean.

**Follow-up noted:** extend `--source`/`--cite` to the other 5 artifact types (only findings carry `source_ids` today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qe4uGwYbVtE5CFZdsBwata