### PR TITLE
feat(resolve-artifacts): filter-based bulk resolve (the gardening path)

### DIFF
--- a/empirica/cli/command_handlers/graph_commands.py
+++ b/empirica/cli/command_handlers/graph_commands.py
@@ -85,6 +85,17 @@ RESOLVE_ARTIFACTS_SCHEMA = {
             "superseded_by": "<optional finding UUID that replaced this one — finding type only>",
         },
     ],
+    "filter": {
+        "_doc": "OPTIONAL bulk-by-filter mode (instead of per-id `resolutions`). "
+        "Enumerates OPEN artifacts matching the filter and resolves them — the "
+        "gardening path, so no per-id enumeration / direct-SQL is needed. DRY-RUN by default.",
+        "type": "finding | unknown",
+        "project_id": "<optional — scope to one project_id (default: any in the active DB)>",
+        "older_than": "<optional ISO date e.g. 2026-05-01 — only artifacts created before it>",
+        "matching": "<optional SQL LIKE pattern on the artifact text, e.g. 'test %'>",
+    },
+    "resolution": "<resolution text, filter mode>",
+    "apply": "<optional bool, default false — false = DRY-RUN (report matched + sample, no mutation); true = resolve>",
 }
 
 DELETE_ARTIFACTS_SCHEMA = {
@@ -727,6 +738,80 @@ def handle_log_artifacts_command(args):
         return 1
 
 
+# B1: filterable bulk resolve — enumerate OPEN artifacts by (type, project_id,
+# older_than, matching) so a gardening pass resolves in one call instead of the
+# direct-SQL workaround. SQLite-only, matching the per-id resolve path; the
+# notes-durability question is separate (tracked as its own goal).
+_FILTER_TYPES = {
+    "finding": ("project_findings", "finding"),
+    "unknown": ("project_unknowns", "unknown"),
+}
+
+
+def _resolve_by_filter(db, filt: dict, resolution: str, apply: bool) -> dict:
+    """Enumerate OPEN artifacts matching ``filt`` and (optionally) resolve them.
+
+    Dry-run by default (``apply=False``): returns matched count + a 10-row sample
+    without mutating — mirrors goals-prune's apply/dry_run safety. ``apply=True``
+    resolves via the same ``is_resolved`` flag the per-id path uses.
+    """
+    import time
+    from datetime import datetime
+
+    atype = filt.get("type")
+    if atype not in _FILTER_TYPES:
+        return {"ok": False, "error": f"filter.type must be one of {sorted(_FILTER_TYPES)}"}
+    table, textcol = _FILTER_TYPES[atype]
+
+    where = ["(is_resolved IS NOT 1)"]
+    params: list = []
+    if filt.get("project_id"):
+        where.append("project_id = ?")
+        params.append(filt["project_id"])
+    if filt.get("older_than"):
+        try:
+            cutoff = datetime.fromisoformat(str(filt["older_than"])).timestamp()
+        except ValueError:
+            return {"ok": False, "error": f"filter.older_than must be an ISO date, got {filt['older_than']!r}"}
+        where.append("created_timestamp < ?")
+        params.append(cutoff)
+    if filt.get("matching"):
+        where.append(f"{textcol} LIKE ?")
+        params.append(str(filt["matching"]))
+    clause = " AND ".join(where)
+
+    cur = db.conn.cursor()
+    cur.execute(
+        f"SELECT id, substr({textcol}, 1, 80) FROM {table} WHERE {clause} ORDER BY created_timestamp LIMIT 5000",
+        params,
+    )
+    rows = cur.fetchall()
+    sample = [{"id": r[0], "text": r[1]} for r in rows[:10]]
+
+    if not apply:
+        return {
+            "ok": True,
+            "dry_run": True,
+            "matched": len(rows),
+            "sample": sample,
+            "hint": 'dry-run — add "apply": true to resolve these',
+        }
+
+    now = time.time()
+    if atype == "finding":
+        cur.execute(
+            f"UPDATE {table} SET is_resolved = 1, resolution = ?, resolved_timestamp = ? WHERE {clause}",
+            [resolution, now, *params],
+        )
+    else:  # unknown
+        cur.execute(
+            f"UPDATE {table} SET is_resolved = 1, resolved_by = ?, resolved_timestamp = ? WHERE {clause}",
+            [resolution, now, *params],
+        )
+    db.conn.commit()
+    return {"ok": True, "dry_run": False, "resolved": cur.rowcount, "sample": sample}
+
+
 def handle_resolve_artifacts_command(args):  # noqa: C901 — batch dispatcher fan-out
     """Handle resolve-artifacts command: batch resolution of open artifacts."""
     if getattr(args, "schema", False):
@@ -754,6 +839,21 @@ def handle_resolve_artifacts_command(args):  # noqa: C901 — batch dispatcher f
         if not db.conn:
             print(json.dumps({"ok": False, "error": "No database connection"}))
             return 1
+
+        # B1: filter-based bulk resolve (instead of per-id `resolutions`).
+        # Enumerates OPEN artifacts matching the filter and resolves them;
+        # dry-run by default. Replaces the direct-SQL a garden falls back to.
+        filt = resolutions.get("filter")
+        if filt:
+            fres = _resolve_by_filter(
+                db,
+                filt,
+                resolutions.get("resolution", resolutions.get("resolved_by", "bulk resolve by filter")),
+                bool(resolutions.get("apply", False)),
+            )
+            db.close()
+            print(json.dumps(fres, indent=2))
+            return 0 if fres.get("ok") else 1
 
         resolved_count = 0
         resolution_errors: list[str] = []

--- a/tests/test_resolve_by_filter.py
+++ b/tests/test_resolve_by_filter.py
@@ -1,0 +1,117 @@
+"""B1: filter-based bulk resolve in resolve-artifacts (_resolve_by_filter).
+
+The gardening path — resolve OPEN findings/unknowns by (project_id, older_than,
+matching) in one call instead of enumerating ids / hand-writing SQL. Dry-run by
+default; apply=True commits. SQLite-only, matching the per-id resolve path.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+import types
+
+from empirica.cli.command_handlers.graph_commands import _resolve_by_filter
+
+
+def _db():
+    conn = sqlite3.connect(":memory:")
+    conn.execute(
+        "CREATE TABLE project_findings (id TEXT PRIMARY KEY, project_id TEXT, finding TEXT, "
+        "created_timestamp REAL, is_resolved INT DEFAULT 0, resolution TEXT, resolved_timestamp REAL)"
+    )
+    conn.execute(
+        "CREATE TABLE project_unknowns (id TEXT PRIMARY KEY, project_id TEXT, unknown TEXT, "
+        "created_timestamp REAL, is_resolved INT DEFAULT 0, resolved_by TEXT, resolved_timestamp REAL)"
+    )
+    return types.SimpleNamespace(conn=conn)
+
+
+def _add_finding(db, fid, text, project="p1", ts=None, resolved=0):
+    db.conn.execute(
+        "INSERT INTO project_findings (id, project_id, finding, created_timestamp, is_resolved) VALUES (?,?,?,?,?)",
+        (fid, project, text, ts if ts is not None else time.time(), resolved),
+    )
+    db.conn.commit()
+
+
+def _open_count(db, table="project_findings"):
+    return db.conn.execute(f"SELECT COUNT(*) FROM {table} WHERE is_resolved IS NOT 1").fetchone()[0]
+
+
+# ── dry-run ───────────────────────────────────────────────────────────────────
+def test_dry_run_reports_matches_without_mutating():
+    db = _db()
+    _add_finding(db, "f1", "real finding")
+    _add_finding(db, "f2", "test noise")
+    res = _resolve_by_filter(db, {"type": "finding", "matching": "test %"}, "garden", apply=False)
+    assert res["ok"] and res["dry_run"] is True
+    assert res["matched"] == 1
+    assert _open_count(db) == 2, "dry-run must not mutate"
+
+
+def test_apply_resolves_matching_only():
+    db = _db()
+    _add_finding(db, "f1", "real finding")
+    _add_finding(db, "f2", "test noise")
+    res = _resolve_by_filter(db, {"type": "finding", "matching": "test %"}, "garden hygiene", apply=True)
+    assert res["ok"] and res["dry_run"] is False
+    assert res["resolved"] == 1
+    row = db.conn.execute("SELECT is_resolved, resolution FROM project_findings WHERE id='f2'").fetchone()
+    assert row[0] == 1 and row[1] == "garden hygiene"
+    assert db.conn.execute("SELECT is_resolved FROM project_findings WHERE id='f1'").fetchone()[0] == 0
+
+
+def test_older_than_filter():
+    db = _db()
+    old = time.mktime(time.strptime("2026-01-01", "%Y-%m-%d"))
+    new = time.mktime(time.strptime("2026-06-01", "%Y-%m-%d"))
+    _add_finding(db, "f1", "old", ts=old)
+    _add_finding(db, "f2", "new", ts=new)
+    res = _resolve_by_filter(db, {"type": "finding", "older_than": "2026-05-01"}, "stale", apply=True)
+    assert res["resolved"] == 1
+    assert db.conn.execute("SELECT is_resolved FROM project_findings WHERE id='f1'").fetchone()[0] == 1
+    assert db.conn.execute("SELECT is_resolved FROM project_findings WHERE id='f2'").fetchone()[0] == 0
+
+
+def test_project_id_filter_scopes():
+    db = _db()
+    _add_finding(db, "f1", "mine", project="p1")
+    _add_finding(db, "f2", "theirs", project="p2")
+    res = _resolve_by_filter(db, {"type": "finding", "project_id": "p2"}, "consolidate", apply=True)
+    assert res["resolved"] == 1
+    assert db.conn.execute("SELECT is_resolved FROM project_findings WHERE id='f1'").fetchone()[0] == 0
+
+
+def test_already_resolved_excluded():
+    db = _db()
+    _add_finding(db, "f1", "open")
+    _add_finding(db, "f2", "already", resolved=1)
+    res = _resolve_by_filter(db, {"type": "finding"}, "x", apply=False)
+    assert res["matched"] == 1  # only the open one
+
+
+def test_unknown_type_uses_resolved_by_column():
+    db = _db()
+    db.conn.execute(
+        "INSERT INTO project_unknowns (id, project_id, unknown, created_timestamp, is_resolved) VALUES "
+        "('u1','p1','stale q',?,0)",
+        (time.time(),),
+    )
+    db.conn.commit()
+    res = _resolve_by_filter(db, {"type": "unknown", "matching": "stale%"}, "answered", apply=True)
+    assert res["resolved"] == 1
+    row = db.conn.execute("SELECT is_resolved, resolved_by FROM project_unknowns WHERE id='u1'").fetchone()
+    assert row[0] == 1 and row[1] == "answered"
+
+
+def test_bad_type_errors():
+    db = _db()
+    res = _resolve_by_filter(db, {"type": "goal"}, "x", apply=True)
+    assert res["ok"] is False and "filter.type" in res["error"]
+
+
+def test_bad_older_than_errors():
+    db = _db()
+    res = _resolve_by_filter(db, {"type": "finding", "older_than": "not-a-date"}, "x", apply=True)
+    assert res["ok"] is False and "older_than" in res["error"]


### PR DESCRIPTION
## Why

`resolve-artifacts` required explicit artifact ids and had no `--older-than`/`--matching` bulk mode (unlike `goals-prune`/`goals-archive`). So the epistemic-garden pass fell back to hand-written SQL — error-prone, and *not* the mechanism to teach other practices when we propagate the gardening pattern. This is the safe verb the shared lesson will point to.

## What

Optional `filter` block on `resolve-artifacts` (extends the existing batch verb — no new verb, per the reduce-CLI-surface direction):

```json
{"filter": {"type": "finding|unknown", "project_id": "...", "older_than": "2026-05-01", "matching": "test %"},
 "resolution": "garden hygiene", "apply": false}
```

- Enumerates **OPEN** matching artifacts and resolves them.
- **DRY-RUN by default** — reports `matched` + a 10-row `sample`, no mutation; `apply: true` commits. Mirrors `goals-prune`'s apply/dry_run safety.
- `apply` lives in the JSON body → **no parser change**.
- **SQLite-only**, matching the existing per-id resolve path. (Notes-durability of resolution — so a from-notes rebuild / multi-device sync preserves it — is a separate, deliberately-scoped goal.)

## Tests

`tests/test_resolve_by_filter.py`: dry-run vs apply, `older_than`/`matching`/`project_id` filters, already-resolved excluded, `unknown` uses `resolved_by`, bad type/date error. Plus CLI smoke (dry-run + `--schema` show the filter block).

🤖 Generated with [Claude Code](https://claude.com/claude-code)