### PR TITLE
fix(cockpit): pane-# window column + root-cause fix for phantom tmux_N rows

### DIFF
--- a/empirica/cli/tui/cockpit_app.py
+++ b/empirica/cli/tui/cockpit_app.py
@@ -160,7 +160,10 @@ class CockpitApp(App):
         # into a single 'N' column. The listener (T8) is the unified wake
         # mechanism — separate columns were noise. N now shows ⊕<count>
         # when there are recent events for this instance, glyph otherwise.
-        table.add_columns("s", "name", "ph", "dom", "S", "N")
+        # '#' = tmux window index the seat lives in (Philipp 2026-07-22): rows
+        # sort ascending by it so cockpit order mirrors the tmux window layout,
+        # making an off/missing seat quick to spot. Blank when unresolvable.
+        table.add_columns("s", "#", "name", "ph", "dom", "S", "N")
         yield table
 
         with Horizontal(id="action-bar"):
@@ -295,9 +298,22 @@ class CockpitApp(App):
         previously_selected = self.selected_instance_id
         table.clear()
         rows = self.payload.get("instances", [])
+        # Sort ascending by tmux window index so cockpit order mirrors the
+        # operator's tmux window layout; seats with no resolvable window sort
+        # last (then by name for a stable, readable order).
+        rows = sorted(
+            rows,
+            key=lambda i: (
+                i.get("tmux_window") is None,
+                i.get("tmux_window") if i.get("tmux_window") is not None else 0,
+                (i.get("label") or i["instance_id"]).lower(),
+            ),
+        )
         for inst in rows:
             iid = inst["instance_id"]
             stat = self._state_glyph(inst["state"])
+            win = inst.get("tmux_window")
+            win_cell = str(win) if win is not None else "·"
             name = (inst.get("label") or iid)[:16]
             phase = self._phase_short(inst.get("phase"), inst.get("asking", False))
             dom = self._domain_chip(inst.get("transaction"))
@@ -306,7 +322,7 @@ class CockpitApp(App):
             # falling back to the loops glyph if no events yet. listeners
             # are subsumed (they're loops with held connections now).
             events_cell = self._events_cell(inst)
-            table.add_row(stat, name, phase, dom, sentinel, events_cell, key=iid)
+            table.add_row(stat, win_cell, name, phase, dom, sentinel, events_cell, key=iid)
 
         if rows:
             target = previously_selected or rows[0]["instance_id"]

--- a/empirica/core/cockpit/instance_state.py
+++ b/empirica/core/cockpit/instance_state.py
@@ -44,7 +44,12 @@ from empirica.core.cockpit.listener_registry import (
     ListenerRegistry,
     is_listener_paused,
 )
-from empirica.core.cockpit.liveness import _live_tmux_panes, is_alive, scan_live_claude
+from empirica.core.cockpit.liveness import (
+    _live_tmux_panes,
+    claude_pane_bindings,
+    is_alive,
+    scan_live_claude,
+)
 from empirica.core.cockpit.loop_registry import LoopRegistry, is_loop_paused
 from empirica.core.cockpit.notify_dispatcher_view import (
     annotate_loops_with_last_notify,
@@ -304,7 +309,7 @@ def _derive_state_symbol(
     return "idle"
 
 
-def discover_instances() -> list[str]:
+def discover_instances(owned_panes: set[str] | None = None) -> list[str]:
     """Return the sorted list of known instance_ids.
 
     Walks the standard state-file globs under ~/.empirica/ and unions the
@@ -316,6 +321,13 @@ def discover_instances() -> list[str]:
     state file ever written) so the cockpit can still see them.
     Synthetic ``tmux_{pane}`` IDs are stable across cockpit refreshes
     because tmux pane numbers are stable for the lifetime of the pane.
+
+    A pane already OWNED by a named seat (its claude declares an
+    ``EMPIRICA_INSTANCE_ID``) is skipped — the seat is discovered via its own
+    state files, so minting a ``tmux_<pane>`` for it would create a duplicate
+    ghost row. ``owned_panes`` is the set of such pane numbers (see
+    :func:`claude_pane_bindings`); passed in by :func:`aggregate_all` to reuse
+    one scan, or computed here when called standalone.
     """
     EMPIRICA_DIR.mkdir(parents=True, exist_ok=True)
     seen: set[str] = set()
@@ -328,7 +340,12 @@ def discover_instances() -> list[str]:
 
     live_panes = _live_tmux_panes()
     if live_panes:
+        if owned_panes is None:
+            owned_panes = claude_pane_bindings()[1]
         for pane in live_panes:
+            if pane in owned_panes:
+                # Pane belongs to a named seat — no synthetic shadow.
+                continue
             seen.add(f"tmux_{pane}")
 
     return sorted(seen)
@@ -442,6 +459,7 @@ def aggregate_instance_state(
     current_instance_id: str | None = None,
     live_claude_instance_ids: set[str] | None = None,
     live_claude_cwds: set[str] | None = None,
+    tmux_windows: dict[str, int] | None = None,
 ) -> dict[str, Any]:
     """Read all state for one instance and return a serializable dict.
 
@@ -550,6 +568,10 @@ def aggregate_instance_state(
     return {
         "instance_id": instance_id,
         "ai_id": _project_ai_id(project_path),
+        # tmux window index this seat's live claude runs in (display-only, for
+        # the cockpit pane-number column). None when not resolvable (no tmux,
+        # dead seat, or proc→pane link couldn't be walked).
+        "tmux_window": (tmux_windows or {}).get(instance_id),
         "label": label,
         "project_path": project_path,
         "session_id": tx_state["session_id"],
@@ -647,6 +669,11 @@ def aggregate_all(include_dead: bool = False) -> dict[str, Any]:
     live_iids = scan.instance_ids if scan else None
     live_cwds = set(scan.cwd_counts) if scan else None
 
+    # One proc→pane scan feeds both the cockpit window column (tmux_windows)
+    # and shadow-suppression at discovery (owned_panes). Best-effort — ({},set())
+    # when tmux/psutil absent.
+    tmux_windows, owned_panes = claude_pane_bindings()
+
     # Resolve the current instance lazily — exempts the running cockpit
     # from liveness checks (it's alive by definition, even if PID/PPID
     # weren't captured by an old session-init).
@@ -664,8 +691,9 @@ def aggregate_all(include_dead: bool = False) -> dict[str, Any]:
             current_instance_id=current_id,
             live_claude_instance_ids=live_iids,
             live_claude_cwds=live_cwds,
+            tmux_windows=tmux_windows,
         )
-        for i in discover_instances()
+        for i in discover_instances(owned_panes=owned_panes)
     ]
 
     # Count-aware dedup: the cwd FALLBACK signal is project-level, so several

--- a/empirica/core/cockpit/liveness.py
+++ b/empirica/core/cockpit/liveness.py
@@ -360,15 +360,14 @@ def live_claude_windows_by_instance() -> dict[str, int]:
     return claude_pane_bindings()[0]
 
 
-def _scan_claude_pane_map() -> tuple[dict[str, int], set[str]]:
+def _tmux_pane_maps() -> tuple[dict[int, str], dict[str, int]]:
+    """``(pane_pid -> pane, pane_id -> window)`` from one ``tmux list-panes``.
+
+    The claude proc is a child of the pane's shell, so ``pane_pid`` keys the
+    ancestry walk; ``pane_id`` (``%N`` stripped) keys the ``tmux_<N>`` fallback.
+    Both empty on any failure (no tmux / timeout / non-zero exit)."""
     if shutil.which("tmux") is None:
-        return {}, set()
-    try:
-        import psutil
-    except ImportError:
-        return {}, set()
-    # pane shell pid -> window (claude proc is a child of the shell); pane id
-    # (%N, stripped) -> window (for the tmux_<N> fallback below).
+        return {}, {}
     try:
         result = subprocess.run(
             ["tmux", "list-panes", "-a", "-F", "#{pane_id} #{pane_pid} #{window_index}"],
@@ -377,9 +376,9 @@ def _scan_claude_pane_map() -> tuple[dict[str, int], set[str]]:
             timeout=2,
         )
     except (subprocess.TimeoutExpired, OSError):
-        return {}, set()
+        return {}, {}
     if result.returncode != 0:
-        return {}, set()
+        return {}, {}
     pane_pid_to_pane: dict[int, str] = {}
     pane_id_to_window: dict[str, int] = {}
     for line in result.stdout.splitlines():
@@ -397,12 +396,23 @@ def _scan_claude_pane_map() -> tuple[dict[str, int], set[str]]:
             pane_pid_to_pane[int(pane_pid)] = pane
         except ValueError:
             pass
-    if not pane_pid_to_pane and not pane_id_to_window:
+    return pane_pid_to_pane, pane_id_to_window
+
+
+def _claude_owned_panes(
+    pane_pid_to_pane: dict[int, str], pane_id_to_window: dict[str, int]
+) -> tuple[dict[str, int], set[str]]:
+    """Match live claude procs to their owning tmux pane by walking ancestry.
+
+    Returns ``(windows_by_instance, owned_panes)`` — named seats matched exactly
+    by their claude proc's ``EMPIRICA_INSTANCE_ID``. Best-effort: any error
+    yields the partial result gathered so far (display-only, never a verdict)."""
+    try:
+        import psutil
+    except ImportError:
         return {}, set()
     windows: dict[str, int] = {}
     owned_panes: set[str] = set()
-    # Named seats: match each live claude proc's EMPIRICA_INSTANCE_ID to the
-    # tmux pane (and window) it runs in — exact, resume-proof.
     try:
         for proc in psutil.process_iter(["name", "cmdline"]):
             try:
@@ -431,7 +441,17 @@ def _scan_claude_pane_map() -> tuple[dict[str, int], set[str]]:
                 if node is None:
                     break
     except Exception:
-        pass
+        # Best-effort display affordance — return whatever we gathered rather
+        # than fail the whole scan (S110: return, not a silent pass).
+        return windows, owned_panes
+    return windows, owned_panes
+
+
+def _scan_claude_pane_map() -> tuple[dict[str, int], set[str]]:
+    pane_pid_to_pane, pane_id_to_window = _tmux_pane_maps()
+    if not pane_pid_to_pane and not pane_id_to_window:
+        return {}, set()
+    windows, owned_panes = _claude_owned_panes(pane_pid_to_pane, pane_id_to_window)
     # Fallback window for unbound seats registered under the tmux_<pane_id> id
     # (they never declared EMPIRICA_INSTANCE_ID). The id already encodes the
     # pane, so read the window straight off pane_id — but only for a window NOT

--- a/empirica/core/cockpit/liveness.py
+++ b/empirica/core/cockpit/liveness.py
@@ -335,6 +335,117 @@ def _scan_live_claude_impl() -> LiveClaudeScan | None:
     return LiveClaudeScan(instance_ids=instance_ids, cwd_counts=cwd_counts)
 
 
+def claude_pane_bindings() -> tuple[dict[str, int], set[str]]:
+    """Bounded ``(windows_by_instance, owned_panes)`` from one proc→pane scan.
+
+    - ``windows_by_instance``: instance_id → tmux window index. Named seats are
+      matched by their live claude proc's ``EMPIRICA_INSTANCE_ID`` env; a
+      ``tmux_<pane_id>`` fallback covers panes NOT owned by a named seat (unbound
+      / pre-empirica sessions). Feeds the cockpit's pane-number column.
+    - ``owned_panes``: pane numbers (``%`` stripped) whose foreground claude
+      declares an ``EMPIRICA_INSTANCE_ID`` — panes already owned by a named
+      seat, so :func:`discover_instances` can skip minting a synthetic
+      ``tmux_<pane>`` shadow for them.
+
+    Both empty on any failure (no tmux / no psutil / bounded timeout). Purely a
+    display + discovery affordance — never a liveness verdict, never blocks a
+    sweep.
+    """
+    return _run_bounded(_scan_claude_pane_map, "claude_pane_bindings") or ({}, set())
+
+
+def live_claude_windows_by_instance() -> dict[str, int]:
+    """Bounded ``instance_id → tmux window index`` (thin wrapper — the window
+    half of :func:`claude_pane_bindings`)."""
+    return claude_pane_bindings()[0]
+
+
+def _scan_claude_pane_map() -> tuple[dict[str, int], set[str]]:
+    if shutil.which("tmux") is None:
+        return {}, set()
+    try:
+        import psutil
+    except ImportError:
+        return {}, set()
+    # pane shell pid -> window (claude proc is a child of the shell); pane id
+    # (%N, stripped) -> window (for the tmux_<N> fallback below).
+    try:
+        result = subprocess.run(
+            ["tmux", "list-panes", "-a", "-F", "#{pane_id} #{pane_pid} #{window_index}"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return {}, set()
+    if result.returncode != 0:
+        return {}, set()
+    pane_pid_to_pane: dict[int, str] = {}
+    pane_id_to_window: dict[str, int] = {}
+    for line in result.stdout.splitlines():
+        parts = line.split()
+        if len(parts) != 3:
+            continue
+        pane_id, pane_pid, win = parts
+        try:
+            window = int(win)
+        except ValueError:
+            continue
+        pane = pane_id.lstrip("%")
+        pane_id_to_window[pane] = window
+        try:
+            pane_pid_to_pane[int(pane_pid)] = pane
+        except ValueError:
+            pass
+    if not pane_pid_to_pane and not pane_id_to_window:
+        return {}, set()
+    windows: dict[str, int] = {}
+    owned_panes: set[str] = set()
+    # Named seats: match each live claude proc's EMPIRICA_INSTANCE_ID to the
+    # tmux pane (and window) it runs in — exact, resume-proof.
+    try:
+        for proc in psutil.process_iter(["name", "cmdline"]):
+            try:
+                info = proc.info
+                if not _is_claude_proc(info.get("name"), info.get("cmdline")):
+                    continue
+                iid = proc.environ().get("EMPIRICA_INSTANCE_ID")
+            except (psutil.Error, OSError):
+                continue
+            if not iid:
+                continue
+            # Walk the claude proc's ancestry up to the tmux pane shell that
+            # owns it; the pane shell's pid is the tmux pane_pid.
+            node = proc
+            for _ in range(8):
+                try:
+                    if node.pid in pane_pid_to_pane:
+                        pane = pane_pid_to_pane[node.pid]
+                        owned_panes.add(pane)
+                        if pane in pane_id_to_window:
+                            windows[iid] = pane_id_to_window[pane]
+                        break
+                    node = node.parent()
+                except (psutil.Error, OSError):
+                    break
+                if node is None:
+                    break
+    except Exception:
+        pass
+    # Fallback window for unbound seats registered under the tmux_<pane_id> id
+    # (they never declared EMPIRICA_INSTANCE_ID). The id already encodes the
+    # pane, so read the window straight off pane_id — but only for a window NOT
+    # already claimed by a named seat (defensive: shadows are suppressed at
+    # discovery now, so this fires for genuine unbound fallbacks like a
+    # not-yet-rebound seat, not for named-seat ghosts).
+    claimed = set(windows.values())
+    for pane, window in pane_id_to_window.items():
+        if window in claimed:
+            continue
+        windows[f"tmux_{pane}"] = window
+    return windows, owned_panes
+
+
 def live_claude_pids_by_instance() -> dict[str, tuple[int, float | None]] | None:
     """Map each live claude ``EMPIRICA_INSTANCE_ID`` to ``(pid, create_time)``
     (wall-clock bounded — same macOS syscall-hang guard as

--- a/tests/test_cockpit_instance_state.py
+++ b/tests/test_cockpit_instance_state.py
@@ -304,8 +304,28 @@ def test_discover_includes_tmux_panes_without_state_files(env, monkeypatch):
     """Philipp's case: pane running claude but no instance_projects file
     (session predates empirica install). Cockpit must still surface it."""
     monkeypatch.setattr(ist, "_live_tmux_panes", lambda: {"4", "11"})
-    discovered = ist.discover_instances()
+    # No pane owned by a named seat → both synthetic ids surface.
+    discovered = ist.discover_instances(owned_panes=set())
     assert "tmux_4" in discovered
+    assert "tmux_11" in discovered
+
+
+def test_discover_skips_panes_owned_by_named_seat(env, monkeypatch):
+    """A pane whose claude declares an EMPIRICA_INSTANCE_ID is already a named
+    seat (discovered via its own state files) — no duplicate tmux_<pane> ghost."""
+    monkeypatch.setattr(ist, "_live_tmux_panes", lambda: {"4", "11"})
+    discovered = ist.discover_instances(owned_panes={"4"})
+    assert "tmux_4" not in discovered  # owned → suppressed
+    assert "tmux_11" in discovered  # unowned → still surfaced
+
+
+def test_discover_consults_pane_bindings_when_owned_not_passed(env, monkeypatch):
+    """Standalone discover_instances() (no owned_panes arg) derives owned panes
+    from claude_pane_bindings()."""
+    monkeypatch.setattr(ist, "_live_tmux_panes", lambda: {"4", "11"})
+    monkeypatch.setattr(ist, "claude_pane_bindings", lambda: ({}, {"4"}))
+    discovered = ist.discover_instances()
+    assert "tmux_4" not in discovered
     assert "tmux_11" in discovered
 
 
@@ -316,7 +336,7 @@ def test_discover_unions_state_files_and_tmux_panes(env, monkeypatch):
     _bind_instance(home, project, "tmux_5")
     _bind_instance(home, project, "term-pts-7")
     monkeypatch.setattr(ist, "_live_tmux_panes", lambda: {"5", "8"})
-    discovered = ist.discover_instances()
+    discovered = ist.discover_instances(owned_panes=set())
     assert discovered == ["term-pts-7", "tmux_5", "tmux_8"]
 
 

--- a/tests/test_cockpit_tui.py
+++ b/tests/test_cockpit_tui.py
@@ -106,11 +106,14 @@ async def test_tui_has_no_kill_button(cockpit_env):
 
 
 @pytest.mark.asyncio
-async def test_table_has_six_columns(cockpit_env):
+async def test_table_has_seven_columns(cockpit_env):
     """T9 (2026-05-15, David): collapsed separate loops + listeners +
     notifications columns into a unified 'N' (events). The listener (T8)
     is the single wake mechanism now — three columns for the same concept
-    was noise."""
+    was noise.
+
+    2026-07-22 (Philipp): a '#' tmux-window column was inserted between 's'
+    and 'name' so rows sort by the operator's tmux window layout."""
     from textual.widgets import DataTable
 
     from empirica.cli.tui import CockpitApp
@@ -121,7 +124,7 @@ async def test_table_has_six_columns(cockpit_env):
         await pilot.pause()
         table = app.query_one("#inst-table", DataTable)
         col_labels = [c.label.plain for c in table.columns.values()]
-        assert col_labels == ["s", "name", "ph", "dom", "S", "N"]
+        assert col_labels == ["s", "#", "name", "ph", "dom", "S", "N"]
 
 
 # ─── data loading ─────────────────────────────────────────────────────────
@@ -424,8 +427,9 @@ async def test_phase_ask_when_asking_flag_present(cockpit_env):
         for row_key in table.rows:
             if str(row_key.value) == "tmux_42":
                 row = table.get_row(row_key)
-                # v1.6: phase column is shortened — 'ask⚠' with no space
-                phase_cell = str(row[2])
+                # v1.6: phase column is shortened — 'ask⚠' with no space.
+                # 2026-07-22: '#' column inserted at idx 1 → phase now at idx 3.
+                phase_cell = str(row[3])
                 assert "ask" in phase_cell, f"expected ask phase, got {phase_cell!r}"
                 return
         pytest.fail("tmux_42 row not found")
@@ -1266,13 +1270,14 @@ async def test_domain_chip_in_table_when_transaction_open(cockpit_env):
         await pilot.pause()
         await pilot.pause()
         table = app.query_one("#inst-table", DataTable)
-        # Read the 'dom' cell directly via table API (column index 3,
-        # zero-indexed: s, name, ph, dom, ...). The table renders as a
+        # Read the 'dom' cell directly via table API (column index 4,
+        # zero-indexed: s, #, name, ph, dom, ...). The '#' tmux-window column
+        # (2026-07-22) shifted dom from idx 3 to 4. The table renders as a
         # widget — we go via get_cell which works in headless tests.
         row_keys = list(table.rows.keys())
         assert row_keys, "expected at least one row"
         # First row, dom column
-        dom_value = table.get_cell_at((0, 3))
+        dom_value = table.get_cell_at((0, 4))
         # 'leg·H' = legal/high domain chip
         assert dom_value == "leg·H", f"expected leg·H, got {dom_value!r}"
 


### PR DESCRIPTION
## What
Brings in Philipp's cockpit branch (`fd5c0c09d`, cross-tenant via `prop_eootrr`, Homer-accepted) as our PR, plus a lint-clean refactor.

Two changes:
1. **`#` window column** — between the status dot and name, showing each seat's tmux window index; rows sorted ascending so cockpit order mirrors the operator's tmux layout.
2. **Root-cause fix for phantom `tmux_N` ghost rows** — `discover_instances()` minted a synthetic `tmux_<pane>` id for *every* live claude pane unconditionally, duplicating each named seat. It now skips panes already owned by a named seat (whose claude declares `EMPIRICA_INSTANCE_ID`). On Philipp's box this dropped the cockpit 17→10 rows.

One shared bounded proc→pane scan (`liveness.claude_pane_bindings`) feeds both the column and the suppression — built on the `_run_bounded` guard (#375) and `_is_claude_proc` (#371), so it's macOS-hang-safe and CC 2.1.x-safe, and degrades to `({}, set())` on any failure (never blocks a liveness verdict).

## Provenance & review
- Authored by @pschwinger (Philipp), authorship preserved on the cherry-pick; brought in as our PR per the cross-tenant membrane rule.
- **Verified the 113-cockpit-test claim locally** (not on report): `test_cockpit_liveness / _instance_state / _tui` all pass.
- Added a lint-clean refactor: the original `_scan_claude_pane_map` tripped C901 (22>15) and S110 (except/pass) — split into `_tmux_pane_maps` + `_claude_owned_panes`, behavior identical, tests still 113/113.
- ruff check + format clean, pyright 0 errors. Independent of `fix/cockpit-inst-table-fit-all` (no overlap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qe4uGwYbVtE5CFZdsBwata