### PR TITLE
fix(sentinel): classify read-only tailscale verbs as noetic

### DIFF
--- a/empirica/plugins/claude-code-integration/hooks/sentinel-gate.py
+++ b/empirica/plugins/claude-code-integration/hooks/sentinel-gate.py
@@ -259,6 +259,15 @@ SAFE_BASH_PREFIXES = (
     "dig ",
     "nslookup ",
     "host ",
+    # Tailscale read-only inspection (status/diagnostic verbs only).
+    # Mutating subcommands (up/set/down/switch/login/logout) are SEPARATE
+    # verbs — they never match these prefixes, so they stay praxic-gated.
+    # `tailscale status` also covers `tailscale status --json`.
+    "tailscale status",
+    "tailscale netcheck",
+    "tailscale ip",
+    "tailscale version",
+    "tailscale whois",
     # Remote inspection (read-only SSH)
     "ssh ",
     # Documentation

--- a/tests/test_sentinel_shell_constructs.py
+++ b/tests/test_sentinel_shell_constructs.py
@@ -795,3 +795,43 @@ class TestQuotedAssignment:
 
     def test_quoted_assignment_then_mutation_still_gates(self, gate):
         assert gate.is_safe_bash_command({"command": 'PAT="a b c" && rm file'}) is False
+
+
+class TestTailscaleReadOnly:
+    """`tailscale status` (and other read-only tailscale inspection verbs) are
+    pure network-status reads — same class as `git status` / `ps` — and must
+    classify noetic. Mutating subcommands (up/set/down/switch/login/logout) are
+    SEPARATE verbs that never match the read-only prefixes, so they stay
+    praxic-gated. Regression for mesh-support prop_4ucsu42r (David caught live)."""
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "tailscale status",
+            "tailscale status --json",
+            "tailscale netcheck",
+            "tailscale ip -4",
+            "tailscale version",
+            "tailscale whois 100.101.102.103",
+        ],
+    )
+    def test_read_only_tailscale_is_noetic(self, gate, cmd):
+        assert gate.is_safe_bash_command({"command": cmd}) is True
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "tailscale up",
+            "tailscale down",
+            "tailscale set --exit-node=foo",
+            "tailscale switch other-tailnet",
+            "tailscale login",
+            "tailscale logout",
+        ],
+    )
+    def test_mutating_tailscale_stays_praxic(self, gate, cmd):
+        assert gate.is_safe_bash_command({"command": cmd}) is False
+
+    def test_read_only_then_mutation_still_gates(self, gate):
+        # A read-only prefix must not launder a chained mutation.
+        assert gate.is_safe_bash_command({"command": "tailscale status && tailscale up"}) is False


### PR DESCRIPTION
## What

`tailscale status` (and `status --json`, `netcheck`, `ip`, `version`, `whois`) are pure read-only network-status commands — same class as `git status` / `ps` — but weren't on the Sentinel's noetic allowlist (`SAFE_BASH_PREFIXES` in `sentinel-gate.py`), so they forced an unneeded CHECK when inspecting the tailnet.

## Fix

Add the read-only inspection verbs as **specific prefixes**. Mutating subcommands (`up`/`set`/`down`/`switch`/`login`/`logout`) are separate verbs that never match these prefixes, so they stay praxic-gated. Chained mutations (`tailscale status && tailscale up`) still gate via the segment classifier.

## Tests

+13 in `TestTailscaleReadOnly` — read-only→noetic, mutating→praxic, chain-gate. Full file 213 pass; ruff check + format clean.

## Provenance

Reported by mesh-support (`prop_4ucsu42r`); David caught it live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)