### PR TITLE
fix(session): pin project_id at creation — end split-brain persistence (Franci/NLE P0)

### DIFF
--- a/empirica/cli/command_handlers/session_create.py
+++ b/empirica/cli/command_handlers/session_create.py
@@ -506,12 +506,21 @@ def _resolve_from_context_files():
                     if pid:
                         return pid
 
-    # Priority 0c: canonical active_work.json
-    canonical_path = os.path.join(os.path.expanduser("~"), ".empirica", "active_work.json")
-    if os.path.exists(canonical_path):
-        with open(canonical_path) as f:
-            active_work = _json.load(f)
-            return _get_project_id_from_context(active_work)
+    # Priority 0c: generic active_work.json — HEADLESS MODE ONLY.
+    # This mirrors the canonical invariant enforced by
+    # session_resolver.get_active_project_path (see its "HEADLESS MODE ONLY"
+    # block): in an interactive session there IS a terminal identity, so
+    # instance_projects (0a) + active_work_{uuid} (0b) own resolution and a
+    # generic global fallback must NOT win. Reading it unconditionally here was
+    # a divergent second copy of the resolution logic and let a stale
+    # cross-project active_work.json contaminate the session's project_id
+    # (split-brain persistence — Franci/NLE, verified 2026-07-18).
+    if R.is_headless():
+        canonical_path = os.path.join(os.path.expanduser("~"), ".empirica", "active_work.json")
+        if os.path.exists(canonical_path):
+            with open(canonical_path) as f:
+                active_work = _json.load(f)
+                return _get_project_id_from_context(active_work)
 
     return None
 

--- a/empirica/plugins/claude-code-integration/hooks/session-init.py
+++ b/empirica/plugins/claude-code-integration/hooks/session-init.py
@@ -103,13 +103,22 @@ def archive_stale_plans() -> list:
     return archived
 
 
-def _create_empirica_session(ai_id: str, env: dict) -> tuple:
+def _create_empirica_session(ai_id: str, env: dict, project_id: str | None = None) -> tuple:
     """Run session-create CLI command and return (session_id, error).
+
+    When ``project_id`` is a validated canonical UUID it is passed explicitly as
+    ``--project-id`` so session-create does NOT re-resolve the project from its
+    context-file chain (which can pick a stale global active_work.json and bind
+    the session to the wrong project — split-brain persistence). Omitted when
+    None, preserving the resolver fallback for unregistered projects.
 
     Returns (session_id, None) on success, (None, error_msg) on failure.
     """
+    cmd = ["empirica", "session-create", "--ai-id", ai_id, "--output", "json"]
+    if project_id:
+        cmd += ["--project-id", project_id]
     create_cmd = subprocess.run(
-        ["empirica", "session-create", "--ai-id", ai_id, "--output", "json"],
+        cmd,
         capture_output=True,
         text=True,
         timeout=15,
@@ -297,6 +306,79 @@ _PROJECT_ID_UUID_RE = re.compile(
 )
 
 
+def _lookup_project_id_by_trajectory(project_root: str | Path | None) -> str | None:
+    """Resolve the canonical project UUID from workspace.db global_projects by
+    trajectory_path, tolerating BOTH stored forms: ``<root>`` and
+    ``<root>/.empirica``.
+
+    workspace.db is populated by paths that disagree on the form: project-init /
+    workspace_init store ``<root>/.empirica`` while projects-discover
+    (project_commands) stores the bare ``<root>``. Read paths elsewhere already
+    normalize both; the session-init healers historically did a single
+    exact-match on ``<root>/.empirica`` and silently missed rows stored as
+    ``<root>`` — defeating the ghost-project_id heal (split-brain persistence,
+    Franci/NLE, verified 2026-07-18). Query both forms.
+
+    Returns the UUID string, or None when the path is not registered.
+    """
+    if not project_root:
+        return None
+    try:
+        import sqlite3
+
+        ws_db = Path.home() / ".empirica" / "workspace" / "workspace.db"
+        if not ws_db.exists():
+            return None
+        root = Path(project_root)
+        candidates = (str(root / ".empirica"), str(root))
+        conn = sqlite3.connect(str(ws_db))
+        try:
+            cursor = conn.execute(
+                "SELECT id FROM global_projects WHERE trajectory_path IN (?, ?)",
+                candidates,
+            )
+            row = cursor.fetchone()
+        finally:
+            conn.close()
+        return row[0] if row else None
+    except Exception as e:
+        print(f"session-init: trajectory lookup skipped ({type(e).__name__}: {e})", file=sys.stderr)
+        return None
+
+
+def _resolve_canonical_project_id_for_root(project_root: str | Path | None) -> str | None:
+    """Best-effort canonical project UUID for an already-validated project_root.
+
+    Used to pin the session's project_id EXPLICITLY at creation (session-create
+    ``--project-id``) instead of letting session-create re-resolve it — the
+    re-resolution path could pick a stale global active_work.json and bind the
+    session to the wrong project while the UI showed the right one (split-brain).
+
+    Precedence:
+      1. .empirica/project.yaml project_id when UUID-shaped (canonical declared
+         identity; project-init heals it to a UUID).
+      2. workspace.db global_projects trajectory_path (both forms).
+
+    Returns None when neither yields a UUID — the caller then omits
+    ``--project-id`` and session-create falls back to its (now headless-gated)
+    resolver chain.
+    """
+    if not project_root:
+        return None
+    try:
+        import yaml
+
+        project_yaml = Path(project_root) / ".empirica" / "project.yaml"
+        if project_yaml.exists():
+            cfg = yaml.safe_load(project_yaml.read_text()) or {}
+            pid = (cfg.get("project_id") or "").strip()
+            if _PROJECT_ID_UUID_RE.match(pid):
+                return pid
+    except Exception:
+        pass
+    return _lookup_project_id_by_trajectory(project_root)
+
+
 def _resolve_ai_id_for_session(project_root: str | Path | None) -> str:
     """Resolve the canonical ai_id at session-init time.
 
@@ -438,25 +520,10 @@ def _heal_project_yaml_project_id_at_init(project_root: str | None) -> None:
         if _PROJECT_ID_UUID_RE.match(current):
             return  # already UUID-shaped — nothing to do
 
-        # Look up canonical UUID via workspace.db trajectory_path
-        import sqlite3
-
-        ws_db = Path.home() / ".empirica" / "workspace" / "workspace.db"
-        if not ws_db.exists():
-            return
-        trajectory = str(Path(project_root) / ".empirica")
-        conn = sqlite3.connect(str(ws_db))
-        try:
-            cursor = conn.execute(
-                "SELECT id FROM global_projects WHERE trajectory_path = ?",
-                (trajectory,),
-            )
-            row = cursor.fetchone()
-        finally:
-            conn.close()
-        if not row:
+        # Look up canonical UUID via workspace.db trajectory_path (both forms).
+        canonical_uuid = _lookup_project_id_by_trajectory(project_root)
+        if not canonical_uuid:
             return  # not registered — leave alone, never guess
-        canonical_uuid = row[0]
         if canonical_uuid == current:
             return  # already matches (defensive — UUID regex should've caught)
 
@@ -471,7 +538,7 @@ def _heal_project_yaml_project_id_at_init(project_root: str | None) -> None:
         print(f"session-init: project.yaml heal skipped ({type(e).__name__}: {e})", file=sys.stderr)
 
 
-def _heal_session_project_id_at_init(session_id: str, project_root: str | None) -> None:
+def _heal_session_project_id_at_init(session_id: str, project_root: str | None) -> str | None:
     """Validate-and-heal session.project_id at session-init boundary.
 
     Mirrors post-compact._auto_heal_session's stage 2 — catches the
@@ -480,26 +547,19 @@ def _heal_session_project_id_at_init(session_id: str, project_root: str | None) 
     folder_name match, tmux pane reuse). Cwd is reliable here because
     session-init already os.chdir'd to project_root before this runs.
 
+    Returns the heal status ("healed" | "ok" | "missing"), or None when no
+    authoritative check could run (no session/root, or unregistered path). A
+    "healed" result means the session was bound to the WRONG project at creation
+    — the caller elevates that to a loud split-brain signal.
+
     Non-fatal — logs to stderr on issue, never blocks session boot.
     """
     if not session_id or not project_root:
-        return
+        return None
     try:
-        import sqlite3
-
-        ws_db = Path.home() / ".empirica" / "workspace" / "workspace.db"
-        if not ws_db.exists():
-            return
-        trajectory = str(Path(project_root) / ".empirica")
-        conn = sqlite3.connect(str(ws_db))
-        try:
-            cursor = conn.execute("SELECT id FROM global_projects WHERE trajectory_path = ?", (trajectory,))
-            row = cursor.fetchone()
-        finally:
-            conn.close()
-        if not row:
-            return  # path not registered — leave alone, never guess
-        expected_project_id = row[0]
+        expected_project_id = _lookup_project_id_by_trajectory(project_root)
+        if not expected_project_id:
+            return None  # path not registered — leave alone, never guess
 
         from empirica.data.session_database import SessionDatabase
 
@@ -509,14 +569,15 @@ def _heal_session_project_id_at_init(session_id: str, project_root: str | None) 
                 session_id=session_id,
                 expected_project_id=expected_project_id,
             )
-            if status == "healed":
-                print(
-                    f"session-init: healed session {session_id[:8]} project_id "
-                    f"-> {expected_project_id[:8]} (ghost-project_id pattern)",
-                    file=sys.stderr,
-                )
         finally:
             db.close()
+        if status == "healed":
+            print(
+                f"session-init: healed session {session_id[:8]} project_id "
+                f"-> {expected_project_id[:8]} (ghost-project_id pattern)",
+                file=sys.stderr,
+            )
+        return status
     except Exception as e:
         print(f"session-init: project_id heal skipped ({type(e).__name__}: {e})", file=sys.stderr)
 
@@ -601,6 +662,12 @@ def _heal_mesh_metadata_at_init(project_root: str | None) -> None:
 def create_session_and_bootstrap(ai_id: str, project_id: str | None = None) -> dict:
     """Create session + run bootstrap in sequence.
 
+    ``project_id`` (the canonical UUID for the already-validated cwd project_root)
+    is passed through to session-create as ``--project-id`` so the session is
+    PINNED to the right project at creation instead of being re-resolved from a
+    context-file chain that can pick a stale global active_work.json (split-brain
+    persistence — Franci/NLE). None → session-create falls back to its resolver.
+
     Returns dict with session_id, bootstrap_output, error.
     Orchestrates: session creation, bootstrap, and optional Cortex sync.
     """
@@ -610,9 +677,10 @@ def create_session_and_bootstrap(ai_id: str, project_id: str | None = None) -> d
         # Set EMPIRICA_CWD_RELIABLE=true because session-init already os.chdir'd
         # to the resolved project_root.
         env = {**os.environ, "EMPIRICA_CWD_RELIABLE": "true"}
+        project_root = os.environ.get("PWD") or os.getcwd()
 
-        # Step 1: Create session
-        session_id, error = _create_empirica_session(ai_id, env)
+        # Step 1: Create session — pinned to the validated project_id when known.
+        session_id, error = _create_empirica_session(ai_id, env, project_id)
         if error:
             result["error"] = error
             return result
@@ -620,21 +688,34 @@ def create_session_and_bootstrap(ai_id: str, project_id: str | None = None) -> d
 
         # Step 1b: Heal session.project_id if session-create's resolution
         # bound to a stale project (ghost-project_id pattern). Idempotent.
-        _heal_session_project_id_at_init(session_id, os.environ.get("PWD") or os.getcwd())
+        # A "healed" status means the session was created with the WRONG
+        # project_id — the split-brain we now pin against. With Step-1 pinning
+        # this should be "ok"/None in the normal path; a residual "healed" is a
+        # fail-LOUD signal that resolver inputs are still contaminating creation.
+        heal_status = _heal_session_project_id_at_init(session_id, project_root)
+        if heal_status == "healed":
+            print(
+                f"session-init: ⚠ SPLIT-BRAIN CORRECTED — session {session_id[:8]} was "
+                f"bound to the wrong project at creation and healed to the cwd's canonical "
+                f"id. Persistence would otherwise have landed in the wrong project. "
+                f"Investigate resolver inputs (stale ~/.empirica/active_work.json?).",
+                file=sys.stderr,
+            )
+            result["split_brain_corrected"] = True
 
         # Step 1c: Heal .empirica/project.yaml project_id if it's a slug-shape
         # legacy value (pre-UUID project-init era). Idempotent.
-        _heal_project_yaml_project_id_at_init(os.environ.get("PWD") or os.getcwd())
+        _heal_project_yaml_project_id_at_init(project_root)
 
         # Step 1d: Heal .empirica/project.yaml ai_id if it's a stripped-prefix
         # legacy value (pre-strict-canonical era, 1.11.x). Idempotent.
-        _heal_project_yaml_ai_id_at_init(os.environ.get("PWD") or os.getcwd())
+        _heal_project_yaml_ai_id_at_init(project_root)
 
         # Step 1e: Backfill mesh tenant metadata (canonical_seat etc.) for
         # ai_id-only project.yamls so cortex_session_init can seat a
         # multi-practice api_key. Idempotent + cortex-read-only (no seat is
         # passed here — that's the cortex-gated Phase 2).
-        _heal_mesh_metadata_at_init(os.environ.get("PWD") or os.getcwd())
+        _heal_mesh_metadata_at_init(project_root)
 
         # Step 2: Run bootstrap
         bootstrap_data, project_context = _run_bootstrap(session_id, env)
@@ -1579,8 +1660,13 @@ def main():
     if not is_resume:
         _handle_orphan_adoption(claude_session_id, project_root)
 
-    # Create session and bootstrap
-    result = create_session_and_bootstrap(ai_id)
+    # Create session and bootstrap — pin the session to the cwd-validated
+    # project UUID so session-create does NOT re-resolve it from a context-file
+    # chain that could pick a stale global active_work.json (split-brain
+    # persistence, Franci/NLE, verified 2026-07-18). project_root here is
+    # already cwd-first (see _try_cwd_adoption / _prefer_cwd_on_startup above).
+    canonical_project_id = _resolve_canonical_project_id_for_root(project_root)
+    result = create_session_and_bootstrap(ai_id, project_id=canonical_project_id)
 
     if result.get("session_id"):
         _write_instance_projects(str(project_root), claude_session_id, result["session_id"])

--- a/tests/test_split_brain_persistence.py
+++ b/tests/test_split_brain_persistence.py
@@ -1,0 +1,262 @@
+"""Regression tests for the split-brain project-persistence fix.
+
+Franci/NLE verified diagnosis (2026-07-18): a session displayed the correct
+project but PERSISTED its session row + artifacts to a stale project, because
+session-create re-resolved the project_id from a context-file chain that read a
+3-month-old global ~/.empirica/active_work.json — while the healer that would
+have caught it silently missed the workspace.db row on a trajectory_path form
+mismatch.
+
+Four legs, tested here:
+  1. session-init pins the session with an explicit --project-id resolved from
+     the cwd-validated project_root (_resolve_canonical_project_id_for_root +
+     _create_empirica_session argv).
+  2. session_create's generic active_work.json read is gated on is_headless()
+     (matches session_resolver's canonical invariant).
+  3. the healers' trajectory lookup tolerates BOTH <root> and <root>/.empirica
+     forms (_lookup_project_id_by_trajectory).
+  4. a "healed" session bind is elevated to a loud split_brain_corrected signal.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+import yaml
+
+HOOK_PATH = (
+    Path(__file__).parent.parent / "empirica" / "plugins" / "claude-code-integration" / "hooks" / "session-init.py"
+)
+
+UUID_A = "839e2223-c351-44f6-9ce6-6592fbcdd569"  # empirica-ai-consulting (correct)
+UUID_B = "d5fea011-119b-47b3-8342-40e5fb7bd544"  # Q-Trading (the stale contaminator)
+
+
+def _load_hook_module():
+    """Import session-init.py despite the dash in the filename."""
+    spec = importlib.util.spec_from_file_location("session_init_hook", HOOK_PATH)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    plugin_lib = HOOK_PATH.parent.parent / "lib"
+    sys.path.insert(0, str(plugin_lib))
+    try:
+        spec.loader.exec_module(mod)
+    finally:
+        sys.path.remove(str(plugin_lib))
+    return mod
+
+
+def _make_workspace_db(tmp_path: Path, trajectory: str, project_uuid: str) -> Path:
+    ws_dir = tmp_path / ".empirica" / "workspace"
+    ws_dir.mkdir(parents=True, exist_ok=True)
+    db = ws_dir / "workspace.db"
+    conn = sqlite3.connect(str(db))
+    conn.execute("CREATE TABLE IF NOT EXISTS global_projects (id TEXT PRIMARY KEY, name TEXT, trajectory_path TEXT)")
+    conn.execute(
+        "INSERT INTO global_projects (id, name, trajectory_path) VALUES (?, ?, ?)",
+        (project_uuid, "test-proj", trajectory),
+    )
+    conn.commit()
+    conn.close()
+    return db
+
+
+def _make_project_yaml(project_root: Path, project_id_value: str) -> Path:
+    (project_root / ".empirica").mkdir(parents=True, exist_ok=True)
+    yaml_path = project_root / ".empirica" / "project.yaml"
+    yaml_path.write_text(
+        yaml.safe_dump(
+            {"name": "Test", "ai_id": "test", "project_id": project_id_value, "version": "2.0"},
+            sort_keys=False,
+        )
+    )
+    return yaml_path
+
+
+# ---------------------------------------------------------------------------
+# Leg 3 — trajectory_path lookup tolerates both stored forms
+# ---------------------------------------------------------------------------
+
+
+def test_trajectory_lookup_matches_dotempirica_form(tmp_path, monkeypatch):
+    mod = _load_hook_module()
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    _make_workspace_db(tmp_path, str(proj / ".empirica"), UUID_A)
+    assert mod._lookup_project_id_by_trajectory(str(proj)) == UUID_A
+
+
+def test_trajectory_lookup_matches_bare_root_form(tmp_path, monkeypatch):
+    """THE FIX: a project registered with trajectory_path=<root> (no /.empirica)
+    — the projects-discover form — must still resolve. The old exact-match on
+    <root>/.empirica silently missed this, defeating the ghost-project_id heal."""
+    mod = _load_hook_module()
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    _make_workspace_db(tmp_path, str(proj), UUID_A)  # bare root form
+    assert mod._lookup_project_id_by_trajectory(str(proj)) == UUID_A
+
+
+def test_trajectory_lookup_unregistered_returns_none(tmp_path, monkeypatch):
+    mod = _load_hook_module()
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    _make_workspace_db(tmp_path, "/some/other/path", "other-uuid")
+    assert mod._lookup_project_id_by_trajectory(str(proj)) is None
+
+
+def test_trajectory_lookup_none_root_and_no_db(tmp_path, monkeypatch):
+    mod = _load_hook_module()
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    assert mod._lookup_project_id_by_trajectory(None) is None
+    assert mod._lookup_project_id_by_trajectory(str(tmp_path / "proj")) is None  # no workspace.db
+
+
+# ---------------------------------------------------------------------------
+# Leg 1a — canonical project_id resolution for a validated root
+# ---------------------------------------------------------------------------
+
+
+def test_canonical_id_prefers_uuid_yaml(tmp_path, monkeypatch):
+    """project.yaml UUID wins directly — no workspace.db needed."""
+    mod = _load_hook_module()
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    proj = tmp_path / "proj"
+    _make_project_yaml(proj, UUID_A)
+    # deliberately NO workspace.db — yaml UUID must suffice
+    assert mod._resolve_canonical_project_id_for_root(str(proj)) == UUID_A
+
+
+def test_canonical_id_falls_back_to_trajectory_on_slug_yaml(tmp_path, monkeypatch):
+    """Slug-shaped yaml → fall through to workspace.db (bare-root form)."""
+    mod = _load_hook_module()
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    proj = tmp_path / "proj"
+    _make_project_yaml(proj, "some-slug")
+    _make_workspace_db(tmp_path, str(proj), UUID_A)
+    assert mod._resolve_canonical_project_id_for_root(str(proj)) == UUID_A
+
+
+def test_canonical_id_none_when_unresolvable(tmp_path, monkeypatch):
+    mod = _load_hook_module()
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    proj = tmp_path / "proj"
+    proj.mkdir()  # no yaml, no workspace.db
+    assert mod._resolve_canonical_project_id_for_root(str(proj)) is None
+
+
+# ---------------------------------------------------------------------------
+# Leg 1b — session-create is invoked with an explicit --project-id
+# ---------------------------------------------------------------------------
+
+
+class _FakeCompleted:
+    def __init__(self, argv):
+        self.argv = argv
+        self.returncode = 0
+        self.stdout = '{"session_id": "sess-123"}'
+        self.stderr = ""
+
+
+def test_create_session_passes_project_id(monkeypatch):
+    mod = _load_hook_module()
+    captured = {}
+
+    def _fake_run(cmd, **kwargs):
+        captured["argv"] = cmd
+        return _FakeCompleted(cmd)
+
+    monkeypatch.setattr(mod.subprocess, "run", _fake_run)
+    sid, err = mod._create_empirica_session("test-ai", dict(os.environ), project_id=UUID_A)
+    assert err is None and sid == "sess-123"
+    assert "--project-id" in captured["argv"]
+    assert captured["argv"][captured["argv"].index("--project-id") + 1] == UUID_A
+
+
+def test_create_session_omits_project_id_when_none(monkeypatch):
+    mod = _load_hook_module()
+    captured = {}
+
+    def _fake_run(cmd, **kwargs):
+        captured["argv"] = cmd
+        return _FakeCompleted(cmd)
+
+    monkeypatch.setattr(mod.subprocess, "run", _fake_run)
+    mod._create_empirica_session("test-ai", dict(os.environ), project_id=None)
+    assert "--project-id" not in captured["argv"]
+
+
+# ---------------------------------------------------------------------------
+# Leg 4 — a healed (wrong) binding is elevated to a loud split-brain signal
+# ---------------------------------------------------------------------------
+
+
+def _stub_bootstrap_chain(mod, monkeypatch, heal_status):
+    monkeypatch.setattr(mod, "_create_empirica_session", lambda *a, **k: ("sess-123", None))
+    monkeypatch.setattr(mod, "_heal_session_project_id_at_init", lambda *a, **k: heal_status)
+    monkeypatch.setattr(mod, "_heal_project_yaml_project_id_at_init", lambda *a, **k: None)
+    monkeypatch.setattr(mod, "_heal_project_yaml_ai_id_at_init", lambda *a, **k: None)
+    monkeypatch.setattr(mod, "_heal_mesh_metadata_at_init", lambda *a, **k: None)
+    monkeypatch.setattr(mod, "_run_bootstrap", lambda *a, **k: ({}, None))
+    monkeypatch.setattr(mod, "_cortex_remote_sync", lambda *a, **k: None)
+
+
+def test_split_brain_flag_set_on_healed(tmp_path, monkeypatch, capsys):
+    mod = _load_hook_module()
+    _stub_bootstrap_chain(mod, monkeypatch, heal_status="healed")
+    result = mod.create_session_and_bootstrap("test-ai", project_id=UUID_A)
+    assert result.get("split_brain_corrected") is True
+    assert "SPLIT-BRAIN" in capsys.readouterr().err
+
+
+def test_no_split_brain_flag_when_ok(tmp_path, monkeypatch, capsys):
+    mod = _load_hook_module()
+    _stub_bootstrap_chain(mod, monkeypatch, heal_status="ok")
+    result = mod.create_session_and_bootstrap("test-ai", project_id=UUID_A)
+    assert "split_brain_corrected" not in result
+    assert "SPLIT-BRAIN" not in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# Leg 2 — session_create ignores generic active_work.json in interactive mode
+# ---------------------------------------------------------------------------
+
+
+def test_generic_active_work_ignored_when_interactive(tmp_path, monkeypatch):
+    """Interactive (is_headless False) + stale generic active_work.json present,
+    no instance/tty context → resolution must return None (NOT the stale id)."""
+    from empirica.cli.command_handlers import session_create as sc
+
+    empirica_dir = tmp_path / ".empirica"
+    empirica_dir.mkdir(parents=True)
+    (empirica_dir / "active_work.json").write_text(f'{{"project_id": "{UUID_B}"}}')
+
+    monkeypatch.setattr(os.path, "expanduser", lambda p: str(tmp_path))
+    monkeypatch.setattr(sc.R, "instance_id", staticmethod(lambda: None))
+    monkeypatch.setattr(sc.R, "tty_session", staticmethod(lambda warn_if_stale=False: None))
+    monkeypatch.setattr(sc.R, "is_headless", staticmethod(lambda: False))
+
+    assert sc._resolve_from_context_files() is None
+
+
+def test_generic_active_work_used_when_headless(tmp_path, monkeypatch):
+    """Headless (containers/CI) → the generic active_work.json IS the fallback."""
+    from empirica.cli.command_handlers import session_create as sc
+
+    empirica_dir = tmp_path / ".empirica"
+    empirica_dir.mkdir(parents=True)
+    (empirica_dir / "active_work.json").write_text(f'{{"project_id": "{UUID_A}"}}')
+
+    monkeypatch.setattr(os.path, "expanduser", lambda p: str(tmp_path))
+    monkeypatch.setattr(sc.R, "instance_id", staticmethod(lambda: None))
+    monkeypatch.setattr(sc.R, "tty_session", staticmethod(lambda warn_if_stale=False: None))
+    monkeypatch.setattr(sc.R, "is_headless", staticmethod(lambda: True))
+
+    assert sc._resolve_from_context_files() == UUID_A


### PR DESCRIPTION
## Verified P0 — silent cross-tenant persistence contamination

Diagnosed by Franci (NLE) via ecodex, independently verified against 1.12.26 by direct code read + git history. A session **displayed** the correct project but **persisted** its session row + artifacts to a stale project — findings/goals/calibration silently landing in the wrong project while the UI showed the right one.

### Root cause (3 confirmed engine faults)
1. `session_create._resolve_from_context_files` read the generic `~/.empirica/active_work.json` **unconditionally**, while `session_resolver.get_active_project_path` gates the same file behind `is_headless()` ("HEADLESS MODE ONLY"). A divergent second copy of the resolution logic — a 3-month-old global file outranked cwd/project.yaml in interactive mode.
2. `session-init` created the session with **no `--project-id`** (the param existed on `create_session_and_bootstrap` but was dead), so session-create re-resolved and hit fault 1.
3. Both session-init healers exact-matched `trajectory_path=<root>/.empirica` and silently returned on miss — projects registered as bare `<root>` (the projects-discover form) defeated the ghost-project_id heal that would have caught this.

### The fix (4 legs)
1. **Pin at creation** — `_resolve_canonical_project_id_for_root(project_root)` (project.yaml UUID → normalized workspace.db lookup) threaded as `--project-id` through `create_session_and_bootstrap → _create_empirica_session`. The cwd-validated root was already computed; it just wasn't used to pin the session.
2. **Kill the divergent copy** — gate `_resolve_from_context_files`'s generic `active_work.json` read on `R.is_headless()`, matching the canonical resolver invariant.
3. **Normalize the heal** — both healers share `_lookup_project_id_by_trajectory`, tolerating **both** `<root>` and `<root>/.empirica` forms (single source of truth).
4. **Fail loud** — a residual `"healed"` bind is elevated to a `split_brain_corrected` stderr signal + result flag (not a hard abort — too disruptive fleet-wide).

### Tests
`tests/test_split_brain_persistence.py` — 12 regression tests mapping Franci's spec items 1/2/5/7 (global stale fallback, first-run no instance file, two trajectory forms, split-brain detector). Related suites green: **133 tests** (session-init, session_create, resolver, auto-init, project-identity). ruff + pyright clean.

Not ecodex-only — the divergent `active_work` copy + healer gap were latent for Claude Code too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)