### PR TITLE
fix(identity): reconcile targets by-slug authority, not the register response

### DIFF
--- a/empirica/cli/command_handlers/projects_commands.py
+++ b/empirica/cli/command_handlers/projects_commands.py
@@ -1449,18 +1449,54 @@ def _project_register_error(message: str, hint: str, output_format: str) -> int:
     return 1
 
 
+def _cortex_canonical_project_id(project_path, cortex_outcome):
+    """Cortex's AUTHORITATIVE canonical project id for this project.
+
+    Prefer ``GET /v1/projects/by-slug`` (the id roster / practice-context /
+    blob-upload all validate against). Fall back to the register-POST response
+    only when by-slug can't resolve.
+
+    Why not the register response directly: the register endpoint can report a
+    stale ``already_registered`` id that DISAGREES with tenants.db / roster —
+    web hit exactly this (register said 258aa934 / diverged:false, while
+    roster + blob-upload only know dc6298e2). Trusting the register flag made
+    --reconcile decline to rekey while the media upload kept failing. by-slug is
+    the surface that matters, so it's the truth the reconcile must target.
+    """
+    try:
+        from pathlib import Path
+
+        import yaml
+
+        from empirica.core.identity_migration import _make_cortex_slug_resolver
+
+        cfg = {}
+        pj = Path(project_path) / ".empirica" / "project.yaml"
+        if pj.exists():
+            cfg = yaml.safe_load(pj.read_text(encoding="utf-8")) or {}
+        slug = cfg.get("slug") or cfg.get("name") or Path(project_path).name
+        canonical = _make_cortex_slug_resolver()(slug, None)
+        if canonical:
+            return canonical
+    except Exception:
+        pass
+    return cortex_outcome.get("project_id")
+
+
 def _reconcile_identity_if_diverged(args, project_path, local_id, cortex_outcome, output_format):
     """After register, detect local ≠ cortex-canonical project UUID.
 
-    Cortex is authority (David's directive): the register response carries
-    cortex's canonical id. If it differs from the local id, the identity has
-    diverged (the root cause of web's media blocker — first op to pass a raw
-    project_id cross-boundary surfaces it). Warn ALWAYS (closes the silent gap);
-    with --reconcile, rekey every local store to the cortex id.
+    Cortex is authority (David's directive): the canonical id comes from
+    ``GET /v1/projects/by-slug`` (roster/practice-context), NOT the register
+    response — the register endpoint can report a stale id that disagrees with
+    the surface blob-upload validates against (web's 258aa934 vs dc6298e2). If
+    the canonical differs from the local id, the identity has diverged (the root
+    cause of web's media blocker). Warn ALWAYS (closes the silent gap); with
+    --reconcile, rekey every local store to the canonical id.
 
     Returns a divergence dict for the result payload, or None when aligned.
     """
-    cortex_id = cortex_outcome.get("project_id")
+    cortex_id = _cortex_canonical_project_id(project_path, cortex_outcome)
     if not cortex_id or cortex_id == local_id or cortex_outcome.get("outcome") == "owner_conflict":
         return None
     info: dict[str, Any] = {"local_id": local_id, "cortex_id": cortex_id, "reconciled": False}

--- a/tests/test_project_identity_reconcile.py
+++ b/tests/test_project_identity_reconcile.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import sqlite3
 import types
 
+import pytest
 import yaml
 
 from empirica.cli.command_handlers.projects_commands import _reconcile_identity_if_diverged
@@ -21,6 +22,17 @@ from empirica.core.identity_migration import (
 
 OLD = "258aa934-a34b-4773-b1bb-96f429de6761"
 NEW = "dc6298e2-6262-44e6-a468-45cf63ef040e"
+
+
+@pytest.fixture(autouse=True)
+def _byslug_returns_none(monkeypatch):
+    """Default: by-slug can't resolve (no cortex) → _cortex_canonical_project_id
+    falls back to the register response. Keeps the existing divergence tests
+    network-free and preserving their register-response semantics. Individual
+    tests override this to exercise the by-slug-preferred path."""
+    import empirica.core.identity_migration as im
+
+    monkeypatch.setattr(im, "_make_cortex_slug_resolver", lambda *a, **k: lambda slug, tenant: None)
 
 
 def _make_local_db(path):
@@ -115,6 +127,27 @@ def test_reconcile_force_bypasses_open_transaction(tmp_path, monkeypatch):
     )
     assert out.get("blocked") is None
     assert out["reconciled"] is True
+
+
+def test_reconcile_prefers_by_slug_over_register_response(monkeypatch):
+    # Web's bug: cortex's register endpoint returns the LOCAL id (258aa934,
+    # "already_registered", diverged:false) so the old code declined to rekey —
+    # but roster/blob-upload/by-slug use dc6298e2. The fix must target by-slug,
+    # NOT the register response. Here register agrees with local (no divergence
+    # by register), but by-slug says NEW → divergence must still surface.
+    import empirica.core.identity_migration as im
+
+    monkeypatch.setattr(im, "_make_cortex_slug_resolver", lambda *a, **k: lambda slug, tenant: NEW)
+    out = _reconcile_identity_if_diverged(_args(False), "/p", OLD, {"project_id": OLD, "outcome": "skipped"}, "json")
+    assert out is not None  # register said no-divergence, by-slug caught it
+    assert out["cortex_id"] == NEW  # targets the by-slug canonical, not the register id
+
+
+def test_by_slug_falls_back_to_register_when_unresolvable():
+    # by-slug returns None (autouse fixture) → fall back to the register response.
+    from empirica.cli.command_handlers.projects_commands import _cortex_canonical_project_id
+
+    assert _cortex_canonical_project_id("/p", {"project_id": NEW}) == NEW
 
 
 def test_divergence_detection_aligned_returns_none():


### PR DESCRIPTION
## What web found (running 1.12.20's `--reconcile`)
It didn't fix their media blocker. `project-register --reconcile --force` → `diverged:false`, no rekey, `source-add --media` still fails "unknown project_id 258aa934".

**Root cause**: cortex's register endpoint disagrees with every other cortex surface about web's project_id:

| cortex surface | project_id |
|---|---|
| register endpoint (my #332 trusted this) | `258aa934` (already_registered, diverged:false) |
| roster / practice-context / by-slug | `dc6298e2` |
| blob-upload `POST /body` | only knows `dc6298e2` |
| tenants.db | only `dc6298e2` |

My #332 read the canonical id from the **register-POST response**, so it saw `diverged:false` and declined to rekey — while blob-upload requires `dc6298e2`.

## Fix
Cortex confirmed at #332 scoping that **`GET /v1/projects/by-slug` is authoritative** — I wired to the wrong endpoint. New `_cortex_canonical_project_id` resolves via by-slug **first** (`_make_cortex_slug_resolver`), falling back to the register response only when by-slug can't resolve. The divergence check now compares local vs the id blob-upload/roster actually validate against.

2 new tests (by-slug-preferred even when register agrees with local — the exact web scenario; fallback-to-register when unresolvable). 12 total green, ruff+pyright clean.

## Separate cortex bug (flagged, not blocking)
The register endpoint reporting a phantom `258aa934` that tenants.db doesn't have is a cortex-side data inconsistency — cortex should reconcile register's view with tenants.db for defense-in-depth. This empirica fix unblocks web regardless.

Fixes the media SER (`ser_a92b3a05`) DoD blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)