### PR TITLE
fix(entities): close org-mint registry-without-detail orphan gap

### DIFF
--- a/empirica/cli/command_handlers/entity_commands.py
+++ b/empirica/cli/command_handlers/entity_commands.py
@@ -365,6 +365,21 @@ def mint_entity(
         # engagement-create (written to the sidecar after this mint); the stable
         # point id makes that a clean idempotent enrichment.
         _embed_entity_row(entity_type, eid, name, description, metadata)
+        # Write the organizations-table detail row alongside the registry entry
+        # to close the registry-without-detail orphan gap (SER ser_5aeddc9d).
+        # Org-specific fields (domain/industry/org_type) are extracted from
+        # extra_metadata — fleet members pass --metadata '{...}' on the CLI.
+        if entity_type == "organization":
+            meta = extra_metadata or {}
+            repo.upsert_organization_detail(
+                org_id=eid,
+                name=name,
+                domain=meta.get("domain"),
+                industry=meta.get("industry"),
+                org_type=meta.get("org_type", "prospect"),
+                description=description,
+                tags=json.dumps(meta["tags"]) if isinstance(meta.get("tags"), list) else None,
+            )
         return {"ok": True, "entity_id": eid, "created": created, "matched_by": None if created else "id"}
 
     if repo is not None:

--- a/empirica/data/repositories/workspace_db.py
+++ b/empirica/data/repositories/workspace_db.py
@@ -922,6 +922,39 @@ class WorkspaceDBRepository(BaseRepository):
         )
         self.commit()
 
+    def upsert_organization_detail(
+        self,
+        org_id: str,
+        name: str,
+        domain: str | None = None,
+        industry: str | None = None,
+        org_type: str | None = None,
+        description: str | None = None,
+        tags: str | None = None,
+    ) -> None:
+        """Insert or update an organizations-table detail row alongside the
+        entity_registry entry. Idempotent — ON CONFLICT(org_id) DO UPDATE.
+        The ``tags`` field is a raw JSON array string (None = skip). Called
+        from ``mint_entity`` when entity_type == ``organization`` to close the
+        registry-without-detail orphan gap (SER ser_5aeddc9d).
+        """
+        now = time.time()
+        self._execute(
+            """INSERT INTO organizations
+               (org_id, name, domain, industry, org_type, description, tags, created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+               ON CONFLICT(org_id) DO UPDATE SET
+                   name = excluded.name,
+                   domain = excluded.domain,
+                   industry = excluded.industry,
+                   org_type = excluded.org_type,
+                   description = excluded.description,
+                   tags = excluded.tags,
+                   updated_at = excluded.updated_at""",
+            (org_id, name, domain, industry, org_type, description, tags, now, now),
+        )
+        self.commit()
+
     def update_entity_metadata(self, entity_type: str, entity_id: str, patch: dict[str, Any]) -> bool:
         """Merge ``patch`` into an entity's metadata JSON (read-merge-write).
 


### PR DESCRIPTION
## What

`entity-create --type organization` created an `entity_registry` row but **not** the organizations-table detail row (domain/industry/org_type/description), and a re-mint returned `created=false` — so the detail never got written (orphan gap). Adds `upsert_organization_detail` and wires it into the mint path.

## Provenance

This commit (`68bfd01c`) was authored earlier this session as `Empirica System` (my own git identity) and had been sitting **direct on local `develop`, unpushed**, from before a compaction. Recovered it onto a clean branch off `origin/develop` and PR'd it so CI validates it properly rather than leaving orphan work on a diverged local develop. Entity tests pass locally (220), lint + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)