### PR TITLE
fix(hooks): loop-install Gate 5 keys listener-armed on ai_id, not session id

### DIFF
--- a/empirica/core/cockpit/canonical_loops.py
+++ b/empirica/core/cockpit/canonical_loops.py
@@ -83,6 +83,14 @@ CANONICAL_LOOPS: list[dict[str, Any]] = [
         # the Monitor armed at SessionStart (session-monitor-arm.py).
         # Must match VALID_SCHEDULER_KIND in loop_registry.py.
         "scheduler_kind": "systemd-user",
+        # This poll is PURE REDUNDANCY when a persistent listener is armed for
+        # this ai_id — the listener already bridges the same inbox/outbox events
+        # via push (faster than 30s polling). The loop-install pickup hook uses
+        # this flag to skip auto-queuing it on wake-on-events seats (David: "that
+        # loop should never be installed, it's only for non-wake-on-events
+        # environments"). Genuine housekeeping crons (message-cleanup) do NOT set
+        # this — they install regardless of the listener.
+        "redundant_when_listener_armed": True,
     },
     {
         # Housekeeping: prune expired git-notes mesh messages once a day.

--- a/empirica/plugins/claude-code-integration/hooks/loop-install-pickup.py
+++ b/empirica/plugins/claude-code-integration/hooks/loop-install-pickup.py
@@ -95,20 +95,37 @@ def _maybe_auto_install_canonical_loops(instance_id: str, project_root: Path) ->
         from empirica.core.cockpit.canonical_loops import CANONICAL_LOOPS
         from empirica.core.cockpit.loop_install_request import write_pending
 
-        # Gate 5: on a wake-on-event harness (an armed listener bridges events
-        # into the session via the loop_fires Monitor), event-drivable canonical
-        # loops — those the catalog runs via systemd + the wake bridge
-        # (scheduler_kind='systemd-user') — are pure redundancy as a CronCreate
-        # poll. Skip them here; genuine housekeeping crons (message-cleanup) still
-        # install. (extension prop_syrvccyu6: this poller was surfaced every
-        # session on 30+ wake-on-event seats.)
-        listener_armed = any(empirica_home.glob(f"listener_active_{instance_id}_*.json"))
+        # Gate 5: on a wake-on-event harness (a persistent listener bridges
+        # inbox/outbox events into the session via push), catalog loops flagged
+        # `redundant_when_listener_armed` (the cortex-mailbox-poll poller) are
+        # pure redundancy — skip auto-queuing them when a listener is armed.
+        # Genuine housekeeping crons (message-cleanup) are not flagged and still
+        # install.
+        #
+        # CRITICAL: the ``listener_active_*`` markers are keyed by AI_ID, NOT the
+        # session ``instance_id``. The old check globbed
+        # ``listener_active_{instance_id}_*`` (a session/thread UUID) which never
+        # matched the ai_id-keyed marker → listener_armed was always False → the
+        # poller was re-offered every session on wake-on-events seats
+        # (cortex prop_osuft3rn; extension prop_syrvccyu6). Resolve ai_id from
+        # project.yaml (basename fallback) and glob by that.
+        ai_id = ""
+        try:
+            import yaml
+
+            _cfg = yaml.safe_load((project_root / ".empirica" / "project.yaml").read_text()) or {}
+            ai_id = (_cfg.get("ai_id") or "").strip()
+        except Exception:
+            ai_id = ""
+        if not ai_id:
+            ai_id = project_root.name
+        listener_armed = bool(ai_id) and any(empirica_home.glob(f"listener_active_{ai_id}_*.json"))
 
         installed = 0
         for entry in CANONICAL_LOOPS:
             scheduler_kind = entry.get("scheduler_kind")
-            if listener_armed and scheduler_kind == "systemd-user":
-                continue  # gate 5: event-drivable + listener already armed → redundant
+            if listener_armed and entry.get("redundant_when_listener_armed"):
+                continue  # gate 5: redundant with the armed push listener
             try:
                 write_pending(
                     instance_id=instance_id,

--- a/tests/test_loop_install_listener_gate.py
+++ b/tests/test_loop_install_listener_gate.py
@@ -1,0 +1,89 @@
+"""Gate 5: cortex-mailbox-poll must NOT be auto-queued when a persistent
+listener is armed for this ai_id — the listener already bridges those events.
+
+Regression for the ai_id/session-UUID key mismatch (cortex prop_osuft3rn): the
+listener_armed check must glob by AI_ID (``listener_active_<ai_id>_*.json``), not
+the session ``instance_id``, or the gate never fires on wake-on-events seats and
+the poller gets re-offered every session. Housekeeping crons (message-cleanup)
+are not flagged redundant and still install.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import yaml
+
+HOOK = (
+    Path(__file__).parent.parent
+    / "empirica"
+    / "plugins"
+    / "claude-code-integration"
+    / "hooks"
+    / "loop-install-pickup.py"
+)
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("loop_install_pickup", HOOK)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    plugin_lib = HOOK.parent.parent / "lib"
+    sys.path.insert(0, str(plugin_lib))
+    try:
+        spec.loader.exec_module(mod)
+    finally:
+        sys.path.remove(str(plugin_lib))
+    return mod
+
+
+def _project(tmp_path, ai_id="test-ai"):
+    proj = tmp_path / "proj"
+    (proj / ".empirica").mkdir(parents=True)
+    (proj / ".empirica" / "project.yaml").write_text(yaml.safe_dump({"ai_id": ai_id}))
+    return proj
+
+
+def _setup(monkeypatch, tmp_path, listener_marker_for=None):
+    mod = _load()
+    home = tmp_path / "home"
+    (home / ".empirica").mkdir(parents=True)
+    if listener_marker_for:
+        (home / ".empirica" / f"listener_active_{listener_marker_for}_x-inbox.json").write_text("{}")
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+
+    import empirica.core.cockpit.loop_install_request as lir
+    import empirica.core.cockpit.loop_registry as lr
+
+    monkeypatch.setattr(lr.LoopRegistry, "list_loops", lambda self: [])  # gate 3: empty registry
+    queued: list[str] = []
+    monkeypatch.setattr(lir, "write_pending", lambda **kw: queued.append(kw["name"]))
+    return mod, queued
+
+
+def test_poller_skipped_when_listener_armed_for_ai_id(tmp_path, monkeypatch):
+    mod, queued = _setup(monkeypatch, tmp_path, listener_marker_for="test-ai")
+    proj = _project(tmp_path, ai_id="test-ai")
+    # instance_id is a SESSION UUID — deliberately different from the ai_id.
+    mod._maybe_auto_install_canonical_loops("019f-session-uuid", proj)
+    assert "cortex-mailbox-poll" not in queued  # gate 5 fired (redundant with listener)
+    assert "message-cleanup" in queued  # housekeeping cron still installs
+
+
+def test_poller_queued_when_no_listener(tmp_path, monkeypatch):
+    mod, queued = _setup(monkeypatch, tmp_path, listener_marker_for=None)
+    proj = _project(tmp_path, ai_id="test-ai")
+    mod._maybe_auto_install_canonical_loops("019f-session-uuid", proj)
+    assert "cortex-mailbox-poll" in queued  # non-wake-on-events → the poll is wanted
+    assert "message-cleanup" in queued
+
+
+def test_session_id_keyed_marker_does_not_arm_the_gate(tmp_path, monkeypatch):
+    # The OLD buggy key: a marker keyed by the SESSION instance_id must NOT count
+    # as armed — only the ai_id-keyed marker does. (This test fails on old code.)
+    mod, queued = _setup(monkeypatch, tmp_path, listener_marker_for="019f-session-uuid")
+    proj = _project(tmp_path, ai_id="test-ai")
+    mod._maybe_auto_install_canonical_loops("019f-session-uuid", proj)
+    assert "cortex-mailbox-poll" in queued  # session-id marker ≠ ai_id marker → not armed


### PR DESCRIPTION
## `cortex-mailbox-poll` re-offered every session on wake-on-events seats

David: *"that loop should never be installed, it's only for non-wake-on-events environments."* Independently reported by empirica-cortex (`prop_osuft3rn`) and earlier by extension (`prop_syrvccyu6`).

**Root cause — the suppression gate exists but is broken.** `loop-install-pickup.py` Gate 5 is meant to skip these loops when a listener is armed, but:
```python
listener_armed = any(empirica_home.glob(f"listener_active_{instance_id}_*.json"))
```
`instance_id` is the **session/thread UUID** (visible in the `canonical_loops_installed_019f…` stamps), while the real listener markers are keyed by **ai_id** (`listener_active_empirica_empirica-inbox.json`). The glob never matched → `listener_armed` always `False` → Gate 5 never fired → the poller was re-queued every session, even though `empirica-listener-<ai_id>.service` is running.

**Fix:**
1. Resolve `ai_id` from `project.yaml` (basename fallback) and glob the marker by ai_id — so Gate 5 finally fires.
2. Gate on an explicit `redundant_when_listener_armed` flag (only `cortex-mailbox-poll` sets it) instead of the `scheduler_kind == "systemd-user"` proxy — so the housekeeping cron (`message-cleanup`) still installs regardless of the listener, matching the gate's own stated intent.

**Tests (+3):** poller skipped when an ai_id-keyed marker exists (cron still installs); poller queued when no listener (the non-wake-on-events case it's *for*); and a **session-id-keyed marker does NOT arm the gate** (fails on the old code). ruff/pyright clean.

Deploys to running seats via `setup-claude-code` after release. Coordinated with cortex (I own the core hook; they're not double-implementing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)