### PR TITLE
fix(ecodex): resolver stale-mapping guard + statusline context meter

### DIFF
--- a/empirica/plugins/claude-code-integration/scripts/statusline_empirica.py
+++ b/empirica/plugins/claude-code-integration/scripts/statusline_empirica.py
@@ -1089,7 +1089,12 @@ def format_context_window(stdin_context: dict) -> str:
         color = Colors.YELLOW
     else:
         color = Colors.GREEN
-    return f"{color}{int(used_pct)}%ctx{Colors.RESET}"
+    # Bracketed-cell meter that fills as context is consumed, % at the end —
+    # e.g. [####------] 42%. Data is Claude Code's context_window.used_percentage.
+    cells = 10
+    filled = max(0, min(cells, round(used_pct / 10)))
+    bar = "#" * filled + "-" * (cells - filled)
+    return f"{color}[{bar}] {int(used_pct)}%{Colors.RESET}"
 
 
 def _append_postflight_deltas(parts, phase, deltas):

--- a/empirica/utils/session_resolver.py
+++ b/empirica/utils/session_resolver.py
@@ -956,6 +956,54 @@ def _get_instance_suffix() -> str:
     return ""
 
 
+def _headless_generic_active_work() -> "str | None":
+    """Priority-2 fallback: the generic ``active_work.json`` project_path, but
+    only in headless mode (no terminal identity). Returns None otherwise."""
+    from pathlib import Path
+
+    if not is_headless():
+        return None
+    try:
+        f = Path.home() / ".empirica" / "active_work.json"
+        if f.exists():
+            with open(f) as fh:
+                return json.load(fh).get("project_path")
+    except Exception:
+        pass
+    return None
+
+
+def _cwd_project_override(instance_path: str) -> "str | None":
+    """Stale-mapping guard: if the cwd is a registered project ROOT that differs
+    from ``instance_path``, return cwd — the instance_projects mapping has gone
+    stale and we're really in the cwd project.
+
+    This is the cross-harness misbind (codex/ecodex): those harnesses don't set
+    EMPIRICA_CWD_RELIABLE, so ``get_active_project_path`` fell to a stale
+    instance_projects entry and mis-bound the practice (a session in ecodex-lab
+    resolving to empirica-extension with a frozen snapshot). cwd-is-a-registered-
+    project-root is a harness-agnostic ground truth. Claude Code is unaffected —
+    it sets EMPIRICA_CWD_RELIABLE and returns at Priority -1 before reaching here.
+    """
+    from pathlib import Path
+
+    try:
+        cwd = str(Path.cwd())
+        if (Path(cwd) / ".empirica" / "project.yaml").exists() and os.path.realpath(cwd) != os.path.realpath(
+            instance_path
+        ):
+            logger.warning(
+                "get_active_project_path: cwd is a registered project (%s) but "
+                "instance_projects points elsewhere (%s) — trusting cwd (stale-mapping guard).",
+                cwd,
+                instance_path,
+            )
+            return cwd
+    except Exception:
+        pass
+    return None
+
+
 def get_active_project_path(claude_session_id: str | None = None) -> "str | None":
     """Get the active project path for the current instance.
 
@@ -1031,6 +1079,9 @@ def get_active_project_path(claude_session_id: str | None = None) -> "str | None
     # project-switch CLI updates instance_projects but CAN'T update active_work
     # (doesn't know claude_session_id). So instance_projects is more current.
     if instance_path:
+        override = _cwd_project_override(instance_path)
+        if override:
+            return override
         logger.debug(f"get_active_project_path: from instance_projects: {instance_path}")
         return instance_path
 
@@ -1039,24 +1090,14 @@ def get_active_project_path(claude_session_id: str | None = None) -> "str | None
         logger.debug(f"get_active_project_path: from active_work_{claude_session_id}: {active_work_path}")
         return active_work_path
 
-    # Priority 2: Generic active_work.json — HEADLESS MODE ONLY
-    # In interactive mode (terminal exists), instance_projects + active_work_{uuid}
-    # handle everything. The generic file would only cause pollution by returning
-    # a stale project from a different terminal/session.
-    # In headless mode (containers, CI), there's no terminal identity — the generic
-    # file IS the primary source.
-    if is_headless():
-        generic_work_file = Path.home() / ".empirica" / "active_work.json"
-        if generic_work_file.exists():
-            try:
-                with open(generic_work_file) as f:
-                    data = json.load(f)
-                    generic_path = data.get("project_path")
-                if generic_path:
-                    logger.debug(f"get_active_project_path: from active_work.json (headless): {generic_path}")
-                    return generic_path
-            except Exception:
-                pass
+    # Priority 2: Generic active_work.json — HEADLESS MODE ONLY. In interactive
+    # mode, instance_projects + active_work_{uuid} handle everything; the generic
+    # file would only pollute with a stale project from another terminal. In
+    # headless mode (containers, CI) there's no terminal identity, so it's primary.
+    generic_path = _headless_generic_active_work()
+    if generic_path:
+        logger.debug(f"get_active_project_path: from active_work.json (headless): {generic_path}")
+        return generic_path
 
     # NO CWD FALLBACK - fail explicitly
     logger.debug(

--- a/tests/test_resolver_stale_mapping_guard.py
+++ b/tests/test_resolver_stale_mapping_guard.py
@@ -1,0 +1,75 @@
+"""get_active_project_path stale-mapping guard (cross-harness misbind fix).
+
+On harnesses that don't set EMPIRICA_CWD_RELIABLE (codex/ecodex), the resolver
+fell straight to instance_projects — and a stale entry mis-bound the practice
+(a session in ecodex-lab resolving to empirica-extension with a frozen vector
+snapshot). When cwd is a registered project ROOT that differs from the mapping,
+the cwd (physical ground truth) now wins. Claude Code is unaffected: it sets
+EMPIRICA_CWD_RELIABLE, so it returns at Priority -1 before the guard.
+"""
+
+from __future__ import annotations
+
+import json
+
+import empirica.utils.session_resolver as sr
+
+
+def _mk_project(root, ai_id: str):
+    ed = root / ".empirica"
+    ed.mkdir(parents=True, exist_ok=True)
+    (ed / "project.yaml").write_text(f"ai_id: {ai_id}\n")
+    return root
+
+
+def _bind_instance_projects(home, instance_id: str, project_path):
+    ip = home / ".empirica" / "instance_projects"
+    ip.mkdir(parents=True, exist_ok=True)
+    (ip / f"{instance_id}.json").write_text(json.dumps({"project_path": str(project_path)}))
+
+
+def _setup(tmp_path, monkeypatch, *, instance_path, cwd_path, cwd_reliable=False, instance_id="tmux_t"):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(sr, "get_instance_id", lambda: instance_id)
+    if cwd_reliable:
+        monkeypatch.setenv("EMPIRICA_CWD_RELIABLE", "true")
+    else:
+        monkeypatch.delenv("EMPIRICA_CWD_RELIABLE", raising=False)
+    _bind_instance_projects(tmp_path, instance_id, instance_path)
+    monkeypatch.chdir(cwd_path)
+
+
+def test_stale_mapping_guard_prefers_cwd_project(tmp_path, monkeypatch):
+    # instance_projects (stale) → extension; but we're standing in ecodex-lab.
+    extension = _mk_project(tmp_path / "empirica-extension", "empirica-extension")
+    lab = _mk_project(tmp_path / "ecodex-lab", "ecodex-lab")
+    _setup(tmp_path, monkeypatch, instance_path=extension, cwd_path=lab)
+
+    assert sr.get_active_project_path() == str(lab)  # cwd wins over the stale mapping
+
+
+def test_no_override_when_cwd_matches_mapping(tmp_path, monkeypatch):
+    proj = _mk_project(tmp_path / "proj", "proj")
+    _setup(tmp_path, monkeypatch, instance_path=proj, cwd_path=proj)
+
+    assert sr.get_active_project_path() == str(proj)  # same project → no override
+
+
+def test_no_override_when_cwd_not_a_project_root(tmp_path, monkeypatch):
+    # cwd is a plain dir (no .empirica/project.yaml) — the mapping is authoritative.
+    proj = _mk_project(tmp_path / "proj", "proj")
+    plain = tmp_path / "somewhere-else"
+    plain.mkdir()
+    _setup(tmp_path, monkeypatch, instance_path=proj, cwd_path=plain)
+
+    assert sr.get_active_project_path() == str(proj)  # cwd not a project → mapping wins
+
+
+def test_cwd_reliable_still_returns_cwd_at_priority_minus_1(tmp_path, monkeypatch):
+    # Claude Code path: EMPIRICA_CWD_RELIABLE=true → cwd wins at Priority -1,
+    # before the guard is ever reached. Unaffected by this change.
+    extension = _mk_project(tmp_path / "empirica-extension", "empirica-extension")
+    lab = _mk_project(tmp_path / "ecodex-lab", "ecodex-lab")
+    _setup(tmp_path, monkeypatch, instance_path=extension, cwd_path=lab, cwd_reliable=True)
+
+    assert sr.get_active_project_path() == str(lab)

--- a/tests/test_statusline_context_meter.py
+++ b/tests/test_statusline_context_meter.py
@@ -1,0 +1,53 @@
+"""Statusline context-usage meter (ecodex/David request).
+
+Claude Code passes context usage into the statusline input as
+``context_window.used_percentage``; `format_context_window` renders it as a
+bracketed-cell meter that fills as context is consumed — e.g. `[####------] 42%`.
+Empty string when the harness supplies no usage (older CC / other harnesses).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).parent.parent
+_SL = _ROOT / "empirica" / "plugins" / "claude-code-integration" / "scripts" / "statusline_empirica.py"
+_LIB = _ROOT / "empirica" / "plugins" / "claude-code-integration" / "lib"
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _load():
+    if str(_LIB) not in sys.path:
+        sys.path.insert(0, str(_LIB))
+    spec = importlib.util.spec_from_file_location("statusline_empirica", _SL)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _meter(sl, pct) -> str:
+    return _ANSI.sub("", sl.format_context_window({"context_window": {"used_percentage": pct}}))
+
+
+def test_meter_matches_spec(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    sl = _load()
+    assert _meter(sl, 42) == "[####------] 42%"
+
+
+def test_meter_fills_and_caps(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    sl = _load()
+    assert _meter(sl, 80) == "[########--] 80%"
+    assert _meter(sl, 100) == "[##########] 100%"
+
+
+def test_meter_empty_without_usage(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    sl = _load()
+    # No usage from the harness → render nothing (don't show a fake 0-bar).
+    assert sl.format_context_window({}) == ""
+    assert _meter(sl, 0) == ""


### PR DESCRIPTION
Two items from ecodex's live Devstral testing.

## 1. ai_id / practice misbind (practice-binding class)
A session in a registered project (`ecodex-lab`) resolved its practice to **`empirica-extension`** with a frozen stale-other-session snapshot. Root cause: on harnesses that don't set `EMPIRICA_CWD_RELIABLE` (codex/ecodex), `get_active_project_path` fell straight to a **stale `instance_projects` mapping**.

**Fix (surgical, safe blast radius):** a stale-mapping guard — when `instance_projects` points elsewhere but the **cwd is a registered project ROOT that differs**, trust the cwd (physical ground truth, harness-agnostic). **Claude Code is provably unaffected** — it sets `EMPIRICA_CWD_RELIABLE` and returns at Priority -1 *before* the guard. Extracted two helpers to keep the resolver under C901. +4 tests (guard-fires / same-project-noop / cwd-not-a-project-noop / cwd-reliable-path-unchanged), all existing resolver tests still green.

## 2. Statusline context meter (David's request)
Claude Code already passes context usage as `context_window.used_percentage` (that answers ecodex's open question — the harness *does* surface it). `format_context_window` now renders a **bracketed-cell meter** that fills as context is consumed — e.g. `[####------] 42%` — with the existing green/yellow/red tiering, on the right of the statusline. Empty when the harness supplies no usage (older CC / other harnesses). +3 tests.

ruff + format + pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)