### PR TITLE
feat(serve): self-heal on version drift (surface on /health, self-exit when supervised)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`empirica serve` self-heals on version drift.** After a pip/editable upgrade
+  the daemon kept serving stale code until manually restarted. It now detects the
+  drift (in-process `__version__` vs installed dist-info) and (1) **always surfaces
+  it on `GET /health`** as a `version_drift` field, so an operator, the extension, or
+  ecosystem-update can prompt a restart; and (2) **self-exits gracefully only when
+  supervised** (systemd `INVOCATION_ID`, or `EMPIRICA_SERVE_DRIFT_EXIT=1`) so the
+  supervisor relaunches against the new code. Serve is often standalone, so a blind
+  self-exit would kill an unsupervised daemon — the surface-always / exit-when-
+  supervised split is deliberate. The version compare is now shared with the mesh
+  listener via `core.version_drift`. Watch interval: `EMPIRICA_SERVE_DRIFT_CHECK_SEC`
+  (default 60s; `0` disables the watcher, `/health` still reports live).
+
 ## [1.12.21] — 2026-07-13
 
 ### Fixed

--- a/empirica/api/serve_app.py
+++ b/empirica/api/serve_app.py
@@ -17,6 +17,8 @@ API contract matches empirica-extension/src/api/empirica-client.ts:
 import json
 import logging
 import os
+import signal
+import threading
 from pathlib import Path
 
 from fastapi import Depends, FastAPI, HTTPException
@@ -58,6 +60,13 @@ class HealthResponse(BaseModel):
     # Registry of locally-known projects (v1.9.6+). Empty list when
     # ~/.empirica/registry.yaml is absent — single-project mode.
     known_projects: list[dict] = Field(default_factory=list)
+
+    # Version-drift self-heal (v1.12.22+). None when the in-process code matches
+    # the installed dist-info; otherwise {"in_process": "x", "installed": "y"} —
+    # a pip/editable upgrade landed under the running daemon and it's serving
+    # stale code. Surfaced here (always safe) so an operator / ecosystem-update /
+    # the extension can prompt a restart even when the daemon is unsupervised.
+    version_drift: dict | None = None
 
 
 class ArtifactPayload(BaseModel):
@@ -186,6 +195,87 @@ class ListenersResponse(BaseModel):
     listeners: list[ListenerRow] = Field(default_factory=list)
 
 
+# ── Version-drift self-heal ──────────────────────────────────────────
+# The serve daemon runs a blocking uvicorn loop; after a pip/editable upgrade
+# it serves stale code until restarted. Unlike the listener (which assumes a
+# supervisor and self-exits by default), serve is OFTEN standalone — a blind
+# self-exit would kill an unsupervised daemon permanently. So the policy is
+# inverted: always SURFACE drift on /health (safe), and only self-exit when a
+# relauncher is present. The pure compare is shared via core.version_drift.
+
+
+def _serve_drift_exit_enabled() -> bool:
+    """Whether serve should self-exit on drift (so a supervisor relaunches).
+
+    OFF by default — serve is often standalone and a self-exit would kill it
+    permanently. Enabled when a relauncher is present:
+      - EMPIRICA_SERVE_DRIFT_EXIT truthy — explicit opt-in, or
+      - INVOCATION_ID set — systemd runs units with it (launchd users set the
+        env var explicitly).
+    """
+    return bool(os.environ.get("EMPIRICA_SERVE_DRIFT_EXIT") or os.environ.get("INVOCATION_ID"))
+
+
+def _drift_watch_loop(interval_sec: float, stop: threading.Event) -> None:
+    """Background watch: on version drift, surface it (log) and — only when
+    supervised — gracefully self-exit (SIGTERM, so uvicorn drains in-flight
+    requests) for the supervisor to relaunch against new code.
+
+    Exits the loop after the first drift observed: /health re-checks live on
+    every request, so there's no value in re-warning every interval, and an
+    unsupervised daemon must keep serving (drift surfaced, restart is manual).
+    """
+    from empirica.core.version_drift import version_drift
+
+    while not stop.wait(interval_sec):
+        drift = version_drift()
+        if drift is None:
+            continue
+        in_proc, installed = drift
+        if _serve_drift_exit_enabled():
+            logger.warning(
+                "serve: version drift — in-process v%s, installed v%s; self-exiting for supervisor relaunch.",
+                in_proc,
+                installed,
+            )
+            os.kill(os.getpid(), signal.SIGTERM)
+        else:
+            logger.warning(
+                "serve: version drift — in-process v%s, installed v%s; unsupervised, surfaced on /health "
+                "(restart the daemon to pick up the new code).",
+                in_proc,
+                installed,
+            )
+        return
+
+
+def _make_serve_lifespan():
+    """Build the ASGI lifespan that runs the drift watcher for the app's life.
+
+    Interval from EMPIRICA_SERVE_DRIFT_CHECK_SEC (default 60s); <=0 disables the
+    watcher (the /health surfacing still works — it checks live per request)."""
+    from contextlib import asynccontextmanager
+
+    interval = float(os.environ.get("EMPIRICA_SERVE_DRIFT_CHECK_SEC", "60"))
+    stop = threading.Event()
+
+    @asynccontextmanager
+    async def lifespan(_app: FastAPI):
+        if interval > 0:
+            threading.Thread(
+                target=_drift_watch_loop,
+                args=(interval, stop),
+                daemon=True,
+                name="empirica-serve-drift",
+            ).start()
+        try:
+            yield
+        finally:
+            stop.set()
+
+    return lifespan
+
+
 # ── FastAPI App ──────────────────────────────────────────────────────
 
 
@@ -196,6 +286,7 @@ def create_serve_app() -> FastAPI:
         title="Empirica Serve",
         description="Local daemon for Chrome extension integration",
         version="0.1.0",
+        lifespan=_make_serve_lifespan(),
     )
 
     # CORS: Allow chrome-extension:// and localhost origins.
@@ -246,8 +337,10 @@ def create_serve_app() -> FastAPI:
         the locally-known project registry (v1.9.6+)."""
         from empirica.api.daemon_project import get_cached_daemon_project
         from empirica.api.registry import list_known_projects
+        from empirica.core.version_drift import version_drift
 
         project = get_cached_daemon_project() or {}
+        drift = version_drift()
         return HealthResponse(
             ollama=_check_ollama(),
             qdrant=_check_qdrant(),
@@ -257,6 +350,7 @@ def create_serve_app() -> FastAPI:
             project_slug=project.get("project_slug"),
             repo_url=project.get("repo_url"),
             known_projects=list_known_projects(),
+            version_drift=({"in_process": drift[0], "installed": drift[1]} if drift else None),
         )
 
     @app.post("/api/v1/artifacts/import", response_model=ArtifactImportResponse)

--- a/empirica/core/loop_scheduler/listener.py
+++ b/empirica/core/loop_scheduler/listener.py
@@ -45,7 +45,6 @@ Failure modes handled:
 from __future__ import annotations
 
 import base64
-import importlib.metadata
 import json
 import logging
 import os
@@ -102,13 +101,8 @@ class ListenerUpgraded(Exception):
 def _check_version_drift() -> tuple[str, str] | None:
     """Return (in_process_version, installed_version) on drift, None otherwise.
 
-    `empirica.__version__` is frozen at import time. `importlib.metadata.version`
-    re-reads the dist-info every call — pip overwrites that file on upgrade.
-    A mismatch means a pip upgrade happened under the running listener and
-    the in-memory code is stale.
-
-    Returns None on any error (missing dist-info, import failure) — drift
-    check is best-effort, must never crash the listener.
+    The pure compare lives in ``empirica.core.version_drift`` (shared with the
+    serve daemon). This wrapper layers the listener's self-heal policy on top.
 
     Opt-out via EMPIRICA_LISTENER_NO_DRIFT_EXIT: the upgrade-exit assumes a
     supervisor (systemd Restart=always / launchd KeepAlive) will relaunch
@@ -118,15 +112,9 @@ def _check_version_drift() -> tuple[str, str] | None:
     """
     if os.environ.get("EMPIRICA_LISTENER_NO_DRIFT_EXIT"):
         return None
-    try:
-        from empirica import __version__ as in_process
+    from empirica.core.version_drift import version_drift
 
-        installed = importlib.metadata.version("empirica")
-        if in_process != installed:
-            return (in_process, installed)
-    except Exception:
-        return None
-    return None
+    return version_drift()
 
 
 def _install_signal_handlers() -> None:

--- a/empirica/core/version_drift.py
+++ b/empirica/core/version_drift.py
@@ -1,0 +1,38 @@
+"""Shared version-drift detection for long-running empirica services.
+
+`empirica.__version__` is frozen at import time; `importlib.metadata.version`
+re-reads the dist-info every call, and pip overwrites that file on upgrade. A
+mismatch means a pip upgrade (or editable-install refresh) landed *under* a
+running process — the in-memory code is stale.
+
+Both the mesh listener (`loop_scheduler/listener.py`) and the serve daemon
+(`api/serve_app.py`) need this check, so the pure compare lives here as the
+single source of truth. Each caller layers its OWN self-heal policy on top:
+
+- The listener assumes a supervisor and self-exits by default (opt-OUT via
+  ``EMPIRICA_LISTENER_NO_DRIFT_EXIT``).
+- The serve daemon is often standalone, so it always SURFACES drift (on
+  ``GET /health``) and only self-exits when supervised (opt-IN — see
+  ``serve_app``). This module makes no exit decision; it only reports drift.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+
+
+def version_drift() -> tuple[str, str] | None:
+    """Return ``(in_process_version, installed_version)`` on drift, else None.
+
+    Best-effort: returns None on any error (missing dist-info, import failure)
+    so a drift check can never crash the calling service.
+    """
+    try:
+        from empirica import __version__ as in_process
+
+        installed = importlib.metadata.version("empirica")
+        if in_process != installed:
+            return (in_process, installed)
+    except Exception:
+        return None
+    return None

--- a/tests/test_loop_listener.py
+++ b/tests/test_loop_listener.py
@@ -516,44 +516,40 @@ def test_tee_failure_does_not_break_stdout_stream(monkeypatch, tmp_path):
 
 
 def test_check_version_drift_returns_none_when_match(monkeypatch):
-    """No drift when in-process __version__ matches dist-info version."""
+    """No drift when in-process __version__ matches dist-info version.
+
+    The pure compare moved to empirica.core.version_drift (shared with serve);
+    importlib.metadata is a module singleton, so patching it here reaches the
+    compare regardless of which module imports it."""
+    import importlib.metadata
+
     import empirica
 
     monkeypatch.setattr(empirica, "__version__", "9.9.9")
-    monkeypatch.setattr(
-        listener_mod.importlib.metadata,
-        "version",
-        lambda _: "9.9.9",
-    )
+    monkeypatch.setattr(importlib.metadata, "version", lambda _: "9.9.9")
     assert listener_mod._check_version_drift() is None
 
 
 def test_check_version_drift_returns_tuple_on_mismatch(monkeypatch):
     """Drift returns (in_process, installed) when pip upgraded under us."""
+    import importlib.metadata
+
     import empirica
 
     monkeypatch.setattr(empirica, "__version__", "1.9.10")
-    monkeypatch.setattr(
-        listener_mod.importlib.metadata,
-        "version",
-        lambda _: "1.9.11",
-    )
+    monkeypatch.setattr(importlib.metadata, "version", lambda _: "1.9.11")
     result = listener_mod._check_version_drift()
     assert result == ("1.9.10", "1.9.11")
 
 
 def test_check_version_drift_returns_none_on_metadata_error(monkeypatch):
     """Best-effort: metadata lookup failure must not crash the listener."""
-
-    def boom(_):
-        raise importlib_metadata_error()
-
     import importlib.metadata as md
 
-    def importlib_metadata_error():
-        return md.PackageNotFoundError("empirica")
+    def boom(_):
+        raise md.PackageNotFoundError("empirica")
 
-    monkeypatch.setattr(listener_mod.importlib.metadata, "version", boom)
+    monkeypatch.setattr(md, "version", boom)
     assert listener_mod._check_version_drift() is None
 
 
@@ -574,14 +570,12 @@ def test_listener_exits_cleanly_on_version_drift(monkeypatch):
         },
     )
     # Simulate pip upgrade landed: dist-info says newer than in-process
+    import importlib.metadata
+
     import empirica
 
     monkeypatch.setattr(empirica, "__version__", "1.9.10")
-    monkeypatch.setattr(
-        listener_mod.importlib.metadata,
-        "version",
-        lambda _: "1.9.11",
-    )
+    monkeypatch.setattr(importlib.metadata, "version", lambda _: "1.9.11")
 
     def fake_factory(url, headers):
         return _FakeProc([])  # immediate EOF triggers drift check

--- a/tests/test_serve_version_drift.py
+++ b/tests/test_serve_version_drift.py
@@ -1,0 +1,111 @@
+"""Serve daemon version-drift self-heal (mesh-support prop_rxhboler/prop_wuevnxev).
+
+The daemon serves stale code after a pip/editable upgrade until restarted. It
+now (1) always SURFACES drift on GET /health, and (2) self-exits ONLY when
+supervised — serve is often standalone, so a blind self-exit would kill an
+unsupervised daemon permanently. These tests mock the version compare + os.kill
+so they run offline and never actually signal the test process.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+import os
+import signal
+import threading
+
+import empirica.api.serve_app as sa
+import empirica.core.version_drift as vd
+
+
+# ── pure compare ─────────────────────────────────────────────────────
+def test_version_drift_none_when_matched(monkeypatch):
+    from empirica import __version__ as real
+
+    monkeypatch.setattr(importlib.metadata, "version", lambda _n: real)
+    assert vd.version_drift() is None
+
+
+def test_version_drift_tuple_when_mismatched(monkeypatch):
+    from empirica import __version__ as real
+
+    monkeypatch.setattr(importlib.metadata, "version", lambda _n: "0.0.0-test")
+    assert vd.version_drift() == (real, "0.0.0-test")
+
+
+def test_version_drift_none_on_error(monkeypatch):
+    def boom(_n):
+        raise importlib.metadata.PackageNotFoundError("empirica")
+
+    monkeypatch.setattr(importlib.metadata, "version", boom)
+    assert vd.version_drift() is None
+
+
+# ── supervised-exit guard ────────────────────────────────────────────
+def test_exit_disabled_by_default(monkeypatch):
+    monkeypatch.delenv("EMPIRICA_SERVE_DRIFT_EXIT", raising=False)
+    monkeypatch.delenv("INVOCATION_ID", raising=False)
+    assert sa._serve_drift_exit_enabled() is False
+
+
+def test_exit_enabled_explicit_optin(monkeypatch):
+    monkeypatch.delenv("INVOCATION_ID", raising=False)
+    monkeypatch.setenv("EMPIRICA_SERVE_DRIFT_EXIT", "1")
+    assert sa._serve_drift_exit_enabled() is True
+
+
+def test_exit_enabled_under_systemd(monkeypatch):
+    monkeypatch.delenv("EMPIRICA_SERVE_DRIFT_EXIT", raising=False)
+    monkeypatch.setenv("INVOCATION_ID", "abc123")  # systemd sets this
+    assert sa._serve_drift_exit_enabled() is True
+
+
+# ── watch loop decision ──────────────────────────────────────────────
+def test_watch_loop_self_exits_when_supervised(monkeypatch):
+    monkeypatch.setattr(vd, "version_drift", lambda: ("1.0.0", "1.0.1"))
+    monkeypatch.setattr(sa, "_serve_drift_exit_enabled", lambda: True)
+    killed = {}
+    monkeypatch.setattr(os, "kill", lambda pid, sig: killed.update(pid=pid, sig=sig))
+
+    sa._drift_watch_loop(0.001, threading.Event())
+    assert killed == {"pid": os.getpid(), "sig": signal.SIGTERM}
+
+
+def test_watch_loop_does_not_exit_when_unsupervised(monkeypatch):
+    monkeypatch.setattr(vd, "version_drift", lambda: ("1.0.0", "1.0.1"))
+    monkeypatch.setattr(sa, "_serve_drift_exit_enabled", lambda: False)
+    killed = {"n": 0}
+    monkeypatch.setattr(os, "kill", lambda *a: killed.__setitem__("n", killed["n"] + 1))
+
+    sa._drift_watch_loop(0.001, threading.Event())  # returns after surfacing
+    assert killed["n"] == 0
+
+
+def test_watch_loop_stops_on_event(monkeypatch):
+    # stop set before entry → loop never checks drift, returns immediately.
+    monkeypatch.setattr(vd, "version_drift", lambda: ("1.0.0", "1.0.1"))
+    monkeypatch.setattr(os, "kill", lambda *a: (_ for _ in ()).throw(AssertionError("must not exit")))
+    stop = threading.Event()
+    stop.set()
+    sa._drift_watch_loop(60.0, stop)  # returns fast, no kill
+
+
+# ── /health surfaces drift ───────────────────────────────────────────
+def test_health_surfaces_drift(monkeypatch):
+    from fastapi.testclient import TestClient
+
+    monkeypatch.setenv("EMPIRICA_SERVE_DRIFT_CHECK_SEC", "0")  # disable bg watcher
+    monkeypatch.setattr(vd, "version_drift", lambda: ("1.12.21", "1.12.22"))
+    with TestClient(sa.create_serve_app()) as client:
+        body = client.get("/api/v1/health").json()
+    assert body["version_drift"] == {"in_process": "1.12.21", "installed": "1.12.22"}
+
+
+def test_health_null_drift_when_matched(monkeypatch):
+    from fastapi.testclient import TestClient
+
+    monkeypatch.setenv("EMPIRICA_SERVE_DRIFT_CHECK_SEC", "0")
+    monkeypatch.setattr(vd, "version_drift", lambda: None)
+    with TestClient(sa.create_serve_app()) as client:
+        body = client.get("/api/v1/health").json()
+    assert body["version_drift"] is None


### PR DESCRIPTION
## What
`empirica serve` ran a blocking `uvicorn.run()` with no version-drift check — after a pip/editable upgrade (the fleet runs from develop) the daemon served **stale code until manually restarted**. The mesh listener already self-heals on drift; serve did not.

## Why the design is asymmetric with the listener
The listener assumes a supervisor and **self-exits by default** (opt-out). Serve is **often standalone** (not systemd-managed) — a blind self-exit would kill an unsupervised daemon *permanently*, which is worse than stale code. So serve inverts the policy:

1. **Always surface** drift on `GET /health` (new `version_drift` field) — safe in every case; an operator / the extension / ecosystem-update can prompt a restart.
2. **Self-exit only when supervised** — graceful `SIGTERM` (uvicorn drains in-flight) so the supervisor relaunches against new code. Detected via systemd `INVOCATION_ID`, or explicit `EMPIRICA_SERVE_DRIFT_EXIT=1`.

## Changes
- New `empirica/core/version_drift.py` — pure version compare, **shared** with the listener (DRY; listener now delegates, keeping its own opt-out policy).
- `serve_app.py` — `version_drift` on `HealthResponse`; drift watcher via ASGI **lifespan** (`EMPIRICA_SERVE_DRIFT_CHECK_SEC`, default 60s; `0` disables watcher, /health still live).
- Updated the 4 listener drift tests to patch `importlib.metadata` directly (the compare moved modules).

## Tests
- New `tests/test_serve_version_drift.py` (11): pure compare, supervised-guard combos, watch-loop decision (kills only when supervised), /health surfacing.
- Green locally: 249 serve tests, 60 listener/arm-off/drift tests, ruff + pyright clean.

Closes mesh-support **prop_rxhboler** (stale-daemon-after-upgrade) + **prop_wuevnxev** (serve self-relaunch on version drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)