### PR TITLE
fix(postflight): pickle the detach payload — #366 never actually detached

### DIFF
--- a/empirica/cli/command_handlers/_postflight_storage_worker.py
+++ b/empirica/cli/command_handlers/_postflight_storage_worker.py
@@ -14,15 +14,18 @@ already closed the loop; retrieval is future-tense), so the AI gets its response
 
 from __future__ import annotations
 
-import json
 import os
+import pickle
 import sys
 
 
 def main(payload_path: str) -> None:
+    # pickle, not json: the payload carries an EvidenceBundle object (see
+    # _spawn_detached_storage_pipeline). Same-user 0600 temp file written by our
+    # own process — no untrusted input.
     try:
-        with open(payload_path, encoding="utf-8") as f:
-            payload = json.load(f)
+        with open(payload_path, "rb") as f:
+            payload = pickle.load(f)  # noqa: S301 — our own 0600 temp file, no untrusted input
     except Exception:
         return  # unreadable payload → nothing to do
     finally:

--- a/empirica/cli/command_handlers/_workflow_postflight.py
+++ b/empirica/cli/command_handlers/_workflow_postflight.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import pickle
 import sys
 import time
 from pathlib import Path
@@ -472,12 +473,22 @@ def _spawn_detached_storage_pipeline(
         "postflight_confidence": postflight_confidence,
         "checkpoint_id": checkpoint_id,
     }
+    # pickle, not json: grounded_verification is an EvidenceBundle object (+
+    # other rich values) that json can't serialize — json.dump would fail on
+    # every real POSTFLIGHT and silently fall back to inline (no detach). It's
+    # our own 0600 temp file, consumed once by our own worker: no untrusted input.
+    path = None
     try:
-        fd, path = tempfile.mkstemp(prefix="empirica_pf_storage_", suffix=".json")
-        with os.fdopen(fd, "w", encoding="utf-8") as f:
-            json.dump(payload, f)
+        fd, path = tempfile.mkstemp(prefix="empirica_pf_storage_", suffix=".pkl")
+        with os.fdopen(fd, "wb") as f:
+            pickle.dump(payload, f)
     except Exception:
-        _inline()  # can't stage payload → run inline
+        if path:
+            try:
+                os.unlink(path)
+            except Exception:
+                pass
+        _inline()  # can't stage payload → run inline (never drop the work)
         return
 
     try:

--- a/empirica/cli/command_handlers/_workflow_shared.py
+++ b/empirica/cli/command_handlers/_workflow_shared.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 import json
 import logging
 import os
+import sys
+import time
 
 from empirica.config.path_resolver import resolve_session_db_path
 from empirica.core.canonical.empirica_git.sentinel_hooks import SentinelHooks
@@ -1005,6 +1007,15 @@ def _soft_run(stage_name: str, warnings: list, fn, *args, **kwargs):
     to stop, and we should let it propagate through the whole call stack.
     """
     try:
+        if os.environ.get("EMPIRICA_POSTFLIGHT_TIMING"):
+            _t0 = time.perf_counter()
+            try:
+                return fn(*args, **kwargs)
+            finally:
+                print(
+                    f"[postflight-timing] phase:{stage_name}: {(time.perf_counter() - _t0) * 1000:.0f}ms",
+                    file=sys.stderr,
+                )
         return fn(*args, **kwargs)
     except SystemExit as e:
         # Library code that called sys.exit(N) — treat as a soft failure

--- a/empirica/core/post_test/collector.py
+++ b/empirica/core/post_test/collector.py
@@ -29,7 +29,9 @@ docstring for the full dual-track calibration philosophy.
 
 import json
 import logging
+import os
 import subprocess
+import sys
 import time
 from dataclasses import dataclass, field
 from enum import Enum
@@ -509,9 +511,21 @@ class PostTestCollector:
 
         collectors = universal + profile_collectors
 
+        # Opt-in per-collector timing (EMPIRICA_POSTFLIGHT_TIMING=1) — surfaces
+        # which evidence source dominates grounded-verification latency.
+        _timing = os.environ.get("EMPIRICA_POSTFLIGHT_TIMING")
+
         for source_name, collector_fn in collectors:
             try:
-                items = collector_fn()
+                if _timing:
+                    _t0 = time.perf_counter()
+                    items = collector_fn()
+                    print(
+                        f"[postflight-timing] collect:{source_name}: {(time.perf_counter() - _t0) * 1000:.0f}ms",
+                        file=sys.stderr,
+                    )
+                else:
+                    items = collector_fn()
                 if items:
                     bundle.items.extend(items)
                     bundle.sources_available.append(source_name)

--- a/tests/test_postflight_storage_detach.py
+++ b/tests/test_postflight_storage_detach.py
@@ -3,15 +3,15 @@
 The storage pipeline (embeds + global sync — measured ~5.7s) produces nothing
 the POSTFLIGHT response consumes, so it's spawned fire-and-forget via
 _postflight_storage_worker. Guards:
-  - the spawn stages a JSON payload + detaches (start_new_session), not inline
+  - the spawn stages a pickled payload + detaches (start_new_session), not inline
   - staging/spawn failure falls back to a synchronous run (never drop the work)
   - the worker runs the pipeline from the payload + cleans up the temp file
 """
 
 from __future__ import annotations
 
-import json
 import os
+import pickle
 import tempfile
 from unittest.mock import MagicMock, patch
 
@@ -21,14 +21,23 @@ from empirica.cli.command_handlers import _workflow_postflight as wf
 _V = {"know": 0.8, "do": 0.8, "context": 0.8, "clarity": 0.8}
 
 
+class _NotJsonSerializable:
+    """Stand-in for grounded_verification's EvidenceBundle — pickles fine, but
+    json.dump would raise. This is exactly the object that made the first cut of
+    the detach silently fall back to inline on every real POSTFLIGHT."""
+
+    def __init__(self, tag):
+        self.tag = tag
+
+
 def test_spawn_writes_payload_and_detaches():
     seen = {}
 
     def fake_popen(args, **kwargs):
         seen["args"] = args
         seen["kwargs"] = kwargs
-        with open(args[-1], encoding="utf-8") as pf:
-            seen["payload"] = json.load(pf)
+        with open(args[-1], "rb") as pf:
+            seen["payload"] = pickle.load(pf)  # noqa: S301
         return MagicMock()
 
     with (
@@ -43,6 +52,28 @@ def test_spawn_writes_payload_and_detaches():
     assert seen["payload"]["grounded_verification"] == {"evidence_count": 5}
     assert seen["payload"]["checkpoint_id"] == "ckpt"
     inline.assert_not_called()  # detached, NOT run inline
+
+
+def test_spawn_detaches_with_non_json_serializable_grounded_verification():
+    """Regression: grounded_verification is an EvidenceBundle (not JSON-safe).
+    The payload must pickle + detach, NOT silently fall back to inline."""
+    seen = {}
+
+    def fake_popen(args, **kwargs):
+        with open(args[-1], "rb") as pf:
+            seen["payload"] = pickle.load(pf)  # noqa: S301
+        return MagicMock()
+
+    gv = _NotJsonSerializable("bundle")
+    with (
+        patch("subprocess.Popen", side_effect=fake_popen),
+        patch.object(wf, "_run_postflight_storage_pipeline") as inline,
+    ):
+        wf._spawn_detached_storage_pipeline("sid-gv", _V, {}, "why", gv, 0.8, None)
+
+    inline.assert_not_called()  # detached — did NOT fall back to inline
+    assert isinstance(seen["payload"]["grounded_verification"], _NotJsonSerializable)
+    assert seen["payload"]["grounded_verification"].tag == "bundle"
 
 
 def test_spawn_falls_back_inline_on_popen_failure():
@@ -67,9 +98,9 @@ def test_spawn_falls_back_inline_when_staging_fails():
 
 
 def test_worker_runs_pipeline_and_cleans_up():
-    fd, path = tempfile.mkstemp(suffix=".json")
-    with os.fdopen(fd, "w", encoding="utf-8") as f:
-        json.dump(
+    fd, path = tempfile.mkstemp(suffix=".pkl")
+    with os.fdopen(fd, "wb") as f:
+        pickle.dump(
             {
                 "session_id": "sid-4",
                 "vectors": _V,


### PR DESCRIPTION
## The bug (#366 was a no-op in practice)
#366 shipped the storage-pipeline detach, but it **silently fell back to inline on every real POSTFLIGHT**: the payload's `grounded_verification` is an **`EvidenceBundle` object**, so `json.dump` raised `TypeError` → the `except` ran the pipeline synchronously. Measured proof: `phase:storage_pipeline` was still **3.7s** on the critical path, with empty temp files left behind. The synchronous fallback meant **no data was ever lost** — but no speedup was delivered either. #366's tests passed a plain `dict`, so they never exercised the real object.

Caught by instrumenting the spawn branches (the timing measurement flagged that the phase stayed 3.7s despite "detaching").

## Fix
Serialize the payload with **pickle** instead of json (`EvidenceBundle` pickles cleanly; it's our own 0600 temp file consumed once by our own worker — no untrusted input). Also unlink the temp file when staging fails, so failed spawns leave no debris.

**Validated:** `_spawn` now returns in **~1ms** (was 3.7s inline) with a real `EvidenceBundle`, and the worker consumes the payload end-to-end.

## Also
Opt-in per-stage/per-phase timing (`EMPIRICA_POSTFLIGHT_TIMING`, stderr) across the storage pipeline, the evidence collectors, and `_soft_run` — the observability that surfaced this and localizes future POSTFLIGHT latency work.

## Tests
+1 regression (non-JSON-serializable `grounded_verification` must still detach, not fall back to inline); existing detach tests moved to pickle. 6/6 pass; ruff + format + pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)