### PR TITLE
fix(loop-install): don't offer event-drivable loops as CronCreate pollers on wake-on-event seats

### DIFF
--- a/empirica/plugins/claude-code-integration/hooks/loop-install-pickup.py
+++ b/empirica/plugins/claude-code-integration/hooks/loop-install-pickup.py
@@ -95,8 +95,20 @@ def _maybe_auto_install_canonical_loops(instance_id: str, project_root: Path) ->
         from empirica.core.cockpit.canonical_loops import CANONICAL_LOOPS
         from empirica.core.cockpit.loop_install_request import write_pending
 
+        # Gate 5: on a wake-on-event harness (an armed listener bridges events
+        # into the session via the loop_fires Monitor), event-drivable canonical
+        # loops — those the catalog runs via systemd + the wake bridge
+        # (scheduler_kind='systemd-user') — are pure redundancy as a CronCreate
+        # poll. Skip them here; genuine housekeeping crons (message-cleanup) still
+        # install. (extension prop_syrvccyu6: this poller was surfaced every
+        # session on 30+ wake-on-event seats.)
+        listener_armed = any(empirica_home.glob(f"listener_active_{instance_id}_*.json"))
+
         installed = 0
         for entry in CANONICAL_LOOPS:
+            scheduler_kind = entry.get("scheduler_kind")
+            if listener_armed and scheduler_kind == "systemd-user":
+                continue  # gate 5: event-drivable + listener already armed → redundant
             try:
                 write_pending(
                     instance_id=instance_id,
@@ -107,6 +119,7 @@ def _maybe_auto_install_canonical_loops(instance_id: str, project_root: Path) ->
                     max_interval=entry.get("max_interval"),
                     requested_by="user-prompt-submit",
                     body_skill=entry.get("body_skill"),
+                    scheduler_kind=scheduler_kind,  # DEFECT 1: was dropped → wrongly defaulted to cron-create
                 )
                 installed += 1
             except Exception:


### PR DESCRIPTION
extension `prop_syrvccyu6` (David-directed): the loop-install auto-installer surfaced `cortex-mailbox-poll` as a 30s CronCreate poll **every session on 30+ wake-on-event seats**, despite the systemd loop-listen service + `loop_fires` Monitor already delivering events. Two grounded defects in `_maybe_auto_install_canonical_loops`:

**Defect 1 — `scheduler_kind` dropped:** `write_pending()` never received `scheduler_kind`, so it defaulted to `cron-create` even though the catalog declares `cortex-mailbox-poll` as `systemd-user` (runs via systemd + the wake bridge, not a poll). Fix: pass `scheduler_kind=entry.get(...)`.

**Defect 2 — no wake-on-event gate:** the 4-gate cascade never checked whether a listener was already armed. An event-drivable loop is pure redundancy on any harness with a live `listener_active_{ai_id}_*.json`. Fix: **gate 5** — skip `systemd-user` (event-drivable) entries when the listener's armed; genuine housekeeping crons (`message-cleanup`) still install.

Verified: compiles, ruff clean. (And I did *not* install the two loops this session — empirica wakes on events, which is exactly the redundancy this fixes.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)