### PR TITLE
fix(sources): source-add --media fails loud when the blob upload fails

### DIFF
--- a/empirica/cli/command_handlers/artifact_log_commands.py
+++ b/empirica/cli/command_handlers/artifact_log_commands.py
@@ -2184,12 +2184,16 @@ def handle_source_add_command(args):
         # cortex_uuid). Best-effort: a push failure leaves the local source
         # intact and reports the error — it never fails the whole add.
         media_push = _upload_media_source(args, media_path, source_id, identity, title, project_id, visibility)
+        # --media exists to upload the blob — if that fails, the command failed,
+        # even though the local source row was created. Surface it loudly
+        # (ok:false + non-zero exit) rather than a silent ok:true footnote.
+        media_failed = _media_upload_failed(media_path, media_push)
 
         if output_format == "json":
             print(
                 json.dumps(
                     {
-                        "ok": True,
+                        "ok": not media_failed,
                         "source_id": source_id,
                         "project_id": project_id,
                         "session_id": session_id,
@@ -2200,7 +2204,12 @@ def handle_source_add_command(args):
                         "git_stored": git_stored,
                         "embedded": embedded,
                         "media_push": media_push,
-                        "message": f"Source added ({direction})",
+                        "error": (media_push or {}).get("error") if media_failed else None,
+                        "message": (
+                            f"Source row created but media upload FAILED: {(media_push or {}).get('error')}"
+                            if media_failed
+                            else f"Source added ({direction})"
+                        ),
                     },
                     indent=2,
                 )
@@ -2219,7 +2228,7 @@ def handle_source_add_command(args):
                 print(f"   URL: {source_url}")
             _print_media_push_status(media_push, visibility)
 
-        return 0
+        return 1 if media_failed else 0
 
     except Exception as e:
         handle_cli_error(e, "Source add", getattr(args, "verbose", False))
@@ -2328,6 +2337,16 @@ def _upsert_media_to_cortex(
         return {"pushed": False, "status": e.code, "error": err}
     except (urllib.error.URLError, OSError, TimeoutError) as e:
         return {"pushed": False, "error": f"{type(e).__name__}: {e}"}
+
+
+def _media_upload_failed(media_path, media_push) -> bool:
+    """True when --media was requested but the blob upload did not succeed.
+
+    Used to make the failure LOUD (ok:false + non-zero exit) instead of a
+    silent ok:true — the whole point of --media is the upload, so a source
+    row without its blob is a failed command, not a success with a footnote.
+    """
+    return bool(media_path) and media_push is not None and not media_push.get("pushed")
 
 
 def _print_media_push_status(media_push, visibility):

--- a/tests/test_source_add_media.py
+++ b/tests/test_source_add_media.py
@@ -14,7 +14,10 @@ import json
 import urllib.error
 import urllib.request
 
-from empirica.cli.command_handlers.artifact_log_commands import _upsert_media_to_cortex
+from empirica.cli.command_handlers.artifact_log_commands import (
+    _media_upload_failed,
+    _upsert_media_to_cortex,
+)
 
 
 class _FakeResp:
@@ -103,3 +106,14 @@ def test_default_mime_when_none(monkeypatch):
     cap = _capture(monkeypatch)
     _upsert_media_to_cortex("https://cortex.example", "ctx_key", "src-5", b"x", None, "t", "p", "shared")
     assert cap["headers"]["content-type"] == "application/octet-stream"
+
+
+def test_media_upload_failed_flag():
+    # --media requested + push failed → loud failure (ok:false + exit 1).
+    assert _media_upload_failed("/img.png", {"pushed": False, "error": "cortex not configured"}) is True
+    assert _media_upload_failed("/img.png", {"pushed": False}) is True
+    # --media requested + push succeeded → not failed.
+    assert _media_upload_failed("/img.png", {"pushed": True, "stored": True}) is False
+    # no --media → never a media failure (None push, or no media_path).
+    assert _media_upload_failed(None, None) is False
+    assert _media_upload_failed("", None) is False


### PR DESCRIPTION
## What web caught (first-customer e2e)

`source-add --media` returned `ok:true` + exit 0 **even when the cortex blob upload failed** — leaving a local source row with no retrievable blob. Silent-failure: looks shipped, isn't.

## Fix

`--media` exists to upload the blob, so a failed upload **is** a failed command. Now on upload failure: `ok:false` + **non-zero exit** + surfaced `error`. The local source row is still created (it's valid), but the failure is loud instead of buried in `media_push`. Added `_media_upload_failed()` (pure, unit-tested) + 1 test.

## Important: the e2e is ALSO blocked by a separate **cortex-side** bug

Reproduced deterministically (empirica's producer/consumer are correct):
- `source-add --media` → cortex `POST /body` returns `stored:true`, adopts the uuid, writes the blob to `/var/cortex/raw_bodies/…`
- `source-get --id <same uuid>` → **404 `source_not_found`** (also on a delayed raw re-fetch — not write-lag)

Cortex's upsert-on-body stores the **blob** but never creates the **source catalogue row** that `get_raw` resolves. Reported to cortex on the SER thread; that's the remaining DoD blocker.

16 tests, ruff + pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)