### PR TITLE
fix(cockpit): recognize CC 2.1.x seats in the tmux liveness path too

### DIFF
--- a/empirica/core/cockpit/liveness.py
+++ b/empirica/core/cockpit/liveness.py
@@ -60,6 +60,34 @@ class LivenessResult:
 # 'claude' is the bin name; 'node' covers older installations / dev launches.
 _CLAUDE_COMMANDS = frozenset({"claude", "node"})
 
+# Claude Code 2.1.x renames the foreground process to a bare version string, so
+# tmux's pane_current_command reports e.g. "2.1.212" instead of "claude". A pane
+# whose command matches this is a mangled-CC candidate — resolve its process tree
+# to confirm (Philipp verified: every live 2.1.212 pane reports this).
+_VERSION_NAME_RE = re.compile(r"^\d+\.\d+")
+
+
+def _pane_hosts_claude(pane_pid: int) -> bool:
+    """True if the tmux pane's process tree contains a Claude Code process.
+
+    Used when pane_current_command is a mangled version string (CC 2.1.x) rather
+    than 'claude'. Resolves the pane's foreground process + descendants and reuses
+    `_is_claude_proc` (which matches cmdline[0] basename, surviving the rename).
+    """
+    try:
+        import psutil
+
+        proc = psutil.Process(pane_pid)
+        for p in [proc, *proc.children(recursive=True)]:
+            try:
+                if _is_claude_proc(p.name(), p.cmdline()):
+                    return True
+            except (psutil.NoSuchProcess, psutil.AccessDenied):
+                continue
+    except Exception:  # noqa: S110 — best-effort; psutil missing / proc gone must never break liveness
+        pass
+    return False
+
 
 def _live_tmux_panes() -> set[str] | None:
     """Return set of pane numbers (e.g. {'1', '2', '3'}) where Claude Code is running.
@@ -76,7 +104,7 @@ def _live_tmux_panes() -> set[str] | None:
         return None
     try:
         result = subprocess.run(
-            ["tmux", "list-panes", "-a", "-F", "#{pane_id} #{pane_current_command}"],
+            ["tmux", "list-panes", "-a", "-F", "#{pane_id} #{pane_pid} #{pane_current_command}"],
             capture_output=True,
             text=True,
             timeout=2,
@@ -88,12 +116,21 @@ def _live_tmux_panes() -> set[str] | None:
         return set()
     panes = set()
     for line in result.stdout.splitlines():
-        parts = line.strip().split(maxsplit=1)
-        if len(parts) != 2:
+        parts = line.strip().split(maxsplit=2)
+        if len(parts) != 3:
             continue
-        pane_id, cmd = parts
+        pane_id, pane_pid, cmd = parts
         if cmd in _CLAUDE_COMMANDS:
             panes.add(pane_id.lstrip("%"))
+        elif _VERSION_NAME_RE.match(cmd):
+            # Mangled CC 2.1.x name (e.g. "2.1.212") — confirm via the process
+            # tree. Only version-string names are tree-walked, so shells/python
+            # panes cost nothing.
+            try:
+                if _pane_hosts_claude(int(pane_pid)):
+                    panes.add(pane_id.lstrip("%"))
+            except ValueError:
+                pass
     return panes
 
 

--- a/tests/test_cockpit_liveness.py
+++ b/tests/test_cockpit_liveness.py
@@ -480,3 +480,79 @@ def test_live_claude_pids_by_instance_maps_iid_to_pid(monkeypatch):
     ]
     monkeypatch.setattr(psutil, "process_iter", lambda attrs=None: procs)
     assert lv.live_claude_pids_by_instance() == {"empirica-vr": (101, 5.0)}
+
+
+# ── CC 2.1.x tmux-pane mangle (Philipp): pane_current_command='2.1.212' ──────
+
+
+def test_version_name_regex_matches_mangled_cc():
+    assert lv._VERSION_NAME_RE.match("2.1.212")
+    assert lv._VERSION_NAME_RE.match("10.0")
+    assert not lv._VERSION_NAME_RE.match("claude")
+    assert not lv._VERSION_NAME_RE.match("zsh")
+    assert not lv._VERSION_NAME_RE.match("python3.11")  # name, not a bare version
+
+
+def test_live_tmux_panes_detects_mangled_cc_pane(monkeypatch):
+    # %0 = mangled CC (version-string name) → tree-walk confirms claude
+    # %1 = zsh → not claude, not a version name → skipped (no tree-walk)
+    # %2 = claude → fast path
+    tmux_out = "%0 111 2.1.212\n%1 222 zsh\n%2 333 claude\n"
+
+    class _R:
+        returncode = 0
+        stdout = tmux_out
+
+    monkeypatch.setattr(lv.shutil, "which", lambda _x: "/usr/bin/tmux")
+    monkeypatch.setattr(lv.subprocess, "run", lambda *a, **k: _R())
+    # only pane_pid 111 (the mangled CC pane) hosts claude in its tree
+    monkeypatch.setattr(lv, "_pane_hosts_claude", lambda pid: pid == 111)
+
+    assert lv._live_tmux_panes() == {"0", "2"}
+
+
+def test_live_tmux_panes_mangled_pane_without_claude_is_excluded(monkeypatch):
+    # A version-named pane whose tree has NO claude (e.g. some other tool) is not counted.
+    tmux_out = "%0 111 2.1.212\n"
+
+    class _R:
+        returncode = 0
+        stdout = tmux_out
+
+    monkeypatch.setattr(lv.shutil, "which", lambda _x: "/usr/bin/tmux")
+    monkeypatch.setattr(lv.subprocess, "run", lambda *a, **k: _R())
+    monkeypatch.setattr(lv, "_pane_hosts_claude", lambda pid: False)
+
+    assert lv._live_tmux_panes() == set()
+
+
+def test_pane_hosts_claude_matches_mangled_name_via_cmdline(monkeypatch):
+    import sys
+    import types
+
+    class _FakeProc:
+        def __init__(self, name, cmdline):
+            self._n, self._c = name, cmdline
+
+        def name(self):
+            return self._n
+
+        def cmdline(self):
+            return self._c
+
+        def children(self, recursive=False):
+            return []
+
+    # pane process reports the mangled name but argv[0] is claude
+    root = _FakeProc("2.1.212", ["claude", "--resume"])
+    fake_psutil = types.SimpleNamespace(
+        Process=lambda _pid: root,
+        NoSuchProcess=type("NoSuchProcess", (Exception,), {}),
+        AccessDenied=type("AccessDenied", (Exception,), {}),
+    )
+    monkeypatch.setitem(sys.modules, "psutil", fake_psutil)
+    assert lv._pane_hosts_claude(111) is True
+
+    root2 = _FakeProc("2.1.212", ["node", "server.js"])
+    fake_psutil.Process = lambda _pid: root2
+    assert lv._pane_hosts_claude(111) is False


### PR DESCRIPTION
Follow-up to #371 (process-scan signal). Philipp **verified live** the parallel blind spot I flagged: on CC 2.1.212, `tmux list-panes -F '#{pane_current_command}'` reports `2.1.212` for every live claude pane, so `_live_tmux_panes`'s `{claude,node}` test silently dropped all 9 of his seats via the tmux signal.

## Fix
tmux gives only the command **name** (mangled), not argv — so resolve the pane's process. Fast-path `claude`/`node`; for panes whose command matches a **version-string regex** (the CC-mangle signature), tree-walk `pane_pid` via psutil and reuse `_is_claude_proc` (the #371 `cmdline[0]`-basename match). **Only version-named panes are tree-walked** — shells / python / other tools cost nothing.

## Tests
+4 (regex / mangled-pane-detected / mangled-without-claude-excluded / `_pane_hosts_claude` via cmdline). 44/44 liveness tests pass; ruff/format/pyright clean.

Closes the tmux half of the CC 2.1.x cockpit blind spot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)