### PR TITLE
fix(rebuild): --qdrant-only flag for safe Qdrant resync (no notes-import revert)

### DIFF
--- a/empirica/cli/command_handlers/sync_commands.py
+++ b/empirica/cli/command_handlers/sync_commands.py
@@ -941,6 +941,32 @@ def handle_rebuild_command(args):
         output_format = getattr(args, "output", "json")
         from_notes = getattr(args, "from_notes", True)
         qdrant = getattr(args, "qdrant", False)
+        qdrant_only = getattr(args, "qdrant_only", False)
+
+        # --qdrant-only: re-embed Qdrant from CURRENT SQLite WITHOUT the notes-import
+        # step. The default path (_rebuild_from_notes) reconstructs SQLite from git notes
+        # FIRST, which reverts any direct-SQL/bulk change not yet persisted to notes
+        # (e.g. an epistemic-garden bulk resolve). This flag is the safe resync path after
+        # such changes: it touches Qdrant only, never SQLite.
+        if qdrant_only:
+            from empirica.core.qdrant.vector_store import rebuild_qdrant_from_db
+
+            qdrant_result = rebuild_qdrant_from_db()
+            ok = bool(qdrant_result.get("ok"))
+            result = {
+                "ok": ok,
+                "qdrant": qdrant_result,
+                "message": "Rebuilt Qdrant from current SQLite (notes-import skipped)",
+            }
+            if output_format == "json":
+                print(json.dumps(result, indent=2, default=str))
+            else:
+                print(
+                    "✅ Rebuilt Qdrant from current SQLite (notes-import skipped)"
+                    if ok
+                    else f"❌ Qdrant rebuild failed: {qdrant_result.get('error', 'unknown')}"
+                )
+            return 0 if ok else 1
 
         if not from_notes:
             result = {"ok": False, "error": "Only --from-notes rebuild is currently supported"}

--- a/empirica/cli/parsers/checkpoint_parsers.py
+++ b/empirica/cli/parsers/checkpoint_parsers.py
@@ -2449,7 +2449,15 @@ written to git notes (breadcrumbs ref) for audit trail.
     rebuild_parser.add_argument(
         "--from-notes", action="store_true", default=True, help="Rebuild from git notes (default)"
     )
-    rebuild_parser.add_argument("--qdrant", action="store_true", help="Also rebuild Qdrant embeddings")
+    rebuild_parser.add_argument(
+        "--qdrant", action="store_true", help="Rebuild SQLite from notes FIRST, then also rebuild Qdrant"
+    )
+    rebuild_parser.add_argument(
+        "--qdrant-only",
+        action="store_true",
+        help="Re-embed Qdrant from CURRENT SQLite only, SKIPPING the notes->SQLite rebuild "
+        "(safe resync after direct-SQL/bulk changes not yet persisted to git notes)",
+    )
     rebuild_parser.add_argument("--output", choices=["human", "json"], default="json", help="Output format")
     rebuild_parser.add_argument("--verbose", action="store_true", help="Show detailed operation info")
 

--- a/tests/test_rebuild_qdrant_only.py
+++ b/tests/test_rebuild_qdrant_only.py
@@ -1,0 +1,72 @@
+"""`rebuild --qdrant-only` — the safe Qdrant resync path.
+
+The default `rebuild` (and `rebuild --qdrant`) reconstructs SQLite from git notes
+FIRST (_rebuild_from_notes), which reverts any direct-SQL/bulk change not yet
+persisted to notes — e.g. an epistemic-garden bulk resolve. `--qdrant-only`
+skips that notes-import step and only re-embeds Qdrant from the CURRENT SQLite,
+so it never touches (and never reverts) SQLite. These tests pin that contract:
+notes-import is skipped, Qdrant re-embed runs, and the exit code tracks success.
+"""
+
+from __future__ import annotations
+
+import types
+
+import empirica.cli.command_handlers.sync_commands as sc
+
+
+def _args(**kw):
+    base = {"output": "json", "from_notes": True, "qdrant": False, "qdrant_only": False, "verbose": False}
+    base.update(kw)
+    return types.SimpleNamespace(**base)
+
+
+# The handler imports rebuild_qdrant_from_db locally from vector_store at call time,
+# so patch it at the source module.
+_QDRANT_TARGET = "empirica.core.qdrant.vector_store.rebuild_qdrant_from_db"
+
+
+def test_qdrant_only_skips_notes_import(monkeypatch):
+    called = {"notes": 0, "qdrant": 0}
+
+    def fake_notes():
+        called["notes"] += 1
+        return {"findings": 0}
+
+    def fake_qdrant():
+        called["qdrant"] += 1
+        return {"ok": True, "total_projects": 2, "successful": 2}
+
+    monkeypatch.setattr(sc, "_rebuild_from_notes", fake_notes)
+    monkeypatch.setattr(_QDRANT_TARGET, fake_qdrant)
+
+    rc = sc.handle_rebuild_command(_args(qdrant_only=True))
+
+    assert rc == 0
+    assert called["notes"] == 0, "notes-import MUST be skipped under --qdrant-only (else it reverts direct-SQL)"
+    assert called["qdrant"] == 1, "Qdrant re-embed must run"
+
+
+def test_default_rebuild_still_imports_notes(monkeypatch):
+    """Regression guard: the default path (no --qdrant-only) must STILL import notes,
+    so --qdrant-only is a genuine opt-in and doesn't change existing behavior."""
+    called = {"notes": 0}
+
+    def fake_notes():
+        called["notes"] += 1
+        return {"findings": 0}
+
+    monkeypatch.setattr(sc, "_rebuild_from_notes", fake_notes)
+    sc.handle_rebuild_command(_args(qdrant_only=False, qdrant=False))
+    assert called["notes"] == 1
+
+
+def test_qdrant_only_propagates_failure(monkeypatch):
+    def fake_notes():  # must never be called
+        raise AssertionError("notes-import ran under --qdrant-only")
+
+    monkeypatch.setattr(sc, "_rebuild_from_notes", fake_notes)
+    monkeypatch.setattr(_QDRANT_TARGET, lambda: {"ok": False, "error": "Qdrant not available"})
+
+    rc = sc.handle_rebuild_command(_args(qdrant_only=True))
+    assert rc == 1


### PR DESCRIPTION
## Problem

`empirica rebuild --qdrant` unconditionally runs `_rebuild_from_notes()` **first** (`sync_commands.py`), reconstructing SQLite from git notes before the Qdrant re-embed. That **reverts any direct-SQL / bulk change not yet persisted to git notes** — e.g. an epistemic-garden bulk resolve — and then embeds the reverted state. There was no path to re-embed Qdrant from the *current* SQLite alone.

Surfaced during the epistemic-garden pass: the garden's bulk resolves (unknowns + findings) are direct-SQL (no bulk cross-project resolve verb exists yet), so running `rebuild --qdrant` to resync would have undone the whole garden. Caught before running it.

## Fix

Add `rebuild --qdrant-only`: skips the notes-import entirely and only calls `rebuild_qdrant_from_db()` (Qdrant ← current SQLite). It **never touches SQLite**, so it's the safe resync path after direct-SQL/bulk hygiene.

- Existing `--qdrant` behavior unchanged; its `--help` now documents the notes-first ordering.
- Also noted in passing: `--from-notes` is effectively dead (`store_true` + `default=True` can never be false) — left as-is, out of scope.

## Tests

`tests/test_rebuild_qdrant_only.py`:
- `--qdrant-only` skips `_rebuild_from_notes`, runs `rebuild_qdrant_from_db` → exit 0
- default path still imports notes (opt-in guard, no behavior change)
- Qdrant failure propagates exit 1

Follow-up (separate, planned goal): a bulk resolve-by-filter verb that writes SQLite + git notes + Qdrant atomically, so gardens are durable-by-construction rather than needing this resync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)