### PR TITLE
feat(gardening): --all-projects on goals-list + unknown-list (cross-project view)

### DIFF
--- a/empirica/cli/command_handlers/artifact_log_commands.py
+++ b/empirica/cli/command_handlers/artifact_log_commands.py
@@ -1399,19 +1399,24 @@ def handle_unknown_list_command(args):
         project_id = getattr(args, "project_id", None)
         show_resolved = getattr(args, "resolved", False)
         show_all = getattr(args, "show_all", False)
+        all_projects = getattr(args, "all_projects", False)  # cross-project (gardening)
         subject = getattr(args, "subject", None)
         limit = getattr(args, "limit", 30)
+        if all_projects and limit == 30:
+            limit = 2000  # cross-project sweep shouldn't silently truncate (explicit --limit wins)
         output_format = getattr(args, "output", "human")
 
         db = SessionDatabase()
         cursor = db.conn.cursor()
 
-        project_id = _resolve_project_id_from_context(cursor, session_id, project_id)
+        # --all-projects deliberately bypasses the active-project scope so the whole
+        # unknown graph is visible (stranded/divergent project_ids included).
+        project_id = None if all_projects else _resolve_project_id_from_context(cursor, session_id, project_id)
 
         # Build query
         query = """
             SELECT id, unknown, is_resolved, resolved_by, impact, subject,
-                   created_timestamp, resolved_timestamp, goal_id
+                   created_timestamp, resolved_timestamp, goal_id, project_id
             FROM project_unknowns
             WHERE 1=1
         """
@@ -1448,6 +1453,7 @@ def handle_unknown_list_command(args):
                 "created_at": row[6],
                 "resolved_at": row[7],
                 "goal_id": row[8],
+                "project_id": row[9],
             }
             for row in rows
         ]
@@ -1459,7 +1465,7 @@ def handle_unknown_list_command(args):
             filters_applied.append(f"project={project_id[:8]}...")
         if subject:
             filters_applied.append(f"subject={subject}")
-        filter_desc = ", ".join(filters_applied) if filters_applied else "all"
+        filter_desc = "ALL project_ids (cross-project)" if all_projects else (", ".join(filters_applied) or "all")
         status_desc = "all" if show_all else ("resolved" if show_resolved else "open")
 
         result = {

--- a/empirica/cli/command_handlers/goal_commands.py
+++ b/empirica/cli/command_handlers/goal_commands.py
@@ -1276,18 +1276,28 @@ def handle_goals_list_command(args):
         output_format = getattr(args, "output", "human")
         limit = getattr(args, "limit", 20) if hasattr(args, "limit") else 20
 
+        # --all: cross-project view (gardening). Bypasses the active-project scope so
+        # the whole goal graph is visible — the active-project filter otherwise hides
+        # goals stranded under other/divergent project_ids. Raise the default cap so a
+        # cross-project sweep isn't silently truncated at 20 (explicit --limit wins).
+        all_projects = getattr(args, "all_projects", False)
+        if all_projects and limit == 20:
+            limit = 2000
+
         db = SessionDatabase()
         cursor = db.conn.cursor()
 
-        # GOALS ARE PROJECT-SCOPED: Auto-derive project_id from context if not provided
-        project_id = _handle_goals_list_command_helper(cursor, project_id, session_id)
+        # GOALS ARE PROJECT-SCOPED: auto-derive project_id from context — unless --all,
+        # which deliberately shows every project's goals.
+        project_id = None if all_projects else _handle_goals_list_command_helper(cursor, project_id, session_id)
 
         # Build query based on filters
         base_query = """
             SELECT g.id, g.objective, g.status, g.is_completed,
                    g.created_timestamp, g.session_id, s.ai_id,
                    (SELECT COUNT(*) FROM subtasks WHERE goal_id = g.id) as total_subtasks,
-                   (SELECT COUNT(*) FROM subtasks WHERE goal_id = g.id AND status = 'completed') as completed_subtasks
+                   (SELECT COUNT(*) FROM subtasks WHERE goal_id = g.id AND status = 'completed') as completed_subtasks,
+                   g.project_id
             FROM goals g
             LEFT JOIN sessions s ON g.session_id = s.session_id
             WHERE 1=1
@@ -1359,6 +1369,7 @@ def handle_goals_list_command(args):
                     "ai_id": row[6],
                     "progress": f"{completed}/{total}",
                     "progress_pct": progress_pct,
+                    "project_id": row[9],
                 }
             )
 
@@ -1370,7 +1381,7 @@ def handle_goals_list_command(args):
             filters_applied.append(f"project={project_id[:8]}...")
         if ai_id:
             filters_applied.append(f"ai={ai_id}")
-        filter_desc = ", ".join(filters_applied) if filters_applied else "all"
+        filter_desc = "ALL project_ids (cross-project)" if all_projects else (", ".join(filters_applied) or "all")
         status_desc = "completed" if show_completed else "active"
 
         result = {
@@ -1398,35 +1409,40 @@ def handle_goals_list_command(args):
         if output_format == "json":
             # Return result - CLI core will print as JSON
             return result
-        else:
-            # Human format - print here and return None so CLI core doesn't double-print
-            print(f"{'=' * 70}")
-            if total_matching is not None and total_matching > len(goals):
-                print(
-                    f"🎯 GOALS ({status_desc.upper()}) - showing {len(goals)} of {total_matching} "
-                    f"[{filter_desc}] · raise --limit (now {limit}) to see more"
-                )
-            else:
-                print(f"🎯 GOALS ({status_desc.upper()}) - {len(goals)} found [{filter_desc}]")
-            print(f"{'=' * 70}")
-            print()
-
-            if not goals:
-                print("   (No goals found)")
-            else:
-                for i, g in enumerate(goals, 1):
-                    status_emoji = "✅" if g["is_completed"] else ("🔄" if g["progress"] != "0/0" else "⏳")
-                    print(f"{status_emoji} {i}. {g['objective'][:65]}")
-                    ai_info = f" | AI: {g['ai_id']}" if g["ai_id"] else ""
-                    print(
-                        f"   ID: {g['goal_id'][:8]}... | Progress: {g['progress']} ({g['progress_pct']:.0f}%){ai_info}"
-                    )
-                    print()
-
-            return None  # Prevents CLI core from printing dict items
+        # Human format - print here and return None so CLI core doesn't double-print
+        _print_goals_list_human(goals, status_desc, filter_desc, total_matching, limit, all_projects)
+        return None
 
     except Exception as e:
         handle_cli_error(e, "List goals", getattr(args, "verbose", False))
+
+
+def _print_goals_list_human(goals, status_desc, filter_desc, total_matching, limit, all_projects):
+    """Render goals-list human output. Extracted to keep the handler under the
+    complexity gate; `all_projects` adds a per-goal project column (gardening)."""
+    print(f"{'=' * 70}")
+    if total_matching is not None and total_matching > len(goals):
+        print(
+            f"🎯 GOALS ({status_desc.upper()}) - showing {len(goals)} of {total_matching} "
+            f"[{filter_desc}] · raise --limit (now {limit}) to see more"
+        )
+    else:
+        print(f"🎯 GOALS ({status_desc.upper()}) - {len(goals)} found [{filter_desc}]")
+    print(f"{'=' * 70}")
+    print()
+
+    if not goals:
+        print("   (No goals found)")
+        return
+    for i, g in enumerate(goals, 1):
+        status_emoji = "✅" if g["is_completed"] else ("🔄" if g["progress"] != "0/0" else "⏳")
+        print(f"{status_emoji} {i}. {g['objective'][:65]}")
+        ai_info = f" | AI: {g['ai_id']}" if g["ai_id"] else ""
+        proj_info = f" | proj: {(g['project_id'] or '(null)')[:8]}" if all_projects else ""
+        print(
+            f"   ID: {g['goal_id'][:8]}... | Progress: {g['progress']} ({g['progress_pct']:.0f}%){ai_info}{proj_info}"
+        )
+        print()
 
 
 def handle_goals_get_tasks_command(args):

--- a/empirica/cli/parsers/checkpoint_parsers.py
+++ b/empirica/cli/parsers/checkpoint_parsers.py
@@ -1194,6 +1194,12 @@ def add_checkpoint_parsers(subparsers):
     unknown_list_parser.add_argument("--session-id", required=False, help="Session UUID (to derive project)")
     unknown_list_parser.add_argument("--resolved", action="store_true", help="Show resolved unknowns instead of open")
     unknown_list_parser.add_argument("--all", action="store_true", dest="show_all", help="Show both open and resolved")
+    unknown_list_parser.add_argument(
+        "--all-projects",
+        action="store_true",
+        help="Cross-project view (gardening): list unknowns across ALL project_ids, not just the "
+        "active project. Adds a project column. Surfaces unknowns stranded under divergent project_ids.",
+    )
     unknown_list_parser.add_argument("--subject", help="Filter by subject/workstream")
     unknown_list_parser.add_argument("--limit", type=int, default=30, help="Max unknowns to show (default: 30)")
     unknown_list_parser.add_argument("--output", choices=["human", "json"], default="human", help="Output format")
@@ -2029,6 +2035,13 @@ Example:
     goals_list_parser.add_argument("--session-id", help="Derive project_id from session (convenience)")
     goals_list_parser.add_argument("--transaction-id", help="Filter by transaction ID (measurement scope)")
     goals_list_parser.add_argument("--project-id", help="Filter by project ID (structural scope)")
+    goals_list_parser.add_argument(
+        "--all-projects",
+        action="store_true",
+        help="Cross-project view (gardening): list goals across ALL project_ids, not just the "
+        "active project. Adds a project column and raises the default limit. Surfaces goals "
+        "stranded under other/divergent project_ids that the normal active-project scope hides.",
+    )
     goals_list_parser.add_argument("--scope-breadth-min", type=float, help="Filter by minimum breadth (0.0-1.0)")
     goals_list_parser.add_argument("--scope-breadth-max", type=float, help="Filter by maximum breadth (0.0-1.0)")
     goals_list_parser.add_argument("--scope-duration-min", type=float, help="Filter by minimum duration (0.0-1.0)")

--- a/tests/test_list_all_projects.py
+++ b/tests/test_list_all_projects.py
@@ -1,0 +1,103 @@
+"""`--all-projects` (gardening) on goals-list + unknown-list.
+
+The list verbs normally scope to the active project, which hides goals/unknowns
+stranded under other or divergent project_ids. `--all-projects` bypasses that
+scope so a gardening pass can see (and clean) the whole graph. These tests
+monkeypatch SessionDatabase with an in-memory 2-project DB and assert the flag
+crosses the project boundary while the default stays scoped.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+import types
+
+import empirica.cli.command_handlers.artifact_log_commands as alc
+import empirica.cli.command_handlers.goal_commands as gc
+
+
+class _FakeDB:
+    def __init__(self, conn):
+        self.conn = conn
+
+    def close(self):
+        pass
+
+
+def _goals_db():
+    conn = sqlite3.connect(":memory:")
+    conn.execute(
+        "CREATE TABLE goals (id TEXT PRIMARY KEY, objective TEXT, status TEXT, is_completed INT, "
+        "created_timestamp REAL, session_id TEXT, project_id TEXT, transaction_id TEXT, archived INT DEFAULT 0)"
+    )
+    conn.execute("CREATE TABLE sessions (session_id TEXT PRIMARY KEY, project_id TEXT, ai_id TEXT)")
+    conn.execute("CREATE TABLE subtasks (goal_id TEXT, status TEXT)")
+    now = time.time()
+    conn.execute("INSERT INTO sessions VALUES ('s1','projA','ai')")
+    conn.execute("INSERT INTO goals VALUES ('g-a','goal A','in_progress',0,?,'s1','projA',NULL,0)", (now,))
+    conn.execute("INSERT INTO goals VALUES ('g-b','goal B','in_progress',0,?,'s1','projB',NULL,0)", (now,))
+    conn.execute("INSERT INTO goals VALUES ('g-c','goal C','in_progress',0,?,'s1',NULL,NULL,0)", (now,))
+    conn.commit()
+    return conn
+
+
+def _unknowns_db():
+    conn = sqlite3.connect(":memory:")
+    conn.execute(
+        "CREATE TABLE project_unknowns (id TEXT PRIMARY KEY, unknown TEXT, is_resolved INT, resolved_by TEXT, "
+        "impact REAL, subject TEXT, created_timestamp REAL, resolved_timestamp REAL, goal_id TEXT, project_id TEXT)"
+    )
+    now = time.time()
+    conn.execute("INSERT INTO project_unknowns VALUES ('u-a','q A',0,NULL,0.5,NULL,?,NULL,NULL,'projA')", (now,))
+    conn.execute("INSERT INTO project_unknowns VALUES ('u-b','q B',0,NULL,0.5,NULL,?,NULL,NULL,'projB')", (now,))
+    conn.commit()
+    return conn
+
+
+def _args(**kw):
+    base = {"output": "json", "project_id": None, "session_id": None, "limit": 20}
+    base.update(kw)
+    return types.SimpleNamespace(**base)
+
+
+# The handlers import SessionDatabase locally, so patch it at the source module.
+_DB_TARGET = "empirica.data.session_database.SessionDatabase"
+
+
+# ── goals-list ───────────────────────────────────────────────────────────────
+def test_goals_all_projects_crosses_boundary(monkeypatch):
+    conn = _goals_db()
+    monkeypatch.setattr(_DB_TARGET, lambda: _FakeDB(conn))
+    # default: scoped to the derived/active project → NOT all three
+    scoped = gc.handle_goals_list_command(_args(all_projects=False, project_id="projA"))
+    assert isinstance(scoped, dict) and scoped["goals_count"] == 1
+    # --all-projects: every project_id, incl. the null-project orphan
+    allp = gc.handle_goals_list_command(_args(all_projects=True))
+    assert isinstance(allp, dict)
+    assert allp["goals_count"] == 3
+    goals = allp["goals"]
+    assert isinstance(goals, list)
+    assert {g["project_id"] for g in goals} == {"projA", "projB", None}
+
+
+def test_goals_all_projects_bumps_default_limit(monkeypatch):
+    conn = _goals_db()
+    monkeypatch.setattr(_DB_TARGET, lambda: _FakeDB(conn))
+    # limit stays the default 20 in args, but --all-projects raises it so a sweep isn't capped
+    res = gc.handle_goals_list_command(_args(all_projects=True, limit=20))
+    assert isinstance(res, dict) and res["limit"] == 2000
+
+
+# ── unknown-list ─────────────────────────────────────────────────────────────
+def test_unknowns_all_projects_crosses_boundary(monkeypatch):
+    conn = _unknowns_db()
+    monkeypatch.setattr(_DB_TARGET, lambda: _FakeDB(conn))
+    scoped = alc.handle_unknown_list_command(_args(all_projects=False, project_id="projA", limit=30))
+    assert isinstance(scoped, dict) and scoped["unknowns_count"] == 1
+    allp = alc.handle_unknown_list_command(_args(all_projects=True, limit=30))
+    assert isinstance(allp, dict)
+    assert allp["unknowns_count"] == 2
+    unk = allp["unknowns"]
+    assert isinstance(unk, list)
+    assert {u["project_id"] for u in unk} == {"projA", "projB"}


### PR DESCRIPTION
## What
`goals-list --all-projects` + `unknown-list --all-projects` — a gardening view that bypasses the active-project scope to show the whole artifact graph.

## Why
During the garden pass, the active-project scoping HID the true scale: `goals-list` showed 20 of 118 real open goals; unknowns undercounted (115 real across 12 project_ids). The scatter is a symptom of the project-identity divergence — artifacts stranded under other/divergent project_ids. Gardening needs to see across that filter (David's suggestion).

## How
- `--all-projects` drops the `AND project_id = ?` filter + skips project auto-derivation
- adds a project column to output; raises the default limit to 2000 so a cross-project sweep isn't silently truncated (explicit `--limit` still wins)
- named `--all-projects` (not `--all`) because unknown-list already has `--all` (open+resolved)
- extracted `_print_goals_list_human` to keep the handler under the C901 complexity gate

## Verified
Live: 66 goals / 115-across-12-projects unknowns surfaced (vs 20 / capped before). 3 handler tests (monkeypatched 2-project DB). ruff + pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)