### PR TITLE
fix(cockpit): recognize Claude Code 2.1.x seats (name() is a version string)

### DIFF
--- a/empirica/core/cockpit/liveness.py
+++ b/empirica/core/cockpit/liveness.py
@@ -159,12 +159,21 @@ def _is_claude_proc(name: str | None, cmdline: list[str] | None) -> bool:
     The CC binary reports as ``claude``; older/dev installs run via ``node``
     with the claude entrypoint in argv. We require the ``claude`` token in
     the cmdline for the node case to avoid sweeping in unrelated node apps.
+
+    Claude Code 2.1.x mangles the OS process name (psutil ``name()``) to a bare
+    version string (e.g. ``2.1.212``), so a name-only gate silently hides every
+    live 2.1.x seat — and it recurs on each version bump. ``cmdline()[0]``'s
+    basename reliably stays ``claude`` regardless, so we match on that too.
     """
     nm = (name or "").lower()
     if nm == "claude":
         return True
+    cmd = cmdline or []
+    # argv[0] basename is 'claude' even when name() is a mangled version string.
+    if cmd and os.path.basename(cmd[0] or "").lower() == "claude":
+        return True
     if nm in _CLAUDE_COMMANDS:  # node — confirm it's actually claude
-        return any("claude" in (arg or "").lower() for arg in (cmdline or []))
+        return any("claude" in (arg or "").lower() for arg in cmd)
     return False
 
 

--- a/tests/test_cockpit_liveness.py
+++ b/tests/test_cockpit_liveness.py
@@ -305,6 +305,16 @@ def test_is_claude_proc_rejects_other_processes():
     assert lv._is_claude_proc("python", ["python", "claude_helper.py"]) is False
 
 
+def test_is_claude_proc_matches_mangled_version_name():
+    # Regression (Philipp): Claude Code 2.1.x mangles psutil name() to a bare
+    # version string, so a name-only gate hid every live 2.1.x seat. argv[0]
+    # basename stays 'claude' — match on it.
+    assert lv._is_claude_proc("2.1.212", ["claude", "--resume"]) is True
+    assert lv._is_claude_proc("2.1.212", ["/usr/local/bin/claude", "-p"]) is True
+    # A version-named process that ISN'T claude is still rejected (no over-broadening).
+    assert lv._is_claude_proc("2.1.212", ["node", "server.js"]) is False
+
+
 class _FakeProc:
     """psutil-like process stub for scan_live_claude tests."""
 


### PR DESCRIPTION
## Bug (Philipp, verified against a live seat)
On **Claude Code 2.1.212** the cockpit showed only **4/9** live seats and `empirica instance rebind` failed with *"no live claude process declares this instance_id"*.

## Root cause
`_is_claude_proc(name, cmdline)` gated on psutil `name()` first — True only if `name=='claude'` or `name in {claude,node}`. CC 2.1.x mangles the OS process name to a **bare version string** (`'2.1.212'`), so the live process was filtered out **before** its cmdline (`['claude',...]`) or env was consulted — even though `EMPIRICA_INSTANCE_ID` was set and readable. **Recurs on every CC version bump.**

## Fix
Also match when `cmdline[0]`'s basename is `claude` — argv[0] stays `claude` regardless of the name mangling. Doesn't over-broaden (a version-named `node server.js` is still rejected; existing guards hold). +1 regression test.

## Follow-up flagged
`_live_tmux_panes` uses the same `cmd in _CLAUDE_COMMANDS` match on tmux's `pane_current_command` — a potential same-class blind spot if CC 2.1.x also mangles that. Left unchanged pending verification on a live 2.1.x **tmux** seat (Philipp's repro was the process-scan signal, not the tmux one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)