### PR TITLE
fix(hygiene): sentinel read-only roster/status classify + goals-list cap hint

### DIFF
--- a/empirica/cli/command_handlers/goal_commands.py
+++ b/empirica/cli/command_handlers/goal_commands.py
@@ -1424,7 +1424,7 @@ def _print_goals_list_human(goals, status_desc, filter_desc, total_matching, lim
     if total_matching is not None and total_matching > len(goals):
         print(
             f"🎯 GOALS ({status_desc.upper()}) - showing {len(goals)} of {total_matching} "
-            f"[{filter_desc}] · raise --limit (now {limit}) to see more"
+            f"[{filter_desc}] · CAPPED at {limit} — use --all-projects (or raise --limit) for the full backlog"
         )
     else:
         print(f"🎯 GOALS ({status_desc.upper()}) - {len(goals)} found [{filter_desc}]")

--- a/empirica/cli/parsers/checkpoint_parsers.py
+++ b/empirica/cli/parsers/checkpoint_parsers.py
@@ -1948,9 +1948,10 @@ Example:
     goals_list_parser.add_argument(
         "--all-projects",
         action="store_true",
-        help="Cross-project view (gardening): list goals across ALL project_ids, not just the "
-        "active project. Adds a project column and raises the default limit. Surfaces goals "
-        "stranded under other/divergent project_ids that the normal active-project scope hides.",
+        help="See the COMPLETE backlog (default caps at 20). Cross-project view (gardening): "
+        "list goals across ALL project_ids, not just the active project. Adds a project column "
+        "and raises the limit to 2000. Surfaces goals stranded under other/divergent project_ids "
+        "that the normal active-project scope hides. (`--all` works as a prefix abbreviation.)",
     )
     goals_list_parser.add_argument("--scope-breadth-min", type=float, help="Filter by minimum breadth (0.0-1.0)")
     goals_list_parser.add_argument("--scope-breadth-max", type=float, help="Filter by maximum breadth (0.0-1.0)")

--- a/empirica/plugins/claude-code-integration/hooks/sentinel-gate.py
+++ b/empirica/plugins/claude-code-integration/hooks/sentinel-gate.py
@@ -686,6 +686,9 @@ EMPIRICA_TIER1_PREFIXES = (
     "empirica compact-analysis",  # Compact event analysis - read-only
     "empirica commit-context",  # Per-commit artifact aggregator - read-only
     "empirica practice-context",  # Roster lookup (Ambassador addressbook) - read-only
+    "empirica mesh status",  # Mesh roster/state display - read-only (prefix excludes mesh on/off/restart)
+    "empirica mesh diagnose",  # Mesh diagnostic - read-only
+    "empirica status",  # Cockpit instance overview - read-only
     "empirica lesson-list",
     "empirica lesson-search",
     "empirica lesson-recommend",


### PR DESCRIPTION
Two small backlog-gardening fixes (knocking off stale goals).

## 1. Sentinel read-only classification (goal 44a8aad4)
`mesh status`, `mesh diagnose`, and cockpit `status` are read-only roster/status displays that shouldn't trip the praxic gate — added to the noetic allowlist (joining `practice-context`/`profile-status`). Prefix-match excludes mutating `mesh on/off/restart`. (`project-status` in the goal was a mis-name — that verb doesn't exist.)

## 2. goals-list cap visibility
The 20-cap fooled an AI (me) into triaging a 60-goal backlog as if it were 20. The human footer + JSON `truncated`/`total_matching` already existed, but the footer only said "raise --limit" and never named **`--all-projects`** (the flag that shows the full backlog); `--all` was an undocumented prefix-abbrev of it. Now:
- Footer: `CAPPED at N — use --all-projects (or raise --limit) for the full backlog`
- `--all-projects` help documents the cap + the `--all` abbreviation

Verified: footer renders, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)