### PR TITLE
perf(postflight): run storage pipeline detached, off the response critical path

### DIFF
--- a/empirica/cli/command_handlers/_postflight_storage_worker.py
+++ b/empirica/cli/command_handlers/_postflight_storage_worker.py
@@ -1,0 +1,51 @@
+"""Detached worker for the POSTFLIGHT storage pipeline.
+
+Spawned fire-and-forget by the POSTFLIGHT handler so the storage pipeline
+(embeddings + global sync + snapshot — measured ~5.7s) runs OFF the POSTFLIGHT
+response critical path. The parent writes the pipeline inputs to a JSON payload
+file and execs this module detached (start_new_session); we read the payload,
+delete the temp file, and run the pipeline to completion in the background.
+
+Eventual-consistency by design: embeddings / global-sync land a moment after
+POSTFLIGHT returns. Nothing reads them back synchronously (the in-session AI has
+already closed the loop; retrieval is future-tense), so the AI gets its response
+~5.7s sooner without losing any storage work.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+
+def main(payload_path: str) -> None:
+    try:
+        with open(payload_path, encoding="utf-8") as f:
+            payload = json.load(f)
+    except Exception:
+        return  # unreadable payload → nothing to do
+    finally:
+        # Temp file is single-use; drop it whether or not the load succeeded.
+        try:
+            os.unlink(payload_path)
+        except Exception:
+            pass
+
+    # Import lazily so the detached process only pays for what it runs.
+    from empirica.cli.command_handlers._workflow_postflight import _run_postflight_storage_pipeline
+
+    _run_postflight_storage_pipeline(
+        session_id=payload["session_id"],
+        vectors=payload["vectors"],
+        deltas=payload["deltas"],
+        reasoning=payload["reasoning"],
+        grounded_verification=payload["grounded_verification"],
+        postflight_confidence=payload["postflight_confidence"],
+        checkpoint_id=payload["checkpoint_id"],
+    )
+
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1:
+        main(sys.argv[1])

--- a/empirica/cli/command_handlers/_workflow_postflight.py
+++ b/empirica/cli/command_handlers/_workflow_postflight.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import sys
 import time
 from pathlib import Path
 from typing import Any
@@ -373,7 +374,26 @@ def _run_postflight_storage_pipeline(
 
     now = time.time()
 
-    _pipeline_embed_grounded_calibration(
+    # Opt-in per-stage timing (EMPIRICA_POSTFLIGHT_TIMING=1) — zero overhead when
+    # unset. Every stage here is a side-effect (embed / store / snapshot) that
+    # produces nothing the POSTFLIGHT response consumes, so this is where to look
+    # when POSTFLIGHT feels slow.
+    _timing = os.environ.get("EMPIRICA_POSTFLIGHT_TIMING")
+
+    def _stage(name, fn, *args, **kwargs):
+        if not _timing:
+            return fn(*args, **kwargs)
+        t0 = time.perf_counter()
+        try:
+            return fn(*args, **kwargs)
+        finally:
+            # stderr-direct, not logger.* — an opt-in diagnostic must surface
+            # regardless of the CLI's log level.
+            print(f"[postflight-timing] {name}: {(time.perf_counter() - t0) * 1000:.0f}ms", file=sys.stderr)
+
+    _stage(
+        "embed_grounded_calibration",
+        _pipeline_embed_grounded_calibration,
         session_id,
         vectors,
         grounded_verification,
@@ -382,9 +402,11 @@ def _run_postflight_storage_pipeline(
         goal_id,
         now,
     )
-    _pipeline_cortex_cache_feedback(session_id, vectors, grounded_verification)
-    _pipeline_trajectory_storage(session_id, project_id)
-    _pipeline_episodic_memory(
+    _stage("cortex_cache_feedback", _pipeline_cortex_cache_feedback, session_id, vectors, grounded_verification)
+    _stage("trajectory_storage", _pipeline_trajectory_storage, session_id, project_id)
+    _stage(
+        "episodic_memory",
+        _pipeline_episodic_memory,
         session_id,
         vectors,
         deltas,
@@ -395,10 +417,12 @@ def _run_postflight_storage_pipeline(
         goal_id,
         now,
     )
-    _pipeline_auto_embed_memories(session_id, project_id)
-    _pipeline_workspace_index_sync(session_id, project_id)
-    _pipeline_decay_and_global_sync(session_id, project_id)
-    _pipeline_epistemic_snapshot(
+    _stage("auto_embed_memories", _pipeline_auto_embed_memories, session_id, project_id)
+    _stage("workspace_index_sync", _pipeline_workspace_index_sync, session_id, project_id)
+    _stage("decay_and_global_sync", _pipeline_decay_and_global_sync, session_id, project_id)
+    _stage(
+        "epistemic_snapshot",
+        _pipeline_epistemic_snapshot,
         session_id,
         vectors,
         deltas,
@@ -406,6 +430,70 @@ def _run_postflight_storage_pipeline(
         postflight_confidence,
         checkpoint_id,
     )
+
+
+def _spawn_detached_storage_pipeline(
+    session_id: str,
+    vectors: dict,
+    deltas: dict,
+    reasoning: str,
+    grounded_verification: dict | None,
+    postflight_confidence: float,
+    checkpoint_id: str | None,
+) -> None:
+    """Run the storage pipeline OFF the POSTFLIGHT response critical path.
+
+    Writes the pipeline inputs to a temp JSON payload and spawns
+    ``_postflight_storage_worker`` detached (``start_new_session``), so the
+    ~5.7s of embeds + global sync doesn't block the POSTFLIGHT response. Falls
+    back to a synchronous run if staging or spawning fails — correctness over
+    latency; the storage work is never silently dropped.
+    """
+    import subprocess
+    import tempfile
+
+    def _inline():
+        _run_postflight_storage_pipeline(
+            session_id=session_id,
+            vectors=vectors,
+            deltas=deltas,
+            reasoning=reasoning,
+            grounded_verification=grounded_verification,
+            postflight_confidence=postflight_confidence,
+            checkpoint_id=checkpoint_id,
+        )
+
+    payload = {
+        "session_id": session_id,
+        "vectors": vectors,
+        "deltas": deltas,
+        "reasoning": reasoning,
+        "grounded_verification": grounded_verification,
+        "postflight_confidence": postflight_confidence,
+        "checkpoint_id": checkpoint_id,
+    }
+    try:
+        fd, path = tempfile.mkstemp(prefix="empirica_pf_storage_", suffix=".json")
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(payload, f)
+    except Exception:
+        _inline()  # can't stage payload → run inline
+        return
+
+    try:
+        subprocess.Popen(
+            [sys.executable, "-m", "empirica.cli.command_handlers._postflight_storage_worker", path],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+    except Exception:
+        try:
+            os.unlink(path)
+        except Exception:
+            pass
+        _inline()  # spawn failed → run inline
 
 
 def _run_grounded_verification(
@@ -1937,10 +2025,14 @@ def handle_postflight_submit_command(args):
                 tx_info["transaction_id"],
                 _extract_evidence_bundle(grounded_verification),
             )
+            # Detached: the ~5.7s storage pipeline (embeds + global sync) runs
+            # off the response critical path via _postflight_storage_worker.
+            # Falls back to synchronous inside the spawn helper if it can't
+            # detach, so the work is never dropped.
             _soft_run(
                 "storage_pipeline",
                 warnings,
-                _run_postflight_storage_pipeline,
+                _spawn_detached_storage_pipeline,
                 session_id=session_id,
                 vectors=vectors,
                 deltas=deltas,

--- a/tests/test_postflight_storage_detach.py
+++ b/tests/test_postflight_storage_detach.py
@@ -1,0 +1,97 @@
+"""POSTFLIGHT storage pipeline runs detached, off the response critical path.
+
+The storage pipeline (embeds + global sync — measured ~5.7s) produces nothing
+the POSTFLIGHT response consumes, so it's spawned fire-and-forget via
+_postflight_storage_worker. Guards:
+  - the spawn stages a JSON payload + detaches (start_new_session), not inline
+  - staging/spawn failure falls back to a synchronous run (never drop the work)
+  - the worker runs the pipeline from the payload + cleans up the temp file
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from unittest.mock import MagicMock, patch
+
+from empirica.cli.command_handlers import _postflight_storage_worker as worker
+from empirica.cli.command_handlers import _workflow_postflight as wf
+
+_V = {"know": 0.8, "do": 0.8, "context": 0.8, "clarity": 0.8}
+
+
+def test_spawn_writes_payload_and_detaches():
+    seen = {}
+
+    def fake_popen(args, **kwargs):
+        seen["args"] = args
+        seen["kwargs"] = kwargs
+        with open(args[-1], encoding="utf-8") as pf:
+            seen["payload"] = json.load(pf)
+        return MagicMock()
+
+    with (
+        patch("subprocess.Popen", side_effect=fake_popen),
+        patch.object(wf, "_run_postflight_storage_pipeline") as inline,
+    ):
+        wf._spawn_detached_storage_pipeline("sid-1", _V, {"know": 0.1}, "why", {"evidence_count": 5}, 0.82, "ckpt")
+
+    assert seen["kwargs"]["start_new_session"] is True
+    assert "_postflight_storage_worker" in seen["args"][2]
+    assert seen["payload"]["session_id"] == "sid-1"
+    assert seen["payload"]["grounded_verification"] == {"evidence_count": 5}
+    assert seen["payload"]["checkpoint_id"] == "ckpt"
+    inline.assert_not_called()  # detached, NOT run inline
+
+
+def test_spawn_falls_back_inline_on_popen_failure():
+    with (
+        patch("subprocess.Popen", side_effect=OSError("cannot spawn")),
+        patch.object(wf, "_run_postflight_storage_pipeline") as inline,
+    ):
+        wf._spawn_detached_storage_pipeline("sid-2", _V, {}, "why", None, 0.8, None)
+
+    inline.assert_called_once()  # spawn failed → work runs synchronously, never dropped
+    assert inline.call_args.kwargs["session_id"] == "sid-2"
+
+
+def test_spawn_falls_back_inline_when_staging_fails():
+    with (
+        patch("tempfile.mkstemp", side_effect=OSError("no temp")),
+        patch.object(wf, "_run_postflight_storage_pipeline") as inline,
+    ):
+        wf._spawn_detached_storage_pipeline("sid-3", _V, {}, "why", None, 0.8, None)
+
+    inline.assert_called_once()
+
+
+def test_worker_runs_pipeline_and_cleans_up():
+    fd, path = tempfile.mkstemp(suffix=".json")
+    with os.fdopen(fd, "w", encoding="utf-8") as f:
+        json.dump(
+            {
+                "session_id": "sid-4",
+                "vectors": _V,
+                "deltas": {},
+                "reasoning": "r",
+                "grounded_verification": None,
+                "postflight_confidence": 0.8,
+                "checkpoint_id": None,
+            },
+            f,
+        )
+
+    with patch.object(wf, "_run_postflight_storage_pipeline") as pipe:
+        worker.main(path)
+
+    pipe.assert_called_once()
+    assert pipe.call_args.kwargs["session_id"] == "sid-4"
+    assert not os.path.exists(path)  # temp payload cleaned up
+
+
+def test_worker_unreadable_payload_is_noop():
+    # Missing file → return quietly, never call the pipeline.
+    with patch.object(wf, "_run_postflight_storage_pipeline") as pipe:
+        worker.main("/nonexistent/path/payload.json")
+    pipe.assert_not_called()


### PR DESCRIPTION
## Measured first (per David's "if it truly is the bottleneck")
`EMPIRICA_POSTFLIGHT_TIMING` + live harness — the POSTFLIGHT **storage pipeline is ~5.7s** of pure side-effect latency on the response critical path:

| Stage | ms |
|---|---|
| decay_and_global_sync | 2860 |
| embed_grounded_calibration | 1244 |
| auto_embed_memories | 1152 |
| episodic_memory | 214 |
| snapshot / workspace / trajectory / cortex_cache | ~195 |
| **TOTAL** | **~5681** |

None of it feeds `_build_postflight_result` (the response comes from vectors/calibration/compliance, computed separately) — so it was pure blocking cost.

## Fix (Option B)
`_spawn_detached_storage_pipeline` writes the pipeline inputs to a temp JSON payload and spawns `_postflight_storage_worker` **detached** (`start_new_session`). The ~5.7s runs in the background; the POSTFLIGHT response returns that much sooner. Eventual-consistency by design — embeds/global-sync land a beat after return; nothing reads them back synchronously.

**Correctness:** falls back to a **synchronous** run if staging *or* spawn fails — storage work is never silently dropped. Validated end-to-end (worker consumes payload, runs pipeline, cleans temp file).

Also adds opt-in per-stage timing (`EMPIRICA_POSTFLIGHT_TIMING`, stderr) for future perf work.

## Tests
+5: detach-not-inline / fallback-on-spawn-fail / fallback-on-staging-fail / worker-runs+cleans / worker-noop-on-bad-payload. 34 existing postflight-pipeline tests still green; ruff + format + pyright clean.

## Note for follow-up
A code-work POSTFLIGHT still totals ~16s wall-clock — so **grounded verification (code_quality: pyright/radon/git/pytest) is the larger cost**, and it's response-critical (can't detach the same way). Flagged separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)