### PR TITLE
fix(statusline): make the context meter opt-in — don't change CC's display

### DIFF
--- a/empirica/plugins/claude-code-integration/scripts/statusline_empirica.py
+++ b/empirica/plugins/claude-code-integration/scripts/statusline_empirica.py
@@ -1089,12 +1089,17 @@ def format_context_window(stdin_context: dict) -> str:
         color = Colors.YELLOW
     else:
         color = Colors.GREEN
-    # Bracketed-cell meter that fills as context is consumed, % at the end —
-    # e.g. [####------] 42%. Data is Claude Code's context_window.used_percentage.
-    cells = 10
-    filled = max(0, min(cells, round(used_pct / 10)))
-    bar = "#" * filled + "-" * (cells - filled)
-    return f"{color}[{bar}] {int(used_pct)}%{Colors.RESET}"
+    # The bracketed-cell meter ([####------] 42%) is OPT-IN, not the default: it's
+    # an ecodex display preference (open-weights operators watching context
+    # headroom). The shared statusline must NOT change Claude Code's existing
+    # plain-'%ctx' render for one harness's visual choice — so a harness that
+    # wants the meter sets EMPIRICA_CTX_METER; everyone else keeps '%ctx'.
+    if os.environ.get("EMPIRICA_CTX_METER", "").strip().lower() in ("1", "true", "bar"):
+        cells = 10
+        filled = max(0, min(cells, round(used_pct / 10)))
+        bar = "#" * filled + "-" * (cells - filled)
+        return f"{color}[{bar}] {int(used_pct)}%{Colors.RESET}"
+    return f"{color}{int(used_pct)}%ctx{Colors.RESET}"
 
 
 def _append_postflight_deltas(parts, phase, deltas):

--- a/tests/test_statusline_context_meter.py
+++ b/tests/test_statusline_context_meter.py
@@ -28,26 +28,38 @@ def _load():
     return mod
 
 
-def _meter(sl, pct) -> str:
+def _render(sl, pct) -> str:
     return _ANSI.sub("", sl.format_context_window({"context_window": {"used_percentage": pct}}))
 
 
-def test_meter_matches_spec(tmp_path, monkeypatch):
+def test_meter_matches_spec_when_opted_in(tmp_path, monkeypatch):
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("EMPIRICA_CTX_METER", "1")
     sl = _load()
-    assert _meter(sl, 42) == "[####------] 42%"
+    assert _render(sl, 42) == "[####------] 42%"
 
 
-def test_meter_fills_and_caps(tmp_path, monkeypatch):
+def test_meter_fills_and_caps_when_opted_in(tmp_path, monkeypatch):
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("EMPIRICA_CTX_METER", "bar")
     sl = _load()
-    assert _meter(sl, 80) == "[########--] 80%"
-    assert _meter(sl, 100) == "[##########] 100%"
+    assert _render(sl, 80) == "[########--] 80%"
+    assert _render(sl, 100) == "[##########] 100%"
 
 
-def test_meter_empty_without_usage(tmp_path, monkeypatch):
+def test_default_render_is_plain_percent(tmp_path, monkeypatch):
+    # Without the opt-in env, the shared statusline keeps the plain '%ctx' render
+    # (Claude Code + other harnesses are unchanged — the meter is ecodex-only).
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("EMPIRICA_CTX_METER", raising=False)
+    sl = _load()
+    assert _render(sl, 42) == "42%ctx"
+
+
+def test_empty_without_usage_regardless_of_opt_in(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("EMPIRICA_CTX_METER", "1")
     sl = _load()
     # No usage from the harness → render nothing (don't show a fake 0-bar).
     assert sl.format_context_window({}) == ""
-    assert _meter(sl, 0) == ""
+    assert _render(sl, 0) == ""


### PR DESCRIPTION
## The boundary miss
1.12.31's context meter changed the **shared** statusline for *every* harness — so Claude Code users got the bracketed `[####------] 42%` meter replacing their plain `%ctx`, which they didn't ask for. The meter is an ecodex display preference; mutating the shared statusline for one harness's visual crosses the wrong boundary (David's call, relayed via ecodex).

## Fix
Gate the meter behind **`EMPIRICA_CTX_METER`** (`1`/`true`/`bar`). Default — Claude Code and every other harness — keeps the plain `%ctx`, unchanged. A harness that wants the meter (ecodex) sets the env in its wrapper. Meter code + green/yellow/red tiering unchanged; just the gate.

## Tests
Meter cases now opt in; +a default-plain regression. 4/4 pass, ruff/format/pyright clean.

Rides the next release. The resolver guard (item 1) is untouched — this only scopes the item-2 meter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)