### PR TITLE
fix(compliance): release_chain checks PyPI via live API, not pip's stale cache

### DIFF
--- a/empirica/cli/command_handlers/compliance_report_commands.py
+++ b/empirica/cli/command_handlers/compliance_report_commands.py
@@ -598,6 +598,23 @@ def _build_release_chain_check(project_root: Path) -> dict[str, Any]:
     }
 
 
+def _pypi_has_version(pkg: str, version: str) -> bool:
+    """Query PyPI's live JSON API for whether ``version`` of ``pkg`` is published.
+
+    Uses the live API rather than ``pip index versions`` — pip reads its local
+    HTTP cache, which lags minutes behind a fresh publish and produced a
+    false-negative in ``release_chain`` right after ``release.py --publish``.
+    """
+    import urllib.request
+
+    try:
+        with urllib.request.urlopen(f"https://pypi.org/pypi/{pkg}/json", timeout=10) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+        return version in data.get("releases", {})
+    except Exception:
+        return False
+
+
 def _check_channel(channel: str, version: str, project_root: Path) -> str:
     """Check if version is published to a specific channel. Returns status string."""
     try:
@@ -621,22 +638,10 @@ def _check_channel(channel: str, version: str, project_root: Path) -> str:
             return "published" if result.returncode == 0 else "missing"
 
         if channel == "pypi":
-            result = subprocess.run(
-                ["pip", "index", "versions", "empirica"],
-                capture_output=True,
-                text=True,
-                timeout=15,
-            )
-            return "published" if version in result.stdout else "missing"
+            return "published" if _pypi_has_version("empirica", version) else "missing"
 
         if channel == "pypi_mcp":
-            result = subprocess.run(
-                ["pip", "index", "versions", "empirica-mcp"],
-                capture_output=True,
-                text=True,
-                timeout=15,
-            )
-            return "published" if version in result.stdout else "missing"
+            return "published" if _pypi_has_version("empirica-mcp", version) else "missing"
 
         if channel == "docker":
             # Check Docker Hub tag existence via API

--- a/tests/test_release_chain_pypi.py
+++ b/tests/test_release_chain_pypi.py
@@ -1,0 +1,50 @@
+"""release_chain PyPI check queries the live API, not pip's local cache.
+
+Regression: `_check_channel("pypi", ...)` used `pip index versions`, which reads
+pip's HTTP cache — stale for minutes after a fresh publish — so `release_chain`
+reported pypi "missing" right after `release.py --publish` even though the
+version was live. `_pypi_has_version` now hits PyPI's JSON API directly.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+from empirica.cli.command_handlers.compliance_report_commands import _pypi_has_version
+
+
+def _fake_response(payload: dict):
+    """A urlopen() context-manager stand-in whose .read() returns `payload`."""
+    resp = MagicMock()
+    resp.read.return_value = json.dumps(payload).encode("utf-8")
+    cm = MagicMock()
+    cm.__enter__.return_value = resp
+    cm.__exit__.return_value = False
+    return cm
+
+
+def test_true_when_version_present():
+    with patch("urllib.request.urlopen", return_value=_fake_response({"releases": {"1.12.30": [], "1.12.29": []}})):
+        assert _pypi_has_version("empirica", "1.12.30") is True
+
+
+def test_false_when_version_absent():
+    with patch("urllib.request.urlopen", return_value=_fake_response({"releases": {"1.12.29": []}})):
+        assert _pypi_has_version("empirica", "1.12.30") is False
+
+
+def test_false_on_network_error():
+    # A transient failure must not crash the compliance report — just "missing".
+    with patch("urllib.request.urlopen", side_effect=OSError("network down")):
+        assert _pypi_has_version("empirica", "1.12.30") is False
+
+
+def test_false_on_malformed_json():
+    resp = MagicMock()
+    resp.read.return_value = b"not json"
+    cm = MagicMock()
+    cm.__enter__.return_value = resp
+    cm.__exit__.return_value = False
+    with patch("urllib.request.urlopen", return_value=cm):
+        assert _pypi_has_version("empirica", "1.12.30") is False


### PR DESCRIPTION
## Bug
`release_chain`'s pypi/pypi_mcp checks used `pip index versions`, which reads pip's **local HTTP cache** — stale for minutes after a fresh publish. So right after `release.py --publish`, `release_chain` reported pypi **"missing"** even though the version was already live on the `/simple/` index pip resolves against. Observed on the 1.12.30 release (4/6 channels, pypi false-negative).

## Fix
`_pypi_has_version` queries PyPI's **live JSON API** (`https://pypi.org/pypi/<pkg>/json`), which reflects a publish immediately. Verified live: `release_chain` now reports **6/6** and overall **fully_compliant 13/13** for 1.12.30.

## Tests
+4 (present / absent / network-error / malformed-json) — all mock `urlopen`, no network in CI. ruff + format + pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)