### PR TITLE
feat(export): artifacts-generate --format okf — Open Knowledge Format bundle (knowledge-out interop)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **`artifacts-generate --format okf` — export the epistemic graph as an Open
+  Knowledge Format bundle.** OKF (Google Cloud, 2026) is a portable, vendor-neutral
+  markdown format: a directory of concept files with YAML frontmatter, linked by
+  markdown links. `--format okf` projects each empirica artifact (finding, decision,
+  unknown, dead-end, mistake, assumption, goal) into one OKF concept file with the
+  required `type` field plus `title`/`description`/`tags`/`timestamp`, and an
+  `index.md`. Empirica's calibration layer — impact, confidence, provenance — rides
+  as `empirica_*` frontmatter **extension keys** (OKF permits arbitrary keys), so
+  OKF-aware consumers get the calibrated graph and plain OKF consumers still get a
+  valid bundle. This is the "knowledge out" interop surface: the graph other agents
+  and tools can consume without an Empirica account. `--format audit` (the browsable
+  per-type trail) remains the default.
 - **`empirica serve` self-heals on version drift.** After a pip/editable upgrade
   the daemon kept serving stale code until manually restarted. It now detects the
   drift (in-process `__version__` vs installed dist-info) and (1) **always surfaces

--- a/empirica/cli/command_handlers/artifacts_commands.py
+++ b/empirica/cli/command_handlers/artifacts_commands.py
@@ -1187,6 +1187,7 @@ def handle_artifacts_generate_command(args):
         verbose = getattr(args, "verbose", False)
         output_format = getattr(args, "output", "text")
         output_dir = getattr(args, "output_dir", None)
+        bundle_format = getattr(args, "format", "audit")
 
         result = subprocess.run(["git", "rev-parse", "--show-toplevel"], capture_output=True, text=True)
         if result.returncode != 0:
@@ -1194,6 +1195,24 @@ def handle_artifacts_generate_command(args):
             return 1
 
         workspace_root = result.stdout.strip()
+
+        # OKF format: portable Open Knowledge Format bundle (one concept per
+        # artifact) instead of the browsable per-type audit trail.
+        if bundle_format == "okf":
+            from empirica.core.okf_export import generate_okf_bundle
+
+            okf = generate_okf_bundle(
+                workspace_root=workspace_root,
+                output_dir=output_dir,
+                verbose=(verbose or output_format != "json"),
+            )
+            if output_format == "json":
+                print(json.dumps(okf, indent=2))
+            else:
+                print(f"\n✅ OKF bundle: {okf['concept_count']} concepts in {okf['output_dir']}/")
+                for t, n in sorted(okf.get("by_type", {}).items()):
+                    print(f"   {t}: {n}")
+            return 0
 
         result = generate_artifacts(
             workspace_root=workspace_root,

--- a/empirica/cli/parsers/checkpoint_parsers.py
+++ b/empirica/cli/parsers/checkpoint_parsers.py
@@ -2444,6 +2444,15 @@ written to git notes (breadcrumbs ref) for audit trail.
     artifacts_parser = subparsers.add_parser(
         "artifacts-generate", help="Generate browsable .empirica/ markdown files from git notes"
     )
-    artifacts_parser.add_argument("--output-dir", help="Output directory (default: .empirica/)")
+    artifacts_parser.add_argument(
+        "--output-dir", help="Output directory (default: .empirica/, or .empirica/okf/ for OKF)"
+    )
     artifacts_parser.add_argument("--output", choices=["human", "json"], default="human", help="Output format")
+    artifacts_parser.add_argument(
+        "--format",
+        choices=["audit", "okf"],
+        default="audit",
+        help="Bundle format: 'audit' = browsable per-type markdown (default); "
+        "'okf' = Open Knowledge Format bundle (one concept per artifact, portable/AI-friendly)",
+    )
     artifacts_parser.add_argument("--verbose", action="store_true", help="Show detailed operation info")

--- a/empirica/core/okf_export.py
+++ b/empirica/core/okf_export.py
@@ -1,0 +1,256 @@
+"""Export empirica's epistemic graph as an Open Knowledge Format (OKF) bundle.
+
+OKF (Google Cloud, 2026 — github.com/GoogleCloudPlatform/knowledge-catalog) is a
+directory of markdown files with YAML frontmatter, one file per *concept*, linked
+by markdown links into a graph. The only REQUIRED frontmatter field is ``type``;
+``title``/``description``/``tags``/``timestamp`` are recommended, and producers
+MAY add any other keys. A concept's ID is its file path within the bundle minus
+the ``.md`` suffix; ``index.md`` is the reserved directory listing.
+
+This is the "knowledge out" half of Empirica's thesis: the epistemic graph other
+agents and tools can consume without an Empirica account — the file system is the
+API. What OKF deliberately omits — calibration, confidence, verification — stays
+Empirica's layer, and rides across as frontmatter EXTENSION keys
+(``empirica_impact``, ``empirica_confidence``, ``empirica_epistemic_source``, …):
+OKF-aware consumers that understand them get the calibrated graph; plain OKF
+consumers ignore the extra keys and still get a valid bundle.
+
+The reader half reuses ``artifacts_commands._read_all_notes`` (git notes are the
+canonical artifact store), so this module adds only the OKF *projection*.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+
+# Each empirica artifact namespace → its OKF concept `type` + how to pull the
+# headline text and body from the note payload. Namespaces absent from a repo
+# simply yield no concepts (the reader returns []), so this list is a superset.
+ARTIFACT_SPECS: tuple[dict[str, Any], ...] = (
+    {"ns": "findings", "type": "Finding", "title_keys": ("finding",), "body_keys": ("description",)},
+    {"ns": "unknowns", "type": "Unknown", "title_keys": ("unknown",), "body_keys": ("description", "resolved_by")},
+    {
+        "ns": "dead_ends",
+        "type": "Dead End",
+        "title_keys": ("approach",),
+        "body_keys": ("why_failed", "description"),
+    },
+    {
+        "ns": "mistakes",
+        "type": "Mistake",
+        "title_keys": ("mistake",),
+        "body_keys": ("why_wrong", "prevention", "description"),
+    },
+    {
+        "ns": "decisions",
+        "type": "Decision",
+        "title_keys": ("choice", "decision"),
+        "body_keys": ("rationale", "description"),
+    },
+    {
+        "ns": "assumptions",
+        "type": "Assumption",
+        "title_keys": ("assumption",),
+        "body_keys": ("description",),
+    },
+    {"ns": "goals", "type": "Goal", "title_keys": ("objective",), "body_keys": ("description",)},
+)
+
+# Frontmatter extension keys carrying empirica's calibration layer. Kept under an
+# ``empirica_`` prefix so they never collide with OKF's own recommended keys.
+_EXTENSION_KEYS = ("impact", "confidence", "epistemic_source", "domain", "reversibility", "ai_id", "session_id")
+
+
+def _iso(ts: Any) -> str | None:
+    """Best-effort ISO-8601 timestamp for the OKF ``timestamp`` field."""
+    if not ts:
+        return None
+    if isinstance(ts, (int, float)):
+        try:
+            return datetime.fromtimestamp(ts).isoformat()
+        except (ValueError, OSError):
+            return None
+    if isinstance(ts, str):
+        return ts
+    return None
+
+
+def _first(data: dict, keys: tuple[str, ...]) -> str:
+    """First non-empty value among keys (checking a nested ``*_data`` block too)."""
+    for k in keys:
+        v = data.get(k)
+        if v:
+            return str(v)
+    # goals nest the objective under goal_data; findings under finding_data.
+    for nested in ("goal_data", "finding_data"):
+        block = data.get(nested)
+        if isinstance(block, dict):
+            for k in keys:
+                v = block.get(k)
+                if v:
+                    return str(v)
+    return ""
+
+
+def _one_sentence(text: str, limit: int = 200) -> str:
+    """A single-sentence summary for the OKF ``description`` field."""
+    text = " ".join(str(text).split())
+    if not text:
+        return ""
+    cut = text[:limit]
+    dot = cut.find(". ")
+    if dot > 0:
+        return cut[: dot + 1]
+    return cut + ("…" if len(text) > limit else "")
+
+
+def build_concept(spec: dict[str, Any], artifact_id: str, data: dict) -> dict[str, Any] | None:
+    """Project one empirica artifact into an OKF concept dict, or None if it has
+    no headline text (nothing worth a concept file).
+
+    Returns ``{concept_id, filename, frontmatter, body, links}`` where ``links``
+    is a list of ``(label, target_concept_id)`` derived from the artifact's
+    parent + source references (OKF conveys relationships as markdown links)."""
+    title = _first(data, spec["title_keys"])
+    if not title:
+        return None
+
+    ns = spec["ns"]
+    concept_id = f"{ns}/{artifact_id}"
+
+    frontmatter: dict[str, Any] = {"type": spec["type"], "title": _one_sentence(title, 120)}
+    desc_source = _first(data, spec["body_keys"]) or title
+    description = _one_sentence(desc_source)
+    if description:
+        frontmatter["description"] = description
+    frontmatter["tags"] = ["empirica", ns]
+    ts = _iso(data.get("created_at") or data.get("created_timestamp") or data.get("timestamp"))
+    if ts:
+        frontmatter["timestamp"] = ts
+    frontmatter["empirica_id"] = artifact_id
+    for k in _EXTENSION_KEYS:
+        v = data.get(k)
+        if v is not None and v != "":
+            frontmatter[f"empirica_{k}"] = v
+
+    # Body: the full title text + each populated body field as its own section.
+    body_lines = [title.strip(), ""]
+    labels = {
+        "why_failed": "Why it failed",
+        "why_wrong": "Why it was wrong",
+        "prevention": "Prevention",
+        "rationale": "Rationale",
+        "resolved_by": "Resolved by",
+        "description": "Detail",
+    }
+    for k in spec["body_keys"]:
+        v = data.get(k)
+        if v:
+            body_lines += [f"## {labels.get(k, k.replace('_', ' ').title())}", "", str(v).strip(), ""]
+
+    # Links (OKF = markdown links, untyped edges). Parent artifact + sources.
+    links: list[tuple[str, str]] = []
+    parent_id = data.get("parent_id")
+    parent_type = data.get("parent_type")
+    if parent_id and parent_type:
+        links.append((f"parent {parent_type}", f"{parent_type}s/{parent_id}"))
+    for ref in data.get("source_refs") or data.get("sourced_from") or []:
+        if isinstance(ref, str):
+            links.append(("source", f"sources/{ref}"))
+
+    return {
+        "concept_id": concept_id,
+        "filename": f"{concept_id}.md",
+        "frontmatter": frontmatter,
+        "body": "\n".join(body_lines).rstrip() + "\n",
+        "links": links,
+    }
+
+
+def render_concept(concept: dict[str, Any]) -> str:
+    """Render a concept dict as an OKF markdown file (frontmatter + body + links)."""
+    fm = yaml.safe_dump(concept["frontmatter"], default_flow_style=False, sort_keys=False, allow_unicode=True)
+    parts = ["---", fm.rstrip(), "---", "", concept["body"].rstrip(), ""]
+    links = concept.get("links") or []
+    if links:
+        parts += ["## Related", ""]
+        for label, target in links:
+            parts.append(f"- {label}: [{target}](/{target}.md)")
+        parts.append("")
+    return "\n".join(parts).rstrip() + "\n"
+
+
+def render_index(concepts: list[dict[str, Any]]) -> str:
+    """The OKF-reserved ``index.md`` — a by-type directory listing of concepts."""
+    lines = [
+        "---",
+        "type: Index",
+        "title: Empirica Epistemic Graph",
+        f"description: {len(concepts)} concepts exported from an Empirica project's epistemic graph.",
+        "---",
+        "",
+        "# Empirica Epistemic Graph (OKF bundle)",
+        "",
+        "Exported by [Empirica](https://getempirica.com). Each concept is a markdown",
+        "file with YAML frontmatter; `empirica_*` keys carry the calibration layer",
+        "(impact, confidence, provenance) that plain OKF omits.",
+        "",
+    ]
+    by_type: dict[str, list[dict[str, Any]]] = {}
+    for c in concepts:
+        by_type.setdefault(c["frontmatter"]["type"], []).append(c)
+    for ctype in sorted(by_type):
+        items = by_type[ctype]
+        lines += [f"## {ctype} ({len(items)})", ""]
+        for c in sorted(items, key=lambda x: x["frontmatter"]["title"].lower()):
+            lines.append(f"- [{c['frontmatter']['title']}](/{c['concept_id']}.md)")
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def generate_okf_bundle(
+    workspace_root: str | Path, output_dir: str | Path | None = None, verbose: bool = False
+) -> dict:
+    """Read the project's git-notes artifacts and write an OKF bundle.
+
+    Returns ``{ok, output_dir, concept_count, by_type}``."""
+    from empirica.cli.command_handlers.artifacts_commands import _read_all_notes
+
+    workspace = str(workspace_root)
+    out = Path(output_dir) if output_dir else Path(workspace) / ".empirica" / "okf"
+    out.mkdir(parents=True, exist_ok=True)
+
+    concepts: list[dict[str, Any]] = []
+    for spec in ARTIFACT_SPECS:
+        for artifact_id, data in _read_all_notes(workspace, spec["ns"]):
+            if not isinstance(data, dict):
+                continue
+            concept = build_concept(spec, artifact_id, data)
+            if concept:
+                concepts.append(concept)
+
+    for concept in concepts:
+        target = out / concept["filename"]
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(render_concept(concept), encoding="utf-8")
+
+    (out / "index.md").write_text(render_index(concepts), encoding="utf-8")
+
+    by_type: dict[str, int] = {}
+    for c in concepts:
+        by_type[c["frontmatter"]["type"]] = by_type.get(c["frontmatter"]["type"], 0) + 1
+
+    if verbose:
+        print(f"OKF bundle: {len(concepts)} concepts → {out}/")
+        for t, n in sorted(by_type.items()):
+            print(f"  {t}: {n}")
+
+    return {"ok": True, "output_dir": str(out), "concept_count": len(concepts), "by_type": by_type}

--- a/tests/test_okf_export.py
+++ b/tests/test_okf_export.py
@@ -1,0 +1,135 @@
+"""OKF export — project the empirica epistemic graph into an Open Knowledge
+Format bundle (github.com/GoogleCloudPlatform/knowledge-catalog).
+
+These tests exercise the pure projection (build_concept / render_concept /
+render_index) directly, plus the bundle writer with the git-notes reader mocked,
+so they run offline. The load-bearing OKF invariants: every concept file has a
+`type` frontmatter field, concept IDs are the file path minus .md, relationships
+are markdown links, and empirica's calibration metadata rides as `empirica_*`
+extension keys (which a plain OKF consumer can ignore).
+"""
+
+from __future__ import annotations
+
+import yaml
+
+from empirica.core import okf_export as okf
+
+FINDING_SPEC = next(s for s in okf.ARTIFACT_SPECS if s["ns"] == "findings")
+DEADEND_SPEC = next(s for s in okf.ARTIFACT_SPECS if s["ns"] == "dead_ends")
+DECISION_SPEC = next(s for s in okf.ARTIFACT_SPECS if s["ns"] == "decisions")
+
+
+def _frontmatter(rendered: str) -> dict:
+    """Parse the YAML frontmatter block out of a rendered concept."""
+    assert rendered.startswith("---\n")
+    _, fm, _body = rendered.split("---\n", 2)
+    return yaml.safe_load(fm)
+
+
+# ── build_concept ────────────────────────────────────────────────────────────
+def test_build_concept_required_type_and_extensions():
+    c = okf.build_concept(
+        FINDING_SPEC,
+        "uuid-1",
+        {"finding": "JWTs are signed, not encrypted", "impact": 0.7, "created_at": 1_700_000_000, "ai_id": "empirica"},
+    )
+    assert c is not None
+    fm = c["frontmatter"]
+    assert fm["type"] == "Finding"  # OKF's one required field
+    assert fm["title"].startswith("JWTs are signed")
+    assert "empirica" in fm["tags"] and "findings" in fm["tags"]
+    assert fm["empirica_id"] == "uuid-1"
+    assert fm["empirica_impact"] == 0.7  # calibration rides as an extension key
+    assert fm["empirica_ai_id"] == "empirica"
+    assert c["concept_id"] == "findings/uuid-1"  # OKF concept-id = path minus .md
+    assert c["filename"] == "findings/uuid-1.md"
+
+
+def test_build_concept_none_when_no_headline():
+    assert okf.build_concept(FINDING_SPEC, "x", {"impact": 0.5}) is None
+
+
+def test_build_concept_body_sections_from_body_keys():
+    c = okf.build_concept(
+        DEADEND_SPEC,
+        "d1",
+        {"approach": "Tried passport.js", "why_failed": "Too heavy for JWT-only auth"},
+    )
+    assert "Tried passport.js" in c["body"]
+    assert "## Why it failed" in c["body"]
+    assert "Too heavy for JWT-only auth" in c["body"]
+
+
+def test_build_concept_parent_and_source_links():
+    c = okf.build_concept(
+        DECISION_SPEC,
+        "dec1",
+        {
+            "choice": "Use JWE",
+            "rationale": "JWS leaks at rest",
+            "parent_id": "f9",
+            "parent_type": "finding",
+            "source_refs": ["s1", "s2"],
+        },
+    )
+    targets = {t for _label, t in c["links"]}
+    assert "findings/f9" in targets  # parent_type pluralized → namespace
+    assert "sources/s1" in targets and "sources/s2" in targets
+
+
+# ── render_concept ───────────────────────────────────────────────────────────
+def test_render_concept_is_valid_frontmatter_and_links():
+    c = okf.build_concept(
+        DECISION_SPEC,
+        "dec1",
+        {"choice": "Use Redis", "rationale": "TTL primitives", "parent_id": "f1", "parent_type": "finding"},
+    )
+    rendered = okf.render_concept(c)
+    fm = _frontmatter(rendered)
+    assert fm["type"] == "Decision"
+    assert "## Related" in rendered
+    # OKF relationships are markdown links, bundle-relative (leading /).
+    assert "[findings/f1](/findings/f1.md)" in rendered
+
+
+def test_render_concept_no_related_section_without_links():
+    c = okf.build_concept(FINDING_SPEC, "f1", {"finding": "standalone fact"})
+    assert "## Related" not in okf.render_concept(c)
+
+
+# ── render_index ─────────────────────────────────────────────────────────────
+def test_render_index_groups_by_type_with_links():
+    concepts = [
+        okf.build_concept(FINDING_SPEC, "f1", {"finding": "alpha fact"}),
+        okf.build_concept(FINDING_SPEC, "f2", {"finding": "beta fact"}),
+        okf.build_concept(DECISION_SPEC, "d1", {"choice": "gamma choice", "rationale": "r"}),
+    ]
+    idx = okf.render_index(concepts)
+    assert idx.startswith("---\ntype: Index")
+    assert "## Finding (2)" in idx
+    assert "## Decision (1)" in idx
+    assert "(/findings/f1.md)" in idx
+
+
+# ── generate_okf_bundle (reader mocked) ──────────────────────────────────────
+def test_generate_bundle_writes_files_and_index(tmp_path, monkeypatch):
+    fake_notes = {
+        "findings": [("f1", {"finding": "A fact", "impact": 0.6})],
+        "decisions": [("d1", {"choice": "A choice", "rationale": "because"})],
+    }
+    monkeypatch.setattr(
+        "empirica.cli.command_handlers.artifacts_commands._read_all_notes",
+        lambda ws, ns: fake_notes.get(ns, []),
+    )
+    out = tmp_path / "okf"
+    res = okf.generate_okf_bundle(".", out)
+    assert res["ok"] is True
+    assert res["concept_count"] == 2
+    assert (out / "findings" / "f1.md").exists()
+    assert (out / "decisions" / "d1.md").exists()
+    assert (out / "index.md").exists()
+    # Every concept file carries a `type` (the one OKF-required field).
+    fm = _frontmatter((out / "findings" / "f1.md").read_text())
+    assert fm["type"] == "Finding"
+    assert res["by_type"] == {"Finding": 1, "Decision": 1}


### PR DESCRIPTION
## What
`empirica artifacts-generate --format okf` exports the project's epistemic graph as an [Open Knowledge Format](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md) bundle (Google Cloud, June 2026).

## Why
OKF is a portable, vendor-neutral markdown format — a directory of concept files with YAML frontmatter, linked by markdown links, requiring one field (`type`). Empirica's memory substrate is already ~OKF-shaped; this adds the explicit **projection** so the epistemic graph is consumable by any agent/tool **without an Empirica account** — the "knowledge out" half of the ecosystem thesis. It's also the concrete proof point behind outreach's OKF-convergence article.

The differentiator stays Empirica's: OKF omits calibration/verification, and this export carries it across as `empirica_*` frontmatter **extension keys** (OKF permits arbitrary keys) — OKF-aware consumers get the calibrated graph; plain OKF consumers ignore the extras and still get a valid bundle.

## How
- New `core/okf_export.py` — pure projection: each artifact (finding/decision/unknown/dead-end/mistake/assumption/goal) → one concept file (concept-id = path minus `.md`) with `type` + `title`/`description`/`tags`/`timestamp` + `empirica_*` extensions; `index.md` is the OKF-reserved directory listing. Relationships (`parent_id`/`parent_type`, `source_refs`) render as markdown links. Reuses `artifacts_commands._read_all_notes` (git notes = canonical store).
- CLI: `artifacts-generate` gains `--format {audit,okf}`; `audit` (browsable per-type trail) stays the default. Minimal new-verb footprint per the reduce-CLI directive.

## Verification
- Exports this repo's full graph: **6075 concepts** — validated all 6076 files parse as YAML and carry `type` (0 malformed).
- 8 unit tests (`tests/test_okf_export.py`): required `type`, concept-id convention, extension keys, markdown-link edges, index grouping, bundle writer. ruff + pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
