### PR TITLE
fix(qdrant): per-project guard so one bad DB can't abort the whole rebuild

### DIFF
--- a/empirica/core/qdrant/rebuild.py
+++ b/empirica/core/qdrant/rebuild.py
@@ -387,8 +387,17 @@ def rebuild_qdrant_from_db() -> dict:
             results["failed"] += 1
             continue
 
-        # Step 2: Re-embed from DB
-        embed_result = _embed_project_from_db(project_id, db_path, project_root)
+        # Step 2: Re-embed from DB — per-project guard (mirrors the Step 1 guard
+        # above) so one bad/old-schema project DB can't crash the whole rebuild.
+        # _embed_project_from_db opens SessionDatabase (which runs migrations)
+        # before its own try block, so an old project DB missing a column (e.g.
+        # 'ai_id') would otherwise raise uncaught and abort every remaining project.
+        try:
+            embed_result = _embed_project_from_db(project_id, db_path, project_root)
+        except Exception as e:
+            results["projects"][project_name] = {"error": f"Embed failed: {e}"}
+            results["failed"] += 1
+            continue
 
         results["projects"][project_name] = {
             "collections": recreate_result,

--- a/tests/test_qdrant_rebuild_resilience.py
+++ b/tests/test_qdrant_rebuild_resilience.py
@@ -1,0 +1,51 @@
+"""rebuild_qdrant_from_db must survive one bad/old-schema project DB.
+
+The re-embed loop iterates every project in workspace.db. _embed_project_from_db
+opens SessionDatabase (runs migrations) before its own try block, so an old
+project DB missing a column (e.g. 'ai_id') raised uncaught and aborted every
+remaining project — including a healthy live one queued after it. This is the
+failure hit running `rebuild --qdrant-only` post-garden (the scatter left old
+project DBs registered). The per-project guard isolates the bad one.
+"""
+
+from __future__ import annotations
+
+import empirica.core.qdrant.rebuild as rb
+
+
+def _fake_projects(tmp_path):
+    projs = []
+    for i in range(2):
+        sessions = tmp_path / f"p{i}" / ".empirica" / "sessions"
+        sessions.mkdir(parents=True)
+        (sessions / "sessions.db").write_text("")  # existence check only
+        projs.append(
+            {"id": f"pid{i}", "name": f"proj{i}", "trajectory_path": str(sessions.parent)}
+        )
+    return projs
+
+
+def test_rebuild_survives_one_bad_project(tmp_path, monkeypatch):
+    projs = _fake_projects(tmp_path)
+    monkeypatch.setattr(rb, "_get_all_projects", lambda: projs)
+    monkeypatch.setattr("empirica.core.qdrant.connection._check_qdrant_available", lambda: True)
+    monkeypatch.setattr("empirica.core.qdrant.collections.recreate_project_collections", lambda pid: {"ok": True})
+    monkeypatch.setattr("empirica.core.qdrant.collections.recreate_global_collections", lambda: {"ok": True})
+
+    embedded: list[str] = []
+
+    def fake_embed(pid, db_path, root):
+        embedded.append(pid)
+        if pid == "pid0":
+            raise Exception("no such column: ai_id")  # old-schema project DB
+        return {"embedded": 5}
+
+    monkeypatch.setattr(rb, "_embed_project_from_db", fake_embed)
+
+    result = rb.rebuild_qdrant_from_db()  # must NOT raise
+
+    assert result["ok"] is True
+    assert "pid1" in embedded, "healthy project queued after the bad one must still be processed"
+    assert result["failed"] >= 1
+    assert result["successful"] >= 1
+    assert "Embed failed" in str(result["projects"]["proj0"]), "bad project's error is captured, not fatal"

--- a/tests/test_qdrant_rebuild_resilience.py
+++ b/tests/test_qdrant_rebuild_resilience.py
@@ -19,9 +19,7 @@ def _fake_projects(tmp_path):
         sessions = tmp_path / f"p{i}" / ".empirica" / "sessions"
         sessions.mkdir(parents=True)
         (sessions / "sessions.db").write_text("")  # existence check only
-        projs.append(
-            {"id": f"pid{i}", "name": f"proj{i}", "trajectory_path": str(sessions.parent)}
-        )
+        projs.append({"id": f"pid{i}", "name": f"proj{i}", "trajectory_path": str(sessions.parent)})
     return projs
 
 


### PR DESCRIPTION
## Problem

`rebuild_qdrant_from_db` iterates every project in `workspace.db`. Step 1 (`recreate_project_collections`) was already per-project `try/except`-guarded, but **Step 2 (`_embed_project_from_db`) was not** — and it opens `SessionDatabase` (which runs migrations) *before* its own `try` block. So an old-schema project DB missing a column (observed: `no such column: ai_id`) raised uncaught and aborted every remaining project, including a healthy live one queued after it.

Surfaced running `rebuild --qdrant-only` (PR #340) after the epistemic-garden pass: the identity-divergence scatter left stale/old project DBs registered in `workspace.db`, one of which crashed the entire re-embed. The live project's collections were unharmed (Qdrant is a rebuildable cache), but the resync never completed.

## Fix

Mirror Step 1's guard on Step 2: a bad project is isolated (logged as `failed`) and the rest still rebuild.

## Test

`tests/test_qdrant_rebuild_resilience.py`: a project whose embed raises doesn't abort a healthy project queued after it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)