### PR TITLE
feat(sources): source-surface convergence — source-get raw-fix + shared→register + backfill

### DIFF
--- a/empirica/cli/command_handlers/artifact_log_commands.py
+++ b/empirica/cli/command_handlers/artifact_log_commands.py
@@ -2278,12 +2278,28 @@ def _fetch_source_raw(cortex_url: str, api_key: str, source_id: str, timeout: fl
     req = urllib.request.Request(
         f"{cortex_url}/v1/sources/{source_id}/raw",
         method="GET",
-        headers={"Authorization": f"Bearer {api_key}", "Accept": "application/json"},
+        headers={"Authorization": f"Bearer {api_key}"},
     )
     try:
         with urllib.request.urlopen(req, timeout=timeout) as resp:
-            raw = resp.read().decode("utf-8")
-            return resp.status, (json.loads(raw) if raw else {})
+            data = resp.read()
+            ctype = (resp.headers.get("Content-Type") or "").lower()
+            # The REST /raw endpoint serves the RAW BODY BYTES + an X-Body-Hash
+            # header (verified: image/png, 762KB). Only when it hands back an
+            # explicit JSON envelope do we parse the base64 {content,...} shape
+            # (the MCP-tool serving path). Branch on Content-Type so we never
+            # UTF-8/JSON-decode raw bytes (that crashed on the PNG magic 0x89).
+            if "application/json" in ctype:
+                try:
+                    return resp.status, (json.loads(data.decode("utf-8")) if data else {})
+                except (UnicodeDecodeError, json.JSONDecodeError):
+                    pass  # mislabeled — fall through to raw handling
+            return resp.status, {
+                "raw_bytes": data,
+                "mime": resp.headers.get("Content-Type"),
+                "body_hash": resp.headers.get("X-Body-Hash") or resp.headers.get("x-body-hash"),
+                "size_bytes": len(data),
+            }
     except urllib.error.HTTPError as e:
         try:
             body = json.loads(e.read().decode("utf-8"))
@@ -2460,7 +2476,10 @@ def handle_source_get_command(args):
             return 1
 
         status, body = _fetch_source_raw(cortex_url, api_key, source_id)
-        if status != 200 or not isinstance(body, dict) or "content" not in body:
+        # Accept either shape: raw-bytes response (REST /raw — the common path)
+        # or a base64 JSON envelope (MCP-tool serving path).
+        has_payload = isinstance(body, dict) and ("raw_bytes" in body or "content" in body)
+        if status != 200 or not has_payload:
             err = (body or {}).get("error", f"HTTP {status}")
             hint = ""
             if err == "not_retained":
@@ -2478,7 +2497,7 @@ def handle_source_get_command(args):
         # text-extracted source it hashes the flattened text, so verifying raw
         # bytes against it would spuriously fail. Fall back to content_hash
         # when body_hash is absent (older serve paths).
-        content = base64.b64decode(body["content"])
+        content = body["raw_bytes"] if "raw_bytes" in body else base64.b64decode(body["content"])
         expected = _normalize_hash(body.get("body_hash") or body.get("content_hash"))
         actual = hashlib.sha256(content).hexdigest()
         if expected and expected != actual:

--- a/empirica/cli/command_handlers/artifact_log_commands.py
+++ b/empirica/cli/command_handlers/artifact_log_commands.py
@@ -2201,6 +2201,13 @@ def handle_source_add_command(args):
         # cortex_uuid). Best-effort: a push failure leaves the local source
         # intact and reports the error — it never fails the whole add.
         media_push = _upload_media_source(args, media_path, source_id, identity, title, project_id, visibility)
+        # Convergence (Option B): a shared/public NON-media source registers in
+        # cortex's catalogue so it reaches the one surface the extension +
+        # sources-map read (not stranded in local epistemic_sources). --media
+        # already registers via the /body upsert, so skip it there.
+        _register_shared_source_if_applicable(
+            args, source_id, project_id, title, source_type, visibility, identity, media_path
+        )
         # --media exists to upload the blob — if that fails, the command failed,
         # even though the local source row was created. Surface it loudly
         # (ok:false + non-zero exit) rather than a silent ok:true footnote.
@@ -2370,6 +2377,106 @@ def _upsert_media_to_cortex(
         return {"pushed": False, "status": e.code, "error": err}
     except (urllib.error.URLError, OSError, TimeoutError) as e:
         return {"pushed": False, "error": f"{type(e).__name__}: {e}"}
+
+
+def _register_shared_source_if_applicable(
+    args, source_id, project_id, title, source_type, visibility, identity, media_path
+):
+    """Register a shared/public non-media source in cortex + stamp cortex_uuid.
+
+    Best-effort, never raises. No-op for local sources (stay local), for --media
+    sources (the /body upsert already registered them), and when cortex isn't
+    configured. On success, stamps cortex_uuid=source_id so the row is marked
+    cortex-registered (daemon resolves id OR cortex_uuid).
+    """
+    if media_path or visibility not in ("shared", "public"):
+        return None
+    from empirica.cli.command_handlers.projects_commands import _resolve_cortex_config
+
+    cortex_url, api_key = _resolve_cortex_config(args)
+    if not (cortex_url and api_key):
+        return None
+    try:
+        result = _register_source_in_cortex(
+            cortex_url, api_key, source_id, project_id, title, source_type, visibility, identity
+        )
+        if result.get("registered"):
+            from empirica.data.session_database import SessionDatabase
+
+            db = SessionDatabase()
+            db.conn.execute("UPDATE epistemic_sources SET cortex_uuid = ? WHERE id = ?", (source_id, source_id))
+            db.conn.commit()
+            db.close()
+        return result
+    except Exception as e:
+        return {"registered": False, "error": f"{type(e).__name__}: {e}"}
+
+
+def _register_source_in_cortex(
+    cortex_url,
+    api_key,
+    source_id,
+    project_id,
+    title,
+    source_type,
+    visibility,
+    identity,
+    timeout: float = 30.0,
+):
+    """POST /v1/sources/register — mint a shared source in cortex's catalogue.
+
+    The convergence path (SER ser_ad6397b7 Option B): a CLI source with
+    visibility=shared/public should reach the SAME cortex catalogue the
+    extension reads/writes, so it's discoverable everywhere — not stranded in
+    local epistemic_sources. Metadata-only mint (no body); --media uses the
+    /body upsert path instead. Cortex adopts our posted uuid.
+
+    Returns a status dict (never raises). On success: {registered:True, uuid,
+    adopted_status}. On failure: {registered:False, error}.
+    """
+    import urllib.error
+    import urllib.request
+
+    payload = {
+        "posted_uuid": source_id,
+        "project_id": project_id,
+        "title": title,
+        "source_type": source_type,
+        "visibility": visibility,
+    }
+    for k, col in (
+        ("content_hash", "content_hash"),
+        ("size_bytes", "size_bytes"),
+        ("canonical_path", "canonical_path"),
+        ("mime_type", "mime_type"),
+    ):
+        v = (identity or {}).get(col)
+        if v is not None:
+            payload[k] = v
+    req = urllib.request.Request(
+        f"{cortex_url}/v1/sources/register",
+        data=json.dumps(payload).encode("utf-8"),
+        method="POST",
+        headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            body = json.loads(resp.read().decode("utf-8") or "{}")
+            src = body.get("source") or {}
+            return {
+                "registered": True,
+                "status": resp.status,
+                "uuid": src.get("id") or source_id,
+                "adopted_status": body.get("adopted_status"),
+            }
+    except urllib.error.HTTPError as e:
+        try:
+            err = json.loads(e.read().decode("utf-8")).get("error", f"HTTP {e.code}")
+        except Exception:
+            err = f"HTTP {e.code}"
+        return {"registered": False, "status": e.code, "error": err}
+    except (urllib.error.URLError, OSError, TimeoutError) as e:
+        return {"registered": False, "error": f"{type(e).__name__}: {e}"}
 
 
 def _media_upload_failed(media_path, media_push) -> bool:

--- a/empirica/cli/command_handlers/sources_reconcile_commands.py
+++ b/empirica/cli/command_handlers/sources_reconcile_commands.py
@@ -98,6 +98,51 @@ def _maybe_push_small_body(cortex_url, api_key, cortex_uuid: str, row: dict | No
     return result
 
 
+def _run_register_shared_backfill(args, project_id, output) -> int:
+    """One-time convergence: push existing local-only shared/public sources up to
+    cortex's catalogue (POST /v1/sources/register) + stamp cortex_uuid.
+
+    For sources logged before `source-add` started auto-registering shared
+    sources — materializes them on the shared surface the extension + sources-map
+    read. Skips already-registered (cortex_uuid IS NOT NULL) rows.
+    """
+    from empirica.cli.command_handlers.artifact_log_commands import _register_source_in_cortex
+    from empirica.cli.command_handlers.projects_commands import _resolve_cortex_config
+    from empirica.data.session_database import SessionDatabase
+
+    cortex_url, api_key = _resolve_cortex_config(args)
+    if not (cortex_url and api_key):
+        _emit(output, {"ok": False, "error": "cortex not configured (set cortex.url + cortex.api_key)"})
+        return 1
+
+    db = SessionDatabase()
+    try:
+        cols = ("id", "title", "source_type", "visibility", "content_hash", "size_bytes", "canonical_path", "mime_type")
+        rows = db.conn.execute(
+            f"SELECT {', '.join(cols)} FROM epistemic_sources "
+            "WHERE project_id = ? AND COALESCE(archived, 0) = 0 "
+            "AND visibility IN ('shared', 'public') AND cortex_uuid IS NULL",
+            (project_id,),
+        ).fetchall()
+        registered, failed = 0, []
+        for raw in rows:
+            r = dict(raw) if hasattr(raw, "keys") else dict(zip(cols, raw, strict=False))
+            identity = {k: r.get(k) for k in ("content_hash", "size_bytes", "canonical_path", "mime_type")}
+            res = _register_source_in_cortex(
+                cortex_url, api_key, r["id"], project_id, r["title"], r["source_type"], r["visibility"], identity
+            )
+            if res.get("registered"):
+                db.conn.execute("UPDATE epistemic_sources SET cortex_uuid = ? WHERE id = ?", (r["id"], r["id"]))
+                registered += 1
+            else:
+                failed.append({"id": str(r["id"])[:8], "error": res.get("error")})
+        db.conn.commit()
+        _emit(output, {"ok": True, "candidates": len(rows), "registered": registered, "failed": failed})
+        return 0 if not failed else 2
+    finally:
+        db.close()
+
+
 def handle_sources_reconcile_command(args) -> int:
     from empirica.cli.command_handlers.projects_commands import (
         _resolve_cortex_config,
@@ -122,6 +167,9 @@ def handle_sources_reconcile_command(args) -> int:
             },
         )
         return 1
+
+    if getattr(args, "register_shared", False):
+        return _run_register_shared_backfill(args, project_id, output)
 
     db = SessionDatabase()
     try:

--- a/empirica/cli/command_handlers/sources_reconcile_commands.py
+++ b/empirica/cli/command_handlers/sources_reconcile_commands.py
@@ -133,10 +133,14 @@ def _run_register_shared_backfill(args, project_id, output) -> int:
             )
             if res.get("registered"):
                 db.conn.execute("UPDATE epistemic_sources SET cortex_uuid = ? WHERE id = ?", (r["id"], r["id"]))
+                # Commit per-source: the backfill is a long network loop that can
+                # be interrupted/reaped; a single end-of-loop commit would lose
+                # ALL progress on interruption. Per-source persist makes it
+                # resumable (re-run skips cortex_uuid IS NOT NULL rows).
+                db.conn.commit()
                 registered += 1
             else:
                 failed.append({"id": str(r["id"])[:8], "error": res.get("error")})
-        db.conn.commit()
         _emit(output, {"ok": True, "candidates": len(rows), "registered": registered, "failed": failed})
         return 0 if not failed else 2
     finally:

--- a/empirica/cli/parsers/checkpoint_parsers.py
+++ b/empirica/cli/parsers/checkpoint_parsers.py
@@ -1691,6 +1691,15 @@ def add_checkpoint_parsers(subparsers):
     sources_reconcile_parser.add_argument(
         "--api-key", help="Cortex API key (default: credentials.yaml / CORTEX_API_KEY env)"
     )
+    sources_reconcile_parser.add_argument(
+        "--register-shared",
+        action="store_true",
+        help=(
+            "One-time convergence: push existing local-only shared/public sources up to "
+            "cortex's catalogue (POST /v1/sources/register) so they materialize on the shared "
+            "surface. Skips already-registered rows. Runs standalone (ignores the reconcile flow)."
+        ),
+    )
     sources_reconcile_parser.add_argument("--output", choices=["human", "json"], default="human", help="Output format")
     sources_reconcile_parser.add_argument("--verbose", action="store_true", help="Verbose output")
 

--- a/tests/test_source_get.py
+++ b/tests/test_source_get.py
@@ -74,6 +74,23 @@ def test_happy_path_writes_and_verifies(tmp_path, monkeypatch, capsys):
     assert (tmp_path / "out.png").read_bytes() == PAYLOAD
 
 
+def test_raw_bytes_response_writes_and_verifies(tmp_path, monkeypatch):
+    # The REST /raw endpoint serves RAW BYTES + X-Body-Hash (not a base64
+    # envelope). _fetch_source_raw surfaces that as {raw_bytes, body_hash, mime};
+    # the handler must write the bytes directly + verify, never base64-decode.
+    _mock_fetch(monkeypatch, 200, {"raw_bytes": PAYLOAD, "body_hash": GOOD_HASH, "mime": "image/png"})
+    rc = handle_source_get_command(_args(tmp_path))
+    assert rc == 0
+    assert (tmp_path / "out.png").read_bytes() == PAYLOAD
+
+
+def test_raw_bytes_hash_mismatch_does_not_write(tmp_path, monkeypatch):
+    _mock_fetch(monkeypatch, 200, {"raw_bytes": PAYLOAD, "body_hash": "sha256:" + "0" * 64, "mime": "image/png"})
+    rc = handle_source_get_command(_args(tmp_path))
+    assert rc == 1
+    assert not (tmp_path / "out.png").exists()
+
+
 def test_bare_hash_also_verifies(tmp_path, monkeypatch):
     # cortex may return a bare hex hash (no algo prefix) — must still verify.
     _mock_fetch(

--- a/tests/test_source_register.py
+++ b/tests/test_source_register.py
@@ -1,0 +1,112 @@
+"""Shared-source → cortex catalogue registration (Option B convergence).
+
+`source-add --visibility=shared` for a non-media source now POSTs to
+`/v1/sources/register` so it reaches the one cortex catalogue the extension +
+sources-map read — instead of being stranded in local epistemic_sources. These
+tests mock urllib/config so they run offline and assert the register contract +
+the applicability gate.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+
+from empirica.cli.command_handlers.artifact_log_commands import (
+    _register_shared_source_if_applicable,
+    _register_source_in_cortex,
+)
+
+IDENTITY = {"content_hash": "sha256:abc", "size_bytes": 512, "canonical_path": None, "mime_type": "text/plain"}
+
+
+class _Resp:
+    def __init__(self, status, body):
+        self.status = status
+        self._b = json.dumps(body).encode()
+
+    def read(self):
+        return self._b
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+def _capture(monkeypatch, status=200, body=None):
+    cap = {}
+
+    def fake(req, timeout=None):
+        cap["url"] = req.full_url
+        cap["method"] = req.get_method()
+        cap["payload"] = json.loads(req.data.decode())
+        cap["ctype"] = {k.lower(): v for k, v in req.header_items()}.get("content-type")
+        return _Resp(status, body or {"source": {"id": "src-1"}, "adopted_status": "minted"})
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake)
+    return cap
+
+
+def test_register_posts_expected_body(monkeypatch):
+    cap = _capture(monkeypatch)
+    res = _register_source_in_cortex(
+        "https://cortex.example", "k", "src-1", "proj-9", "RFC 7519", "document", "shared", IDENTITY
+    )
+    assert res["registered"] is True
+    assert res["adopted_status"] == "minted"
+    assert cap["url"].endswith("/v1/sources/register")
+    assert cap["method"] == "POST"
+    assert cap["ctype"] == "application/json"
+    p = cap["payload"]
+    assert p["posted_uuid"] == "src-1"
+    assert p["project_id"] == "proj-9"
+    assert p["title"] == "RFC 7519"
+    assert p["source_type"] == "document"
+    assert p["visibility"] == "shared"
+    assert p["content_hash"] == "sha256:abc"
+    assert p["size_bytes"] == 512
+    assert "canonical_path" not in p  # None identity fields omitted
+
+
+def test_register_http_error_surfaces(monkeypatch):
+    import io
+
+    def fake(req, timeout=None):
+        raise urllib.error.HTTPError(req.full_url, 400, "Bad", {}, io.BytesIO(b'{"error":"bad_visibility"}'))
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake)
+    res = _register_source_in_cortex("https://c", "k", "s", "p", "t", "document", "shared", IDENTITY)
+    assert res["registered"] is False
+    assert res["error"] == "bad_visibility"
+
+
+def _args():
+    import types
+
+    return types.SimpleNamespace(cortex_url=None, api_key=None)
+
+
+def test_applicability_skips_local(monkeypatch):
+    called = {"n": 0}
+    monkeypatch.setattr(
+        "empirica.cli.command_handlers.artifact_log_commands._register_source_in_cortex",
+        lambda *a, **k: called.__setitem__("n", called["n"] + 1) or {"registered": True},
+    )
+    # local visibility → never registers
+    assert _register_shared_source_if_applicable(_args(), "s", "p", "t", "document", "local", IDENTITY, None) is None
+    # --media source → skip (the /body upsert already registered it)
+    assert (
+        _register_shared_source_if_applicable(_args(), "s", "p", "t", "document", "shared", IDENTITY, "/img.png")
+        is None
+    )
+    assert called["n"] == 0
+
+
+def test_applicability_skips_when_cortex_unconfigured(monkeypatch):
+    import empirica.cli.command_handlers.projects_commands as pc
+
+    monkeypatch.setattr(pc, "_resolve_cortex_config", lambda args: (None, None))
+    assert _register_shared_source_if_applicable(_args(), "s", "p", "t", "document", "shared", IDENTITY, None) is None


### PR DESCRIPTION
Iterates the 3 source-gardening items for 1.12.21.

## 1. `source-get` handles raw-bytes `/raw` responses (hotfix)
Web's e2e surfaced it: `GET /v1/sources/{id}/raw` serves **raw body bytes + X-Body-Hash header** (REST-verified, 762KB), but #330's `source-get` JSON/UTF-8-decoded it → crashed on the PNG magic `0x89`. Now `_fetch_source_raw` branches on Content-Type (JSON envelope vs raw bytes); the handler writes bytes directly + verifies `body_hash`.

## 2. Shared sources register in cortex's catalogue (Option B convergence)
The source surface was two disconnected populations (CLI local `epistemic_sources` vs extension cortex-cloud), so 61/62 'shared' sources were declared-shared-but-local-only. Now a shared/public **non-media** source POSTs to `/v1/sources/register` (cortex's canonical create, SER `ser_ad6397b7` Option B), reaching the one surface the extension + `sources-map` read. `--media` already registers via `/body`; local stays local. Stamps `cortex_uuid`.

## 3. `sources-reconcile --register-shared` backfill
One-time push of existing local-only shared sources up to cortex (**commits per-source** — reap-safe/resumable; a batch-end commit lost all progress when the long loop got reaped). Ran it on empirica: register calls 200-succeed.

## Known gap (cortex-side, flagged)
Register 200s (`adopted_status: existing/minted`) but cortex's `GET /v1/practices/{canonical}/sources` enumerate returns `count:0` — a cortex write/read scope mismatch (same class as web's project-id split). Flagged to cortex (`prop_ruenfmne`); empirica code is correct, but shared sources won't *surface* on enumerate until cortex reconciles the two endpoints.

24 source-suite tests green, ruff+pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)