### PR TITLE
fix(daemon): hide archived sources + project cortex_uuid/visibility bridge keys

### DIFF
--- a/empirica/api/routes/artifacts.py
+++ b/empirica/api/routes/artifacts.py
@@ -471,18 +471,35 @@ def _list_decisions(db, project_id: str, limit: int) -> list[dict[str, Any]]:
     ]
 
 
-def _list_sources(db, project_id: str, limit: int) -> list[dict[str, Any]]:
+def _list_sources(db, project_id: str, limit: int, include_archived: bool = False) -> list[dict[str, Any]]:
     cursor = db.conn.cursor()
+    # Optional columns are schema-resilient (same pattern as _list_goals, David
+    # 2026-05-17): archived (hide by default), cortex_uuid + visibility (bridge keys
+    # to the cortex-cloud source population) were added by later migrations, so old
+    # project DBs may lack them.
+    has_archived = _table_has_column(db, "epistemic_sources", "archived")
+    has_cuuid = _table_has_column(db, "epistemic_sources", "cortex_uuid")
+    has_vis = _table_has_column(db, "epistemic_sources", "visibility")
+    extra_cols = ""
+    if has_cuuid:
+        extra_cols += ", cortex_uuid"
+    if has_vis:
+        extra_cols += ", visibility"
+    # Archived filter: previously absent, so a DELETE-archived source kept surfacing
+    # (indistinguishable from active) — the "archived sources still surface in
+    # extension" bug. Hidden by default; opt-in via include_archived.
+    archived_clause = "AND (archived IS NOT 1) " if (has_archived and not include_archived) else ""
     cursor.execute(
-        "SELECT id, title, source_url, source_type, description, confidence, "
-        "epistemic_layer, session_id, discovered_by_ai, discovered_at "
-        "FROM epistemic_sources WHERE project_id = ? "
-        "ORDER BY discovered_at DESC LIMIT ?",
+        f"SELECT id, title, source_url, source_type, description, confidence, "
+        f"epistemic_layer, session_id, discovered_by_ai, discovered_at{extra_cols} "
+        f"FROM epistemic_sources WHERE project_id = ? {archived_clause}"
+        f"ORDER BY discovered_at DESC LIMIT ?",
         (project_id, limit),
     )
     rows = cursor.fetchall()
-    return [
-        {
+    out: list[dict[str, Any]] = []
+    for r in rows:
+        d: dict[str, Any] = {
             "id": r[0],
             "type": "source",
             "title": r[1],
@@ -495,8 +512,15 @@ def _list_sources(db, project_id: str, limit: int) -> list[dict[str, Any]]:
             "discovered_by_ai": r[8],
             "created_at": _to_iso(r[9]),
         }
-        for r in rows
-    ]
+        idx = 10
+        if has_cuuid:
+            d["cortex_uuid"] = r[idx]
+            idx += 1
+        if has_vis:
+            d["visibility"] = r[idx]
+            idx += 1
+        out.append(d)
+    return out
 
 
 def _list_goals(db, project_id: str, status: str, limit: int) -> list[dict[str, Any]]:
@@ -673,9 +697,11 @@ async def list_sources(
     path: str | None = Query(None),
     entity: str | None = Query(None, description="Scope to an entity's linked artifacts (e.g. 'engagement')"),
     entity_id: str | None = Query(None, description="The entity id, required when 'entity' is set"),
+    include_archived: bool = Query(False, description="Include archived sources (hidden by default)"),
 ):
     """List sources. With ``entity=engagement&entity_id=``, scopes to that
-    engagement's linked sources via entity_artifacts (ratified boundary §4)."""
+    engagement's linked sources via entity_artifacts (ratified boundary §4).
+    Archived sources are hidden unless ``include_archived=true``."""
     allowed = _engagement_artifact_ids(entity, entity_id, "source")
     project = _resolve_project_dict(project_id, path)
     proj_pid = project.get("project_id")
@@ -683,7 +709,7 @@ async def list_sources(
         return {"sources": [], "project_id": None}
     db = _open_db_for(project)
     try:
-        rows = _list_sources(db, proj_pid, 500 if allowed is not None else limit)
+        rows = _list_sources(db, proj_pid, 500 if allowed is not None else limit, include_archived=include_archived)
         if allowed is not None:
             rows = [r for r in rows if r.get("id") in allowed][:limit]
         rows = _attach_related_to(db, rows)

--- a/tests/test_serve_artifacts_list.py
+++ b/tests/test_serve_artifacts_list.py
@@ -139,7 +139,10 @@ def _make_project_with_db(tmp_path: Path, project_id: str) -> Path:
             confidence REAL DEFAULT 0.5,
             epistemic_layer TEXT,
             discovered_by_ai TEXT,
-            discovered_at TIMESTAMP NOT NULL
+            discovered_at TIMESTAMP NOT NULL,
+            archived BOOLEAN DEFAULT 0,
+            cortex_uuid TEXT,
+            visibility TEXT
         );
         CREATE TABLE goals (
             id TEXT PRIMARY KEY,
@@ -606,6 +609,66 @@ def test_sources_returns_sources_with_url(tmp_path, monkeypatch, reset_daemon_ca
     assert len(sources) == 1
     assert sources[0]["title"] == "RFC 7519"
     assert sources[0]["url"] == "https://example.com/spec"
+
+
+def _insert_source(db_path: Path, project_id: str, title: str, **kwargs) -> str:
+    sid = str(uuid.uuid4())
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        "INSERT INTO epistemic_sources (id, project_id, source_type, source_url, title, "
+        "description, confidence, discovered_at, archived, cortex_uuid, visibility) "
+        "VALUES (?, ?, 'doc', 'https://x/y', ?, 'd', 0.9, datetime('now'), ?, ?, ?)",
+        (
+            sid,
+            project_id,
+            title,
+            1 if kwargs.get("archived") else 0,
+            kwargs.get("cortex_uuid"),
+            kwargs.get("visibility", "shared"),
+        ),
+    )
+    conn.commit()
+    conn.close()
+    return sid
+
+
+def test_sources_hides_archived_by_default(tmp_path, monkeypatch, reset_daemon_cache):
+    """Regression: archived sources leaked into GET /api/v1/sources because
+    _list_sources had no archived filter — extension kept showing archived rows
+    after a DELETE-archive. Archived must be hidden unless explicitly requested."""
+    pid = str(uuid.uuid4())
+    proj = _make_project_with_db(tmp_path, pid)
+    db_path = proj / ".empirica" / "sessions" / "sessions.db"
+
+    active = _insert_source(db_path, pid, "active source", archived=False)
+    _insert_source(db_path, pid, "archived source", archived=True)
+
+    with patch("empirica.utils.session_resolver.InstanceResolver.project_path", return_value=str(proj)):
+        monkeypatch.chdir(proj)
+        client = TestClient(create_serve_app())
+        default = client.get("/api/v1/sources").json()["sources"]
+        with_arch = client.get("/api/v1/sources?include_archived=true").json()["sources"]
+
+    assert {s["id"] for s in default} == {active}, "archived source must be hidden by default"
+    assert len(with_arch) == 2, "include_archived=true surfaces both"
+
+
+def test_sources_projects_bridge_keys(tmp_path, monkeypatch, reset_daemon_cache):
+    """cortex_uuid + visibility are projected so a consumer can reconcile a local
+    source against its cortex-cloud twin via the bridge key."""
+    pid = str(uuid.uuid4())
+    proj = _make_project_with_db(tmp_path, pid)
+    db_path = proj / ".empirica" / "sessions" / "sessions.db"
+
+    _insert_source(db_path, pid, "linked", cortex_uuid="ctx-abc", visibility="shared")
+
+    with patch("empirica.utils.session_resolver.InstanceResolver.project_path", return_value=str(proj)):
+        monkeypatch.chdir(proj)
+        client = TestClient(create_serve_app())
+        src = client.get("/api/v1/sources").json()["sources"][0]
+
+    assert src["cortex_uuid"] == "ctx-abc"
+    assert src["visibility"] == "shared"
 
 
 # ── Decisions / dead-ends / mistakes — smoke ──────────────────────────


### PR DESCRIPTION
## Problem (surfaced by the epistemic-garden G3 source-coherence pass)

`GET /api/v1/sources` (`_list_sources`) had two coherence gaps:

1. **Archived leak** — no `archived` filter and the `archived` flag wasn't even projected, so a `DELETE`-archived source kept surfacing indistinguishable from active. This is the "archived sources still surface in extension" bug seen after a DELETE-archive.
2. **No bridge key** — `cortex_uuid`/`visibility` weren't projected, so a consumer couldn't reconcile a local `epistemic_sources` row against its cortex-cloud twin. The two source populations (local CLI sources vs cortex-cloud shared_artifacts) looked disjoint.

## Fix

- Archived hidden by default; opt-in via `?include_archived=true`.
- Project `cortex_uuid` + `visibility` (the local↔cloud bridge keys).
- All three columns guarded by `_table_has_column` (schema-resilient on old project DBs), matching the established `_list_goals` description-guard pattern.

## Answers extension prop_wmmb37ty

The 6 shared_artifact fields (`deployment_url`/`provider`/`deployed_at`/`iterations`/`thumbnail_media_refs`) are **correctly absent** from the daemon projection — they're a cortex-cloud concept not present in local `epistemic_sources`. Extension reads them via cortex enumerate (`GET /v1/practices/{id}/sources`). The coherence bridge between the two populations is `cortex_uuid`, now projected. No daemon change needed for those 6 fields.

## Context

Source alignment is far healthier than the last assessment recorded: a prior finding said "only 1/62 sources carry cortex_uuid"; current state is **45/63 linked** — the reconcile / sync-when-small work (commit 95a655de2 + migration 050) already closed most of that gap.

## Tests

`tests/test_serve_artifacts_list.py`: archived hidden by default / surfaced with `include_archived`; bridge keys projected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)