### PR TITLE
feat(ci): parser↔prompt drift check (T2) — catch prompts referencing removed verbs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,12 @@ jobs:
       - name: pyright
         run: pyright empirica/ empirica-mcp/
 
+      - name: prompt↔parser drift
+        # Fails if a skill / prompt template references `empirica <verb>` for a
+        # verb the CLI no longer has (the #348 prune failure mode). In-repo
+        # corpus only; private ~/.claude prompts are a local --include-private run.
+        run: python scripts/check_prompt_parser_drift.py
+
   # ── Tests ───────────────────────────────────────────────────────────
   # Matrix on 3.11 (min for empirica-mcp) + 3.13 (current). empirica
   # itself still declares 3.10 in classifiers, but empirica-mcp requires

--- a/scripts/check_prompt_parser_drift.py
+++ b/scripts/check_prompt_parser_drift.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Parser↔prompt drift check (T2, co-designed with cortex).
+
+Introspects empirica's CLI (`create_argument_parser`) for the LIVE verb set,
+then sweeps the prompt corpus for `empirica <verb>` mentions and diffs both
+directions:
+
+  DRIFT (fails, exit 1): a prompt references `empirica <verb>` for a verb the
+    parser no longer has — the #348 failure mode (prune a verb, leave a dangling
+    reference in a skill / system prompt).
+  COVERAGE (report only, exit 0): parser verbs never mentioned in any prompt —
+    allowlist-filtered (setup / internal verbs). Informational.
+
+Mentions are read ONLY from Markdown code spans (inline `...` and ```fences```),
+never prose — so "your empirica session" (a noun) is not mistaken for a verb.
+
+Corpus:
+  in-repo (CI-runnable): the skills + the shipped system-prompt template — the
+    surfaces actually LOADED AS PROMPTS. General docs are the /code-docs-align
+    lane, not this.
+  --include-private (local only): the operator's ~/.claude/empirica-*.md
+    includes, where the densest verb guidance lives (CI can't see them).
+
+Usage:
+  python scripts/check_prompt_parser_drift.py                    # CI mode
+  python scripts/check_prompt_parser_drift.py --include-private  # + ~/.claude
+  python scripts/check_prompt_parser_drift.py --json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parent.parent
+
+# Prompt surfaces (loaded as prompts) — NOT general docs.
+_IN_REPO_GLOBS = [
+    "empirica/plugins/claude-code-integration/skills/**/*.md",
+    "empirica/plugins/claude-code-integration/templates/*.md",
+]
+_PRIVATE_GLOB = "empirica-*.md"  # under ~/.claude/
+
+# Markdown code spans (fenced first, then inline) — the only place a real CLI
+# invocation lives; prose is excluded to avoid noun false-positives.
+_CODE_SPAN = re.compile(r"```.*?```|`[^`\n]+`", re.DOTALL)
+# `empirica <verb>` where the verb reads as an actual invocation: it must be
+# followed by a flag (` -`), a pipe/continuation, or end-of-line. This rejects
+# prose-in-code-spans like `empirica fleet` (product name), "empirica
+# transaction is open", "from empirica side" — where a noun follows the token.
+_MENTION = re.compile(r"\bempirica\s+([a-z][a-z0-9][a-z0-9-]*)(?=\s+-|\s*[|\\]|\s*$)", re.MULTILINE)
+
+# Verbs intentionally NOT part of the AI-prompt surface — coverage gaps here are
+# expected, not drift. (Aliases need no entry: they're in the live verb set, so
+# a mention of `empirica fl` resolves fine.)
+_ALLOW_UNMENTIONED = frozenset(
+    {
+        "help",
+        "onboard",
+        "setup-claude-code",
+        "plugin-sync",
+        "enp-setup",
+        "diagnose",
+        "doctor",
+        "release",
+        "serve",
+        "chat",
+        "query",
+        "edit-with-confidence",
+        "mco-load",
+        "system-status",
+        "forgejo-publish",
+        "training-export",
+    }
+)
+
+
+def live_verbs() -> set[str]:
+    """Top-level verb names + aliases from the live argparse tree."""
+    from empirica.cli.cli_core import create_argument_parser
+
+    parser = create_argument_parser()
+    verbs: set[str] = set()
+    for action in parser._actions:
+        if isinstance(action, argparse._SubParsersAction):
+            verbs |= set(action.choices.keys())
+    return verbs
+
+
+def corpus_files(include_private: bool) -> list[Path]:
+    files: list[Path] = []
+    for glob in _IN_REPO_GLOBS:
+        files += sorted(_REPO.glob(glob))
+    if include_private:
+        files += sorted((Path.home() / ".claude").glob(_PRIVATE_GLOB))
+    return files
+
+
+def mentions_in(text: str) -> set[str]:
+    """`empirica <verb>` tokens found in the code spans of `text`."""
+    code = "\n".join(_CODE_SPAN.findall(text))
+    return set(_MENTION.findall(code))
+
+
+def scan(files: list[Path], verbs: set[str]) -> tuple[dict[str, list[str]], set[str]]:
+    """Return (drift {verb -> [relpaths]}, mentioned {verb})."""
+    drift: dict[str, list[str]] = {}
+    mentioned: set[str] = set()
+    for path in files:
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        rel = _relpath(path)
+        for verb in mentions_in(text):
+            if verb in verbs:
+                mentioned.add(verb)
+            else:
+                drift.setdefault(verb, [])
+                if rel not in drift[verb]:
+                    drift[verb].append(rel)
+    return drift, mentioned
+
+
+def _relpath(path: Path) -> str:
+    try:
+        return str(path.relative_to(_REPO))
+    except ValueError:
+        return str(path)  # private ~/.claude file — outside the repo
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Check for drift between CLI verbs and prompt mentions.")
+    ap.add_argument("--include-private", action="store_true", help="Also scan ~/.claude/empirica-*.md (local only)")
+    ap.add_argument("--json", action="store_true", help="JSON output")
+    args = ap.parse_args(argv)
+
+    verbs = live_verbs()
+    files = corpus_files(args.include_private)
+    drift, mentioned = scan(files, verbs)
+    uncovered = sorted(v for v in verbs if v not in mentioned and v not in _ALLOW_UNMENTIONED)
+
+    result = {
+        "ok": not drift,
+        "verbs": len(verbs),
+        "corpus_files": len(files),
+        "drift": dict(sorted(drift.items())),
+        "uncovered_count": len(uncovered),
+        "uncovered": uncovered,
+    }
+
+    if args.json:
+        print(json.dumps(result, indent=2))
+    else:
+        print(f"Parser↔prompt drift: {len(verbs)} verbs vs {len(files)} prompt files")
+        if drift:
+            print(f"\n❌ DRIFT — {len(drift)} verb(s) referenced in prompts but NOT in the parser:")
+            for verb, paths in sorted(drift.items()):
+                print(f"  `empirica {verb}` — {', '.join(paths)}")
+            print("\nA pruned/renamed verb still has a dangling prompt reference. Fix the prompt or restore the verb.")
+        else:
+            print("✓ No drift — every `empirica <verb>` in the prompt corpus resolves to a live verb.")
+        print(f"\n(coverage: {len(uncovered)} live verb(s) never mentioned in prompts — informational, not a failure)")
+
+    return 1 if drift else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_prompt_parser_drift.py
+++ b/tests/test_prompt_parser_drift.py
@@ -1,0 +1,63 @@
+"""Tests for scripts/check_prompt_parser_drift.py (T2 — parser↔prompt drift).
+
+The check must (a) catch a prompt referencing a verb the parser no longer has
+(the #348 failure mode), and (b) NOT false-positive on prose that happens to
+follow the word `empirica` inside a code span.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "check_prompt_parser_drift.py"
+_spec = importlib.util.spec_from_file_location("check_prompt_parser_drift", _SCRIPT)
+drift = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(drift)
+
+
+def test_mentions_matches_real_invocations():
+    text = "```\nempirica finding-log --finding x\nempirica status\nempirica goals-create --objective y | jq\n```"
+    assert drift.mentions_in(text) == {"finding-log", "status", "goals-create"}
+
+
+def test_mentions_rejects_prose_in_code_spans():
+    # nouns/product-names after `empirica` inside code spans must NOT match
+    text = "the `empirica fleet` product; an `empirica transaction is open` note"
+    assert drift.mentions_in(text) == set()
+
+
+def test_mentions_ignores_prose_outside_code_spans():
+    assert drift.mentions_in("run empirica finding-log --x described in prose") == set()
+
+
+def test_scan_flags_removed_verb(tmp_path):
+    f = tmp_path / "skill.md"
+    f.write_text("```\nempirica agent-spawn --turtle\nempirica finding-log --x\n```")
+    drift_map, mentioned = drift.scan([f], {"finding-log", "status"})
+    assert "agent-spawn" in drift_map
+    assert str(f) in drift_map["agent-spawn"] or f.name in drift_map["agent-spawn"][0]
+    assert "finding-log" in mentioned  # a live verb is counted as covered, not drift
+
+
+def test_scan_clean_when_all_verbs_live(tmp_path):
+    f = tmp_path / "skill.md"
+    f.write_text("```\nempirica finding-log --x\nempirica goals-create --objective y\n```")
+    drift_map, mentioned = drift.scan([f], {"finding-log", "goals-create"})
+    assert drift_map == {}
+    assert mentioned == {"finding-log", "goals-create"}
+
+
+def test_live_verbs_reflects_parser():
+    verbs = drift.live_verbs()
+    assert "finding-log" in verbs
+    assert "goals-create" in verbs
+    assert "agent-spawn" not in verbs  # pruned in #348 — the drift this guards against
+
+
+def test_repo_corpus_is_clean():
+    """The shipped skills + prompt template must not drift from the parser."""
+    verbs = drift.live_verbs()
+    files = drift.corpus_files(include_private=False)
+    drift_map, _ = drift.scan(files, verbs)
+    assert drift_map == {}, f"prompt→parser drift in shipped corpus: {drift_map}"


### PR DESCRIPTION
## What

`scripts/check_prompt_parser_drift.py` introspects the live CLI verb set (`create_argument_parser`) and sweeps the prompt corpus (skills + the shipped system-prompt template) for `empirica <verb>` mentions, **failing CI when a prompt references a verb the parser no longer has** — the #348 failure mode (prune a verb, leave a dangling reference in a skill/prompt that then misleads the live AI).

## Precision (the hard part)
- Mentions are read only from Markdown **code spans** AND must read as an **actual invocation** (verb followed by a flag / pipe / continuation / EOL) — so prose like `` `empirica fleet` `` (a product name) or "empirica transaction is open" is not mistaken for a verb. Caught 4 such false-positives during design; tightened the matcher until the shipped corpus is clean **and** real drift (`agent-spawn`) still trips it.
- **Coverage** direction (verbs never mentioned) is reported, not failed — allowlist-filtered for setup/internal verbs.
- `--include-private` scans `~/.claude/empirica-*.md` (the operator's system-prompt includes, where the densest verb guidance lives) — local only, CI can't see them.

## Scope
- Wired into `ci.yml` `lint-and-types` (in-repo corpus). Verified **clean on both corpora** post-#348/#349.
- Home is a `scripts/` check, **not a new CLI verb** (post-#348 we're shedding surface, not adding).

## Coordination
Co-designed with cortex — they mirror the two-direction diff + allowlist + exit code for cortex-cli's clap tree vs the cortex prompt corpus.

## Tests
`tests/test_prompt_parser_drift.py` — 7 cases (real-invocation match, prose rejection, drift detection, live-verbs reflects parser, shipped corpus clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)