### PR TITLE
feat(resolution): persist resolution to git notes (durable across rebuild + sync) [B2]

### DIFF
--- a/empirica/cli/command_handlers/graph_commands.py
+++ b/empirica/cli/command_handlers/graph_commands.py
@@ -809,7 +809,32 @@ def _resolve_by_filter(db, filt: dict, resolution: str, apply: bool) -> dict:
             [resolution, now, *params],
         )
     db.conn.commit()
+    # B2: persist resolution to git notes (canonical store) so a bulk garden
+    # resolve survives a from-notes rebuild / multi-device sync. Full ids come
+    # from the SELECT above. Best-effort + non-fatal (git may be unavailable).
+    _persist_filter_resolution_to_notes(atype, [r[0] for r in rows], resolution)
     return {"ok": True, "dry_run": False, "resolved": cur.rowcount, "sample": sample}
+
+
+def _persist_filter_resolution_to_notes(atype: str, ids: list, resolution: str) -> None:
+    """B2: mirror a filter-mode bulk resolve into git notes, one note per id."""
+    if not ids:
+        return
+    try:
+        if atype == "finding":
+            from empirica.core.canonical.empirica_git.finding_store import GitFindingStore
+
+            store = GitFindingStore()
+            for fid in ids:
+                store.resolve_finding(fid, resolution)
+        else:
+            from empirica.core.canonical.empirica_git.unknown_store import GitUnknownStore
+
+            ustore = GitUnknownStore()
+            for uid in ids:
+                ustore.resolve_unknown(uid, resolution)
+    except Exception as e:
+        logger.debug(f"git-notes bulk-resolution persist skipped ({atype}, {len(ids)} ids): {e}")
 
 
 def handle_resolve_artifacts_command(args):  # noqa: C901 — batch dispatcher fan-out

--- a/empirica/cli/command_handlers/sync_commands.py
+++ b/empirica/cli/command_handlers/sync_commands.py
@@ -864,7 +864,11 @@ def _rebuild_insert_breadcrumbs(db, findings, unknowns, dead_ends, mistakes, val
     for key, items, handler in handlers:
         for item in items:
             try:
-                handler(db, item, valid_goal_ids)
+                new_id = handler(db, item, valid_goal_ids)
+                # B2: a from-notes rebuild re-creates artifacts OPEN (log_* make
+                # fresh rows). Re-apply the resolution the note carries so
+                # resolved/superseded state survives rebuild + multi-device sync.
+                _rebuild_apply_resolution(db, key, new_id, item)
                 rebuilt[key] += 1
             except Exception as e:
                 logger.debug(f"{key} rebuild skip: {e}")
@@ -872,6 +876,33 @@ def _rebuild_insert_breadcrumbs(db, findings, unknowns, dead_ends, mistakes, val
                     db.adapter.conn.rollback()
                 except Exception:
                     pass
+
+
+def _rebuild_apply_resolution(db, key, new_id, item) -> None:
+    """B2: after a from-notes rebuild re-creates a finding/unknown as OPEN,
+    re-apply the resolution its git note carries. Direct SQL (not the
+    note-writing resolve) since the note IS the source here. Best-effort."""
+    if not new_id or key not in ("findings", "unknowns"):
+        return
+    import time as _t
+
+    try:
+        cur = db.adapter.conn.cursor()
+        if key == "findings" and item.get("is_resolved"):
+            cur.execute(
+                "UPDATE project_findings SET is_resolved = 1, resolution = ?, "
+                "superseded_by = ?, resolved_timestamp = ? WHERE id = ?",
+                (item.get("resolution") or "resolved", item.get("superseded_by"), _t.time(), new_id),
+            )
+            db.adapter.conn.commit()
+        elif key == "unknowns" and item.get("resolved"):
+            cur.execute(
+                "UPDATE project_unknowns SET is_resolved = 1, resolved_by = ?, resolved_timestamp = ? WHERE id = ?",
+                (item.get("resolved_by") or "resolved", _t.time(), new_id),
+            )
+            db.adapter.conn.commit()
+    except Exception as e:
+        logger.debug(f"rebuild resolution re-apply skip ({key} {new_id}): {e}")
 
 
 def _rebuild_from_notes() -> dict[str, Any]:

--- a/empirica/core/canonical/empirica_git/finding_store.py
+++ b/empirica/core/canonical/empirica_git/finding_store.py
@@ -83,6 +83,9 @@ class GitFindingStore:
         subtask_id: str | None = None,
         subject: str | None = None,
         finding_data: dict[str, Any] | None = None,
+        is_resolved: bool = False,
+        resolution: str | None = None,
+        superseded_by: str | None = None,
     ) -> bool:
         """
         Store finding in git notes
@@ -124,6 +127,10 @@ class GitFindingStore:
                 "subtask_id": subtask_id,
                 "subject": subject,
                 "finding_data": finding_data or {"finding": finding, "impact": impact},
+                "is_resolved": is_resolved,
+                "resolution": resolution,
+                "superseded_by": superseded_by,
+                "resolved_at": datetime.now(timezone.utc).isoformat() if is_resolved else None,
             }
 
             # Serialize
@@ -201,6 +208,30 @@ class GitFindingStore:
         except Exception as e:
             logger.warning(f"Failed to load finding from git: {e}")
             return None
+
+    def resolve_finding(self, finding_id: str, resolution: str, superseded_by: str | None = None) -> bool:
+        """Mark a finding resolved/superseded in git notes (mirrors
+        GitUnknownStore.resolve_unknown) — re-writes the finding's note with
+        is_resolved so a from-notes rebuild / multi-device sync preserves the
+        resolution instead of resurrecting the finding as open."""
+        finding_data = self.load_finding(finding_id)
+        if not finding_data:
+            return False
+        return self.store_finding(
+            finding_id=finding_id,
+            project_id=finding_data["project_id"],
+            session_id=finding_data["session_id"],
+            ai_id=finding_data["ai_id"],
+            finding=finding_data["finding"],
+            impact=finding_data.get("impact"),
+            goal_id=finding_data.get("goal_id"),
+            subtask_id=finding_data.get("subtask_id"),
+            subject=finding_data.get("subject"),
+            finding_data=finding_data.get("finding_data"),
+            is_resolved=True,
+            resolution=resolution,
+            superseded_by=superseded_by,
+        )
 
     def discover_findings(
         self,

--- a/empirica/data/repositories/breadcrumbs.py
+++ b/empirica/data/repositories/breadcrumbs.py
@@ -520,6 +520,7 @@ class BreadcrumbRepository(BaseRepository):
             )
 
         self.commit()
+        self._persist_resolution_to_git_notes("unknown", unknown_id, resolved_by)
         logger.info(f"✅ Unknown resolved: {unknown_id[:8]}...")
 
     def resolve_finding(self, finding_id: str, resolution: str, superseded_by: str | None = None) -> bool:
@@ -546,10 +547,43 @@ class BreadcrumbRepository(BaseRepository):
         )
         self.commit()
         updated = bool(getattr(cur, "rowcount", 0))
+        if updated:
+            self._persist_resolution_to_git_notes("finding", finding_id, resolution, superseded_by)
         logger.info(
             f"{'✅' if updated else '⚠️'} Finding resolve {finding_id[:8]}...: {'updated' if updated else 'no match'}"
         )
         return updated
+
+    def _persist_resolution_to_git_notes(
+        self, kind: str, id_arg: str, reason: str, superseded_by: str | None = None
+    ) -> None:
+        """B2: mirror a SQLite resolution into git notes (the canonical store) so a
+        from-notes rebuild / multi-device sync preserves it instead of resurrecting
+        the artifact as open. Best-effort + non-fatal (git may be unavailable, e.g.
+        in tests). Notes are keyed by FULL id, so resolve any partial-id match to
+        full ids first, then re-write each artifact's note via its store."""
+        try:
+            table = "project_findings" if kind == "finding" else "project_unknowns"
+            where = "id LIKE ?" if len(id_arg) < 36 else "id = ?"
+            match = f"{id_arg}%" if len(id_arg) < 36 else id_arg
+            cur = self._execute(f"SELECT id FROM {table} WHERE {where}", (match,))
+            ids = [r[0] for r in cur.fetchall()]
+            if not ids:
+                return
+            if kind == "finding":
+                from empirica.core.canonical.empirica_git.finding_store import GitFindingStore
+
+                store = GitFindingStore()
+                for fid in ids:
+                    store.resolve_finding(fid, reason, superseded_by=superseded_by)
+            else:
+                from empirica.core.canonical.empirica_git.unknown_store import GitUnknownStore
+
+                ustore = GitUnknownStore()
+                for uid in ids:
+                    ustore.resolve_unknown(uid, reason)
+        except Exception as e:
+            logger.debug(f"git-notes resolution persist skipped ({kind} {id_arg[:8]}): {e}")
 
     def log_dead_end(
         self,

--- a/tests/test_resolution_git_notes.py
+++ b/tests/test_resolution_git_notes.py
@@ -1,0 +1,99 @@
+"""B2: resolution is durable to git notes (survives a from-notes rebuild / sync).
+
+Before this, resolve_finding/resolve_unknown were SQLite-only, so resolution
+lived only in the derived layer — a `rebuild --from-notes` or multi-device sync
+resurrected resolved artifacts as open. Now:
+  - GitFindingStore carries is_resolved/resolution/superseded_by in the note +
+    has resolve_finding (mirrors GitUnknownStore.resolve_unknown).
+  - the rebuild re-applies the note's resolution to the re-created SQLite row.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import uuid
+
+import pytest
+
+from empirica.core.canonical.empirica_git.finding_store import GitFindingStore
+from empirica.core.canonical.empirica_git.unknown_store import GitUnknownStore
+
+
+@pytest.fixture
+def git_repo(tmp_path):
+    root = tmp_path / "repo"
+    root.mkdir()
+
+    def run(*args):
+        subprocess.run(["git", *args], cwd=str(root), check=True, capture_output=True)
+
+    run("init")
+    run("config", "user.email", "t@t.com")
+    run("config", "user.name", "t")
+    run("commit", "--allow-empty", "-m", "init")
+    return str(root)
+
+
+# ── finding store: the new resolve_finding + payload fields ────────────────────
+def test_finding_store_open_by_default(git_repo):
+    s = GitFindingStore(workspace_root=git_repo)
+    fid = str(uuid.uuid4())
+    assert s.store_finding(finding_id=fid, project_id="p", session_id="sess", ai_id="ai", finding="open finding")
+    data = s.load_finding(fid)
+    assert data["is_resolved"] is False
+    assert data["resolution"] is None
+
+
+def test_finding_store_resolve_persists_to_note(git_repo):
+    s = GitFindingStore(workspace_root=git_repo)
+    fid = str(uuid.uuid4())
+    s.store_finding(finding_id=fid, project_id="p", session_id="sess", ai_id="ai", finding="stale finding", impact=0.5)
+    assert s.resolve_finding(fid, "stale", superseded_by="new-id") is True
+    data = s.load_finding(fid)
+    assert data["is_resolved"] is True
+    assert data["resolution"] == "stale"
+    assert data["superseded_by"] == "new-id"
+    assert data["resolved_at"] is not None
+    # the substantive fields (finding text, impact) survive the re-write
+    assert data["finding"] == "stale finding"
+    assert data["impact"] == 0.5
+
+
+def test_finding_store_resolve_missing_returns_false(git_repo):
+    s = GitFindingStore(workspace_root=git_repo)
+    assert s.resolve_finding(str(uuid.uuid4()), "stale") is False
+
+
+# ── unknown store: existing mechanism still persists (regression) ──────────────
+def test_unknown_store_resolve_persists_to_note(git_repo):
+    s = GitUnknownStore(workspace_root=git_repo)
+    uid = str(uuid.uuid4())
+    s.store_unknown(unknown_id=uid, project_id="p", session_id="sess", ai_id="ai", unknown="a question")
+    assert s.resolve_unknown(uid, "answered") is True
+    data = s.load_unknown(uid)
+    assert data["resolved"] is True
+    assert data["resolved_by"] == "answered"
+
+
+# ── rebuild re-applies the note's resolution to the re-created row ─────────────
+def test_rebuild_reapplies_resolution(tmp_path):
+    from empirica.cli.command_handlers.sync_commands import _rebuild_apply_resolution
+    from empirica.data.session_database import SessionDatabase
+
+    db = SessionDatabase(db_path=str(tmp_path / "r.db"))
+    try:
+        pid, sid = str(uuid.uuid4()), str(uuid.uuid4())
+        fid = db.log_finding(pid, sid, "rebuilt open finding")
+        # simulate the rebuild loop seeing a note that says the finding is resolved
+        _rebuild_apply_resolution(
+            db, "findings", fid, {"is_resolved": True, "resolution": "stale", "superseded_by": None}
+        )
+        row = db.conn.execute("SELECT is_resolved, resolution FROM project_findings WHERE id = ?", (fid,)).fetchone()
+        assert row[0] == 1 and row[1] == "stale"
+
+        uid = db.log_unknown(project_id=pid, session_id=sid, unknown="rebuilt open unknown")
+        _rebuild_apply_resolution(db, "unknowns", uid, {"resolved": True, "resolved_by": "answered"})
+        urow = db.conn.execute("SELECT is_resolved, resolved_by FROM project_unknowns WHERE id = ?", (uid,)).fetchone()
+        assert urow[0] == 1 and urow[1] == "answered"
+    finally:
+        db.close()


### PR DESCRIPTION
## Why (B2)

Resolution (`is_resolved`/`resolution`/`superseded_by`) was **SQLite-only** — `resolve_finding`/`resolve_unknown` never wrote git notes. Since git notes are the canonical store, a `rebuild --from-notes` or a multi-device sync **resurrected resolved findings/unknowns as open**. This is the durability gap the epistemic-garden pass surfaced (its bulk resolves reverted on rebuild).

David-ratified approach: make resolution **canonical** — mirror the pattern `GitUnknownStore` already had, rather than invent a new `resolutions` ref.

## What

- **finding_store** — `store_finding` carries `is_resolved`/`resolution`/`superseded_by`/`resolved_at` in the note payload; new `resolve_finding()` loads + re-writes the note (a direct mirror of `GitUnknownStore.resolve_unknown`).
- **breadcrumbs** — `resolve_finding`/`resolve_unknown` now persist to the git store after the SQLite update (best-effort, non-fatal; resolves partial→full id first, since notes are keyed by full id).
- **rebuild** — `_rebuild_insert_breadcrumbs` re-creates artifacts via `log_*` (fresh/open); it now re-applies the note's resolution to the re-created row (direct SQL, since the note is the source). So a from-notes rebuild preserves resolved/superseded state.
- **graph_commands** — B1 filter-mode bulk resolve (`_resolve_by_filter`) persists to notes too (the garden's bulk tool).

## Tests

`tests/test_resolution_git_notes.py` (real-git-repo fixture): finding-store open-by-default, resolve round-trip (fields survive re-write), unknown-store regression, rebuild re-apply for both types. **404 passing** across resolve/rebuild/sync/breadcrumb/store surfaces; existing `test_finding_resolve` still green (change is benignly non-fatal when a note doesn't exist).

## Follow-up (small)

`resolve-artifacts` per-id branches still do direct SQL UPDATEs — route them through `db.resolve_finding`/`resolve_unknown` so they persist too. Left out to keep this PR focused; the single-id verbs + B1 filter (the common paths) are covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)