### PR TITLE
fix(modules): surface 207 partial-grant failures in _post_grants

### DIFF
--- a/empirica/core/modules/executors.py
+++ b/empirica/core/modules/executors.py
@@ -379,8 +379,43 @@ def _register_automation(auto, dry_run: bool) -> dict:
         return {"kind": "automation", "target": auto.name, "status": "error", "detail": str(e)[:300]}
 
 
-def _post_grants(cortex_url: str, api_key: str, grants: list[dict]) -> tuple[bool, str]:
-    """POST ntfy ACL grants to cortex admin (the contract cortex shipped)."""
+def _classify_grant_response(status: int, raw: bytes) -> tuple[str, str]:
+    """Derive a per-grant-aware status from the ntfy-grant response body.
+
+    Cortex returns 200 (all applied) or 207 multi-status with a
+    ``grants_applied[]`` array of ``{user, topic, permission, ok, error}``
+    records. Reading only the status code stamps partial failures as full
+    success — this parses the body so per-grant failures surface.
+
+    Returns ``(status, detail)`` where status is:
+      - ``"granted"`` — 200, or 207 with every ``grants_applied[].ok`` true
+      - ``"partial"`` — 207 with ≥1 failing grant (detail names them), or a
+        207 whose body carries no trustworthy per-grant detail (fail-loud —
+        never assume success from a bare 207)
+      - ``"error"``   — a non-2xx status
+    """
+    if status not in (200, 207):
+        return "error", f"http {status}"
+    try:
+        applied = (json.loads(raw or b"{}") or {}).get("grants_applied") or []
+    except (ValueError, TypeError):
+        applied = []
+    failures = [g for g in applied if not g.get("ok", True)]
+    if failures:
+        named = "; ".join(f"{g.get('user')}@{g.get('topic')}: {g.get('error') or 'failed'}" for g in failures)
+        return "partial", f"http {status} — {len(failures)}/{len(applied)} grants failed: {named}"[:300]
+    if status == 207 and not applied:
+        return "partial", "http 207 — partial status with no grants_applied detail (treated as failure)"
+    return "granted", f"http {status} — {len(applied) or 'all'} grants applied"
+
+
+def _post_grants(cortex_url: str, api_key: str, grants: list[dict]) -> tuple[str, str]:
+    """POST ntfy ACL grants to cortex admin (the contract cortex shipped).
+
+    Returns ``(status, detail)`` from :func:`_classify_grant_response` — a
+    207 multi-status with per-grant failures resolves to ``"partial"``, not a
+    bare success bool. Transport / non-2xx errors resolve to ``"error"``.
+    """
     url = cortex_url.rstrip("/") + "/v1/admin/ntfy/grants"
     body = json.dumps({"grants": grants}).encode()
     req = urllib.request.Request(url, data=body, method="POST")
@@ -388,11 +423,11 @@ def _post_grants(cortex_url: str, api_key: str, grants: list[dict]) -> tuple[boo
     req.add_header("Content-Type", "application/json")
     try:
         with urllib.request.urlopen(req, timeout=30) as resp:
-            return (resp.status in (200, 207), f"http {resp.status}")
+            return _classify_grant_response(resp.status, resp.read())
     except urllib.error.HTTPError as e:
-        return False, f"http {e.code}"
+        return "error", f"http {e.code}"
     except (urllib.error.URLError, OSError) as e:
-        return False, str(e)[:300]
+        return "error", str(e)[:300]
 
 
 def _grant_topics(manifest, cortex_url, cortex_api_key, org, tenant, dry_run) -> list[dict]:
@@ -416,8 +451,8 @@ def _grant_topics(manifest, cortex_url, cortex_api_key, org, tenant, dry_run) ->
         if dry_run:
             out.append({"kind": "topic", "target": t, "status": "would_grant", "detail": json.dumps(grants)})
             continue
-        ok, detail = _post_grants(cortex_url, cortex_api_key, grants)
-        out.append({"kind": "topic", "target": t, "status": "granted" if ok else "error", "detail": detail})
+        status, detail = _post_grants(cortex_url, cortex_api_key, grants)
+        out.append({"kind": "topic", "target": t, "status": status, "detail": detail})
     return out
 
 
@@ -509,7 +544,9 @@ def provision_module(
     steps += _check_env(manifest)
     steps += _register_practice_domains(manifest, dry_run)
 
-    errors = [f"{s['kind']} {s['target']}: {s['detail']}" for s in steps if s["status"] == "error"]
+    # "partial" is a fidelity failure too (a 207 where some grants didn't apply) —
+    # surface it alongside "error" so it flips ok=False instead of masking as success.
+    errors = [f"{s['kind']} {s['target']}: {s['detail']}" for s in steps if s["status"] in ("error", "partial")]
     return {
         "ok": not errors,
         "action": "provision",

--- a/tests/test_module_provision.py
+++ b/tests/test_module_provision.py
@@ -13,6 +13,7 @@ import json
 import tarfile
 from types import SimpleNamespace
 
+import pytest
 import yaml
 
 from empirica.cli.command_handlers.module_commands import handle_module_provision_command
@@ -235,7 +236,7 @@ def test_topics_dry_run_shows_grants(tmp_path):
 def test_topics_granted_calls_cortex(tmp_path, monkeypatch):
     posted = []
     monkeypatch.setattr(
-        executors, "_post_grants", lambda url, key, grants: posted.append((url, grants)) or (True, "http 200")
+        executors, "_post_grants", lambda url, key, grants: posted.append((url, grants)) or ("granted", "http 200")
     )
     m = _manifest(tmp_path, topics=["empirica-outreach-dispatch"])
     receipt = provision_module(
@@ -250,6 +251,69 @@ def test_topics_granted_calls_cortex(tmp_path, monkeypatch):
     )
     topic_step = next(s for s in receipt["steps"] if s["kind"] == "topic")
     assert topic_step["status"] == "granted" and posted
+
+
+def test_topics_partial_207_surfaces_as_failure(tmp_path, monkeypatch):
+    """A 207 with a failing grant must NOT stamp status=granted / ok=True.
+
+    Regression for prop_atoc4: _post_grants used to read only the status code,
+    so a partial 207 masked as full success. The provision rollup must now
+    surface the partial as an error and flip ok=False.
+    """
+    monkeypatch.setattr(
+        executors,
+        "_post_grants",
+        lambda url, key, grants: ("partial", "http 207 — 1/2 grants failed: empirica-u-david@t: topic conflict"),
+    )
+    m = _manifest(tmp_path, topics=["empirica-outreach-dispatch"])
+    receipt = provision_module(
+        m,
+        dry_run=False,
+        plugin_root=tmp_path / "p",
+        staging_root=tmp_path / "s",
+        cortex_url="https://cortex.example",
+        cortex_api_key="admin-key",
+        org="empirica",
+        tenant="david",
+    )
+    topic_step = next(s for s in receipt["steps"] if s["kind"] == "topic")
+    assert topic_step["status"] == "partial"
+    assert receipt["ok"] is False  # partial fidelity failure must flip the rollup
+    assert any("topic conflict" in e for e in receipt["errors"])
+
+
+@pytest.mark.parametrize(
+    "status,body,expected_status,detail_contains",
+    [
+        # 200, all applied
+        (200, {"ok": True, "grants_applied": [{"user": "u", "topic": "t", "ok": True}]}, "granted", "1 grants"),
+        # 200 with no body detail — still granted
+        (200, {}, "granted", "all"),
+        # 207 but every grant ok → granted (cortex may 207 on idempotent re-grant)
+        (207, {"grants_applied": [{"user": "u", "topic": "t", "ok": True}]}, "granted", "http 207"),
+        # 207 with a failing grant → partial, names the failure
+        (
+            207,
+            {"grants_applied": [{"user": "u", "topic": "t", "ok": False, "error": "acl denied"}]},
+            "partial",
+            "acl denied",
+        ),
+        # 207 with no trustworthy per-grant detail → fail-loud partial, not granted
+        (207, {}, "partial", "no grants_applied detail"),
+        # non-2xx → error
+        (500, {}, "error", "http 500"),
+    ],
+)
+def test_classify_grant_response(status, body, expected_status, detail_contains):
+    got_status, detail = executors._classify_grant_response(status, json.dumps(body).encode())
+    assert got_status == expected_status
+    assert detail_contains in detail
+
+
+def test_classify_grant_response_unparseable_207_is_partial():
+    # Garbage body on a 207 must not be assumed successful.
+    got_status, _ = executors._classify_grant_response(207, b"<html>gateway error</html>")
+    assert got_status == "partial"
 
 
 # ── env presence ────────────────────────────────────────────────────────


### PR DESCRIPTION
## What
`_post_grants` (executors.py) read only the HTTP status code from cortex's ntfy-grant endpoint (`200/207 → True`), discarding the 207 multi-status body. Cortex returns `grants_applied[]` with per-grant `{ok, error}`; a partial 207 was stamped `status=granted` with **zero telemetry**. The `provision()` rollup compounded it — `errors` were derived only from `status==error`, so even a new `partial` status would still mask as `ok=True`.

Broccoli pattern: **partial-success-as-success** + **fallback masks primary failure**.

## Fix
- `_classify_grant_response(status, raw)` — pure helper parsing `grants_applied[]`; returns `granted | partial | error`. A 207 with no trustworthy per-grant detail → `partial` (fail-loud; never assume success from a bare 207).
- `_post_grants` reads the response body, returns `(status, detail)` instead of `(bool, detail)`.
- `provision()` rollup counts `status in (error, partial)` → partial flips `ok=False` and names the failing grants in `errors[]`.

## Verification
Endpoint contract cortex-verified (`test_transport.py:2725 test_partial_failure_returns_207`). +7 regression tests (classifier matrix: 200-all-ok / 200-no-detail / 207-all-ok / 207-partial / 207-no-detail / non-2xx / unparseable-207, plus the partial-provision rollup). 30/30 in `test_module_provision.py`, ruff check + format clean.

Routed via cortex CCR `prop_atoc4` (workspace → cortex diagnosis → core).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qe4uGwYbVtE5CFZdsBwata