### PR TITLE
fix: dependabot targets develop + SessionStart skips re-arm when tail already live

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,10 @@ updates:
   # Core empirica package
   - package-ecosystem: pip
     directory: "/"
+    # Land bumps on develop (our trunk), not the default branch (main) — so they
+    # get CI-tested on develop and flow to main via the normal release, instead
+    # of landing on main and needing a manual back-port.
+    target-branch: "develop"
     schedule:
       interval: weekly
       day: monday
@@ -34,6 +38,7 @@ updates:
   # MCP wrapper package
   - package-ecosystem: pip
     directory: "/empirica-mcp"
+    target-branch: "develop"
     schedule:
       interval: weekly
       day: monday
@@ -44,6 +49,7 @@ updates:
   # GitHub Actions versions
   - package-ecosystem: github-actions
     directory: "/"
+    target-branch: "develop"
     schedule:
       interval: weekly
       day: monday

--- a/empirica/plugins/claude-code-integration/hooks/session-monitor-arm.py
+++ b/empirica/plugins/claude-code-integration/hooks/session-monitor-arm.py
@@ -61,6 +61,36 @@ def _has_active_listener_intent(instance_id: str) -> bool:
         return False
 
 
+def _has_live_log_tail(instance_id: str) -> bool:
+    """True iff a live (non-orphan) loop_fires tail-Monitor for this ai_id is
+    already running — a monitor is already bridging wakes into an active session.
+
+    SessionStart re-fires on every compaction / new-session-init, and the AI
+    can't reliably dedup across a compaction (the prior Monitor's task id is
+    gone). Without this check the hook re-emits arm instructions and each arm
+    stacks another tail that delivers every wake event an extra time. If a live
+    tail already exists, the hook skips re-arming.
+
+    Orphan tails (ppid == 1, dead parent) do NOT count — they deliver nowhere
+    and are handled by `listener gc`; only a live-parent tail means an active
+    session is already covered. Never raises.
+    """
+    try:
+        from empirica.core.cockpit.listener_processes import (
+            _ai_id_from_listener_cmdline,
+            walk_listener_processes,
+        )
+
+        for p in walk_listener_processes():
+            if p.get("kind") != "log_tail" or p.get("ppid") == 1:
+                continue
+            if _ai_id_from_listener_cmdline(p.get("cmdline", "")) == instance_id:
+                return True
+    except Exception:
+        pass
+    return False
+
+
 def _build_reaction_table(loop_names: list[str]) -> str:
     """Markdown table mapping each active loop → its body skill."""
     rows = []
@@ -397,6 +427,31 @@ def main() -> int:
     # service + no record of prior intent.
     if not loops and not listener_running and not has_prior_intent:
         print(json.dumps({}))
+        return 0
+
+    # A live tail-Monitor for this ai_id already bridging wakes → do NOT re-emit
+    # arm instructions. SessionStart re-fires on compaction / new-session-init;
+    # re-arming would stack a duplicate tail that delivers every event twice.
+    if _has_live_log_tail(instance_id):
+        already = (
+            f"## 📬 Mesh listener already armed\n\n"
+            f"A live tail-Monitor for `{instance_id}` is already bridging wake events "
+            f"into this session — SessionStart re-fired (compaction / new-session-init), "
+            f"but re-arming would stack a duplicate tail that delivers every event twice. "
+            f"**No action needed — do not arm another Monitor.**\n\n"
+            f"If you ever see duplicate wake deliveries, reap same-ai_id duplicates with "
+            f"`empirica listener gc --apply`."
+        )
+        print(
+            json.dumps(
+                {
+                    "hookSpecificOutput": {
+                        "hookEventName": "SessionStart",
+                        "additionalContext": already,
+                    },
+                }
+            )
+        )
         return 0
 
     additional = _build_additional_context(

--- a/tests/test_monitor_arm_dedup.py
+++ b/tests/test_monitor_arm_dedup.py
@@ -1,0 +1,78 @@
+"""SessionStart hook skips re-arming when a live tail-Monitor already exists.
+
+Regression: SessionStart re-fires on compaction / new-session-init, and the AI
+can't dedup across a compaction (the prior Monitor's task id is gone), so the
+hook re-emitted arm instructions and each arm stacked another loop_fires tail
+that delivered every wake event an extra time. `_has_live_log_tail` detects a
+live (non-orphan) tail for the ai_id so the hook can skip re-arming.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from unittest.mock import patch
+
+_HOOK = (
+    Path(__file__).parent.parent
+    / "empirica"
+    / "plugins"
+    / "claude-code-integration"
+    / "hooks"
+    / "session-monitor-arm.py"
+)
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("session_monitor_arm", _HOOK)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _tail(ai_id: str, ppid: int = 12345) -> dict:
+    return {
+        "pid": 999,
+        "ppid": ppid,
+        "kind": "log_tail",
+        "cmdline": (
+            f'tail -F -n 0 /home/x/.empirica/loop_fires.log | grep -E --line-buffered \'"instance_id": "{ai_id}"\''
+        ),
+    }
+
+
+_WALK = "empirica.core.cockpit.listener_processes.walk_listener_processes"
+
+
+def test_live_tail_for_ai_id_is_detected():
+    mod = _load()
+    with patch(_WALK, return_value=[_tail("empirica")]):
+        assert mod._has_live_log_tail("empirica") is True
+
+
+def test_orphan_tail_does_not_count():
+    # ppid == 1 → dead parent, delivers nowhere; handled by listener gc, not a
+    # reason to skip arming an active session.
+    mod = _load()
+    with patch(_WALK, return_value=[_tail("empirica", ppid=1)]):
+        assert mod._has_live_log_tail("empirica") is False
+
+
+def test_tail_for_a_different_ai_id_is_ignored():
+    mod = _load()
+    with patch(_WALK, return_value=[_tail("empirica-workspace")]):
+        assert mod._has_live_log_tail("empirica") is False
+
+
+def test_no_tails_returns_false():
+    mod = _load()
+    with patch(_WALK, return_value=[]):
+        assert mod._has_live_log_tail("empirica") is False
+
+
+def test_loop_listen_kind_is_not_a_tail():
+    # A loop_listen process is OS-supervised, not a session tail-Monitor.
+    mod = _load()
+    proc = {"pid": 5, "ppid": 5, "kind": "loop_listen", "cmdline": "empirica loop listen --instance empirica"}
+    with patch(_WALK, return_value=[proc]):
+        assert mod._has_live_log_tail("empirica") is False


### PR DESCRIPTION
The two standing housekeeping items.

## 1. Dependabot → develop
All 3 ecosystems get `target-branch: develop`, so bumps land on our trunk (CI-tested there, flow to main via release) instead of on `main` needing a manual back-port each time — exactly what bit us with the `setup-python` 6→7 bump this cycle.

## 2. Monitor re-arm dedup
SessionStart re-fires on every compaction / new-session-init, and the AI can't reliably dedup across a compaction (the prior Monitor's task id is gone) — so the hook re-emitted arm instructions and each arm **stacked another loop_fires tail** delivering every wake event an extra time (observed live: one ai_id ended up with **5 stacked tails**).

`_has_live_log_tail` now detects a live **non-orphan** tail for the ai_id (reusing the existing `walk_listener_processes` + `_ai_id_from_listener_cmdline`). When one exists, the hook emits an "already armed — do not re-arm" note instead of the arm block. Orphan tails (dead parent) don't count — `listener gc`'s job. **Safe: detection only, no cross-session process killing.**

## Tests
+5 (live-tail / orphan-ignored / other-ai_id-ignored / none / loop_listen). ruff + format + pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)