### PR TITLE
fix(loops): key timer loops on the practice ai_id, not the ephemeral seat

### DIFF
--- a/empirica/cli/command_handlers/cockpit_commands.py
+++ b/empirica/cli/command_handlers/cockpit_commands.py
@@ -372,8 +372,38 @@ def _require_instance_id(args) -> str:
     return instance_id
 
 
+def _require_loop_key(args) -> str:
+    """Resolve the PRACTICE key a loop is stored/scheduled under — the stable
+    ``ai_id``, NOT the ephemeral seat (``tmux_N`` / ``pts_N``).
+
+    Loops belong to the practice (one ``cortex-mailbox-poll`` / ``message-cleanup``
+    per ``ai_id``), keyed the same way the persistent listener already is
+    (``empirica-listener-{ai_id}``; docs/architecture/AI_ID_AS_ANCHOR.md). Keying
+    on the practice is what makes loop timer units orphan-proof — the key doesn't
+    die when the pane closes — and stops per-pane duplicate timers.
+
+    Resolution:
+      1. an explicit non-ephemeral ``--instance`` (caller named a practice key)
+      2. the current practice ``ai_id`` (``InstanceResolver.ai_id()``)
+      3. fallback to the seat ``_require_instance_id`` only if ``ai_id`` is
+         unresolvable (no project.yaml) — never crashes, always returns a key
+    """
+    from empirica.core.loop_scheduler.launchd import is_ephemeral_instance
+
+    explicit = getattr(args, "instance", None)
+    if explicit and not is_ephemeral_instance(explicit):
+        return explicit
+    try:
+        from empirica.utils.session_resolver import InstanceResolver
+
+        ai = InstanceResolver.ai_id()
+    except Exception:
+        ai = None
+    return ai or _require_instance_id(args)
+
+
 def handle_loop_register_command(args) -> int:
-    instance_id = _require_instance_id(args)
+    instance_id = _require_loop_key(args)
     registry = LoopRegistry(instance_id)
     try:
         entry = registry.register(
@@ -406,7 +436,7 @@ def handle_loop_register_command(args) -> int:
 
 
 def handle_loop_unregister_command(args) -> int:
-    instance_id = _require_instance_id(args)
+    instance_id = _require_loop_key(args)
     registry = LoopRegistry(instance_id)
     removed = registry.unregister(args.name)
     payload = {"ok": True, "instance_id": instance_id, "removed": removed, "name": args.name}
@@ -430,7 +460,7 @@ def handle_loop_pause_command(args) -> int:
     if pause flag exists, body exits without scheduling next fire and
     the loop dies cleanly after at most one more silent fire.
     """
-    instance_id = _require_instance_id(args)
+    instance_id = _require_loop_key(args)
     paused = set_loop_paused(instance_id, args.name, paused=True)
 
     registry = LoopRegistry(instance_id)
@@ -494,7 +524,7 @@ def handle_loop_resume_command(args) -> int:
     can't reinstall a CronCreate one-shot directly — surface a hint so
     the user knows to re-issue via /loop or trigger one fire manually.
     """
-    instance_id = _require_instance_id(args)
+    instance_id = _require_loop_key(args)
     paused = set_loop_paused(instance_id, args.name, paused=False)
     registry = LoopRegistry(instance_id)
     entry = registry.get(args.name)
@@ -513,7 +543,7 @@ def handle_loop_resume_command(args) -> int:
 
 
 def handle_loop_set_interval_command(args) -> int:
-    instance_id = _require_instance_id(args)
+    instance_id = _require_loop_key(args)
     registry = LoopRegistry(instance_id)
     try:
         entry = registry.set_interval(args.name, args.interval)
@@ -528,7 +558,7 @@ def handle_loop_set_interval_command(args) -> int:
 
 
 def handle_loop_heartbeat_command(args) -> int:
-    instance_id = _require_instance_id(args)
+    instance_id = _require_loop_key(args)
     registry = LoopRegistry(instance_id)
     try:
         entry = registry.heartbeat(
@@ -569,7 +599,7 @@ def handle_loop_schedule_next_command(args) -> int:
     each fire (and after pause check passes), the body calls this to
     learn when to install the next one-shot.
     """
-    instance_id = _require_instance_id(args)
+    instance_id = _require_loop_key(args)
     registry = LoopRegistry(instance_id)
     plan = registry.schedule_next(args.name)
     if plan is None:
@@ -712,7 +742,7 @@ def handle_loop_fire_command(args) -> int:
     cron template captured, just emits the schedule plan so the caller
     knows what to install.
     """
-    instance_id = _require_instance_id(args)
+    instance_id = _require_loop_key(args)
     registry = LoopRegistry(instance_id)
     entry = registry.get(args.name)
     if entry is None:
@@ -763,7 +793,7 @@ def handle_loop_should_fire_command(args) -> int:
 
     JSON output also includes the reason for traceability.
     """
-    instance_id = _require_instance_id(args)
+    instance_id = _require_loop_key(args)
     registry = LoopRegistry(instance_id)
     should, reason = registry.should_fire(args.name)
     payload = {
@@ -780,7 +810,7 @@ def handle_loop_should_fire_command(args) -> int:
 
 def handle_loop_poke_command(args) -> int:
     """Manual escape hatch — zero the streak, clear the next_fire_threshold."""
-    instance_id = _require_instance_id(args)
+    instance_id = _require_loop_key(args)
     registry = LoopRegistry(instance_id)
     entry = registry.poke(args.name)
     if entry is None:
@@ -800,7 +830,7 @@ def handle_loop_poke_command(args) -> int:
 
 
 def handle_loop_list_command(args) -> int:
-    instance_id = _require_instance_id(args)
+    instance_id = _require_loop_key(args)
     registry = LoopRegistry(instance_id)
     loops = registry.list_loops()
 
@@ -828,7 +858,7 @@ def handle_loop_list_command(args) -> int:
 
 
 def handle_loop_status_command(args) -> int:
-    instance_id = _require_instance_id(args)
+    instance_id = _require_loop_key(args)
     registry = LoopRegistry(instance_id)
     entry = registry.get(args.name)
     if entry is None:
@@ -885,7 +915,7 @@ def handle_loop_enable_command(args) -> int:
         get_loop_scheduler,
     )
 
-    instance_id = _require_instance_id(args)
+    instance_id = _require_loop_key(args)
     empirica_bin = _sh.which("empirica")
     if not empirica_bin:
         return _emit(
@@ -982,7 +1012,7 @@ def handle_loop_disable_command(args) -> int:
         get_loop_scheduler,
     )
 
-    instance_id = _require_instance_id(args)
+    instance_id = _require_loop_key(args)
     try:
         sched = get_loop_scheduler()
         removed = sched.disable(instance_id, args.name)
@@ -1002,7 +1032,7 @@ def handle_loop_systemd_status_command(args) -> int:
         get_loop_scheduler,
     )
 
-    instance_id = _require_instance_id(args)
+    instance_id = _require_loop_key(args)
     try:
         sched = get_loop_scheduler()
         st = sched.status(instance_id, args.name)

--- a/empirica/cli/tui/cockpit_app.py
+++ b/empirica/cli/tui/cockpit_app.py
@@ -803,10 +803,13 @@ class CockpitApp(App):
                     args_dict["interval"] = loop_data.get("interval") or loop_data.get("base_interval") or "30s"
                 args = Namespace(**args_dict)
             else:
+                # Loops are practice-keyed now (registered/enabled under ai_id via
+                # _require_loop_key), so pause/resume must target the same
+                # ai_id_for_timer as the systemd branch — not the ephemeral seat.
                 handler = handle_loop_pause_command if target_paused else handle_loop_resume_command
                 args = Namespace(
                     name=name,
-                    instance=inst["instance_id"],
+                    instance=ai_id_for_timer,
                     output="json",
                 )
             try:

--- a/empirica/core/cockpit/instance_state.py
+++ b/empirica/core/cockpit/instance_state.py
@@ -50,7 +50,7 @@ from empirica.core.cockpit.liveness import (
     is_alive,
     scan_live_claude,
 )
-from empirica.core.cockpit.loop_registry import LoopRegistry, is_loop_paused
+from empirica.core.cockpit.loop_registry import LoopRegistry, is_loop_paused, registry_path
 from empirica.core.cockpit.notify_dispatcher_view import (
     annotate_loops_with_last_notify,
     build_notify_dispatcher_block,
@@ -69,7 +69,10 @@ ABANDONED_WINDOW_S = 24 * 60 * 60
 INSTANCE_GLOBS = (
     "instance_projects/*.json",
     "sentinel_paused_*",
-    "loops_*.json",
+    # NB: loops_*.json is intentionally NOT a discovery signal — loops are
+    # PRACTICE-keyed now (loops_{ai_id}.json), so a loops file is a practice
+    # footprint, not a seat. Deriving a seat from it would mint a phantom
+    # instance named after the ai_id. Seats come from instance_projects/.
     "listeners_*.json",
     "active_session_*",
     "hook_counters_*.json",
@@ -506,13 +509,22 @@ def aggregate_instance_state(
 
     sentinel = sentinel_status(instance_id)
 
-    # Loop registry — graceful when registry doesn't exist.
-    registry = LoopRegistry(instance_id, label=label)
+    # Loop registry — graceful when registry doesn't exist. Loops belong to the
+    # PRACTICE (ai_id), not the ephemeral seat: one cortex-mailbox-poll /
+    # message-cleanup per practice, keyed like the persistent listener
+    # (docs/architecture/AI_ID_AS_ANCHOR.md). Fall back to the seat only when the
+    # ai_id can't be resolved. This keeps the cockpit reading the same key
+    # `loop enable` writes under, so systemd state annotates correctly.
+    loop_key = _project_ai_id(project_path) or instance_id
     loops_dict: dict[str, Any] = {}
-    for entry in registry.list_loops():
-        d = entry.to_dict()
-        d["paused"] = is_loop_paused(instance_id, entry.name)
-        loops_dict[entry.name] = d
+    # Read-only: don't construct a registry (which would CREATE an empty
+    # loops_{ai_id}.json) for a practice that has no loops — that'd be clutter.
+    if registry_path(loop_key).exists():
+        registry = LoopRegistry(loop_key, label=label)
+        for entry in registry.list_loops():
+            d = entry.to_dict()
+            d["paused"] = is_loop_paused(loop_key, entry.name)
+            loops_dict[entry.name] = d
 
     # systemd state annotation (Phase 1c-tail, goal f718156c): for loops
     # registered with scheduler_kind='systemd', the file-flag pause is
@@ -520,7 +532,7 @@ def aggregate_instance_state(
     # `systemd_active` + `systemd_enabled` so the TUI panel + glyph
     # logic can show accurate state. Best-effort: skip silently when
     # systemd-user isn't available (macOS / Windows-native hosts).
-    _annotate_loops_with_systemd_state(instance_id, loops_dict)
+    _annotate_loops_with_systemd_state(loop_key, loops_dict)
 
     # Per-loop last-notify annotation (audit log → loops by `loop:{name}` source).
     annotate_loops_with_last_notify(loops_dict)
@@ -706,8 +718,22 @@ def aggregate_all(include_dead: bool = False) -> dict[str, Any]:
     if not include_dead:
         instances = [i for i in instances if i.get("alive")]
 
-    loops_registered = sum(len(i["loops"]) for i in instances)
-    loops_paused = sum(1 for i in instances for loop in i["loops"].values() if loop.get("paused"))
+    # Loops are practice-keyed — the same loop shows under every live seat of a
+    # practice, so count DISTINCT (ai_id, loop_name) to avoid double-counting a
+    # practice's loop across its seats.
+    _seen_loops: set[tuple[str, str]] = set()
+    loops_registered = 0
+    loops_paused = 0
+    for i in instances:
+        akey = i.get("ai_id") or i["instance_id"]
+        for lname, loop in i["loops"].items():
+            ident = (akey, lname)
+            if ident in _seen_loops:
+                continue
+            _seen_loops.add(ident)
+            loops_registered += 1
+            if loop.get("paused"):
+                loops_paused += 1
     listeners_registered = sum(len(i.get("listeners") or {}) for i in instances)
     listeners_paused = sum(
         1 for i in instances for listener in (i.get("listeners") or {}).values() if listener.get("paused")

--- a/empirica/plugins/claude-code-integration/hooks/loop-install-pickup.py
+++ b/empirica/plugins/claude-code-integration/hooks/loop-install-pickup.py
@@ -78,15 +78,28 @@ def _maybe_auto_install_canonical_loops(instance_id: str, project_root: Path) ->
     try:
         if not project_root.joinpath(".empirica").is_dir():
             return 0  # gate 2
+        # Loops are a PRACTICE concern — dedup stamp + the registry gate key on
+        # the stable ai_id, not the ephemeral seat, so a practice open in N panes
+        # queues its canonical loops ONCE and `enable` writes one unit per
+        # practice (docs/architecture/AI_ID_AS_ANCHOR.md). enable() resolves the
+        # same ai_id key. The pending write/consume pair stays seat-keyed — it
+        # just surfaces the request to the current seat's AI, which then runs
+        # `empirica loop enable` (itself ai_id-resolving).
+        try:
+            from empirica.utils.session_resolver import InstanceResolver
+
+            loop_key = InstanceResolver.ai_id() or instance_id
+        except Exception:
+            loop_key = instance_id
         empirica_home = Path.home() / ".empirica"
-        safe_inst = instance_id.replace(":", "_").replace("/", "-")
+        safe_inst = loop_key.replace(":", "_").replace("/", "-")
         stamp = empirica_home / f"canonical_loops_installed_{safe_inst}"
         if stamp.exists():
             return 0  # gate 4
 
         from empirica.core.cockpit.loop_registry import LoopRegistry
 
-        registry = LoopRegistry(instance_id)
+        registry = LoopRegistry(loop_key)
         if registry.list_loops():
             stamp.parent.mkdir(parents=True, exist_ok=True)
             stamp.write_text("skipped: registry already had entries\n")

--- a/tests/test_cockpit_instance_state.py
+++ b/tests/test_cockpit_instance_state.py
@@ -182,10 +182,14 @@ def test_aggregate_includes_sentinel_pause(env):
 def test_aggregate_includes_loops_with_pause_state(env):
     home, project = env
     _bind_instance(home, project, "tmux_5")
-    reg = lr.LoopRegistry("tmux_5")
+    # Loops are PRACTICE-keyed now (ai_id), not seat-keyed — the project has no
+    # project.yaml so the ai_id resolves to the basename. Registering under the
+    # practice key and aggregating the SEAT still surfaces them.
+    key = project.name
+    reg = lr.LoopRegistry(key)
     reg.register(name="poll-a", kind="cron", cron="*/5 * * * *")
     reg.register(name="poll-b", kind="monitor")
-    lr.set_loop_paused("tmux_5", "poll-b", True)
+    lr.set_loop_paused(key, "poll-b", True)
 
     state = ist.aggregate_instance_state("tmux_5")
     assert set(state["loops"].keys()) == {"poll-a", "poll-b"}
@@ -199,7 +203,8 @@ def test_aggregate_all_summary_counts(env):
     _write_transaction(project, "tmux_5", status="open")
     _bind_instance(home, project, "tmux_7")
     _write_transaction(project, "tmux_7", status="closed")
-    reg = lr.LoopRegistry("tmux_5")
+    # Practice-keyed loop (ai_id = project basename); both seats share it.
+    reg = lr.LoopRegistry(project.name)
     reg.register(name="poll", kind="monitor")
 
     # include_dead=True so synthetic instances aren't filtered by liveness.

--- a/tests/test_cockpit_tui.py
+++ b/tests/test_cockpit_tui.py
@@ -268,7 +268,10 @@ async def test_l_pauses_all_loops_when_any_unpaused(cockpit_env):
 
     home, project = cockpit_env
     _bind_instance(home, project, "tmux_42")
-    reg = LoopRegistry("tmux_42")
+    # Loops are practice-keyed (ai_id = project basename); the TUI resolves the
+    # same ai_id_for_timer and pauses under it.
+    key = project.name
+    reg = LoopRegistry(key)
     reg.register(name="loop-a", kind="monitor")
     reg.register(name="loop-b", kind="monitor")
 
@@ -281,8 +284,8 @@ async def test_l_pauses_all_loops_when_any_unpaused(cockpit_env):
 
         from empirica.core.cockpit import is_loop_paused
 
-        assert is_loop_paused("tmux_42", "loop-a")
-        assert is_loop_paused("tmux_42", "loop-b")
+        assert is_loop_paused(key, "loop-a")
+        assert is_loop_paused(key, "loop-b")
 
 
 @pytest.mark.asyncio
@@ -292,11 +295,13 @@ async def test_l_resumes_all_loops_when_all_paused(cockpit_env):
 
     home, project = cockpit_env
     _bind_instance(home, project, "tmux_42")
-    reg = LoopRegistry("tmux_42")
+    # Practice-keyed loops (ai_id = project basename).
+    key = project.name
+    reg = LoopRegistry(key)
     reg.register(name="loop-a", kind="monitor")
     reg.register(name="loop-b", kind="monitor")
-    set_loop_paused("tmux_42", "loop-a", True)
-    set_loop_paused("tmux_42", "loop-b", True)
+    set_loop_paused(key, "loop-a", True)
+    set_loop_paused(key, "loop-b", True)
 
     app = CockpitApp(include_dead=True)
     async with app.run_test(headless=True, size=(54, 20)) as pilot:
@@ -305,8 +310,8 @@ async def test_l_resumes_all_loops_when_all_paused(cockpit_env):
         await pilot.press("e")
         await pilot.pause()
 
-        assert not is_loop_paused("tmux_42", "loop-a")
-        assert not is_loop_paused("tmux_42", "loop-b")
+        assert not is_loop_paused(key, "loop-a")
+        assert not is_loop_paused(key, "loop-b")
 
 
 # ─── stop ─────────────────────────────────────────────────────────────────
@@ -620,8 +625,9 @@ async def test_l_button_writes_pending_uninstall_when_armed(cockpit_env):
     from empirica.core.cockpit.loop_registry import LoopRegistry
 
     # Register a loop with a recorded job_id (mimics what a healthy
-    # loop body's heartbeat call writes after CronCreate).
-    reg = LoopRegistry("tmux_test")
+    # loop body's heartbeat call writes after CronCreate). Practice-keyed
+    # (ai_id = project basename) — the TUI pauses under the same key.
+    reg = LoopRegistry(project.name)
     reg.register(name="foo", kind="cron", cron="*/15 * * * *", description="t")
     reg.heartbeat(
         name="foo",

--- a/tests/test_loop_practice_key.py
+++ b/tests/test_loop_practice_key.py
@@ -1,0 +1,32 @@
+"""Loops key on the PRACTICE (ai_id), not the ephemeral seat.
+
+`_require_loop_key` is the seam every `empirica loop` handler resolves through:
+loops belong to the practice (one cortex-mailbox-poll / message-cleanup per
+ai_id), keyed like the persistent listener (docs/architecture/AI_ID_AS_ANCHOR.md).
+Keying on the practice is what makes loop timer units orphan-proof — the key
+doesn't die when the pane closes — and stops per-pane duplicate timers.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from empirica.cli.command_handlers.cockpit_commands import _require_loop_key
+from empirica.core.loop_scheduler.launchd import is_ephemeral_instance
+
+
+def test_explicit_practice_key_returned_as_is():
+    """An explicit non-ephemeral --instance (a practice ai_id, which is what the
+    cockpit TUI resolves and passes) is used verbatim — no ambient resolution."""
+    assert _require_loop_key(SimpleNamespace(instance="empirica")) == "empirica"
+    assert _require_loop_key(SimpleNamespace(instance="empirica-workspace")) == "empirica-workspace"
+    assert _require_loop_key(SimpleNamespace(instance="cortex")) == "cortex"
+
+
+def test_ephemeral_seats_are_not_practice_keys():
+    """Seat ids never satisfy the explicit-practice-key fast path — they'd fall
+    through to ai_id resolution instead of being used as the loop key."""
+    for seat in ("tmux_12", "pts_3", "term_pts_6", "x11_78940210"):
+        assert is_ephemeral_instance(seat)
+    for practice in ("empirica", "empirica-workspace", "cortex", "ecodex"):
+        assert not is_ephemeral_instance(practice)


### PR DESCRIPTION
## What
The deeper half of the practitioner/practice keying work (assessed + greenlit earlier). Timer loops were keyed on the **ephemeral seat** (`tmux_N`/`pts_N` from the session resolver), so a practice open in N panes installed N duplicate timers and each became an orphan when its pane died. The persistent listener was **already** ai_id-keyed (`empirica-listener-{ai_id}`); this brings the timer loops onto the same anchor (`docs/architecture/AI_ID_AS_ANCHOR.md`).

## Change — a `_require_loop_key(args)` seam
- Resolves the practice `ai_id` (explicit non-ephemeral `--instance` as-is → `InstanceResolver.ai_id()` → seat only if unresolvable).
- Swapped into **all 15 timer-loop handlers** → `LoopRegistry` + systemd/launchd units become `{ai_id}`-keyed. Persistent-listener + listener-registry handlers untouched (already ai_id-aware).
- `aggregate_instance_state`, the TUI L-button (systemd + legacy branches), and the install-pickup hook's dedup stamp + registry gate all resolve the same practice key.

## Discovery coupling fixed (the subtle part)
`discover_instances` derived seats from `loops_*.json` globs — so a practice-keyed loops file minted a **phantom instance** named after the ai_id (aggregate showed N+1 instances; the TUI acted on the phantom). Fixes:
- Removed `loops_*.json` from `INSTANCE_GLOBS` — loops are a *practice* footprint, not a seat; seats come from `instance_projects/`.
- Aggregate loop-read is now **read-only** (guards on `registry_path(key).exists()` so it never *creates* an empty `loops_{ai_id}.json`).
- Summary loop counts dedupe by `(ai_id, name)` so a practice's loop isn't double-counted across its live seats.

## Outcome
**One loop per practice** (no per-pane duplicates); **orphans are structurally impossible** — the key no longer dies with the pane. The reaper (#379) becomes belt-and-suspenders. Migration: the reaper clears stale seat-keyed units; re-enable re-registers under `ai_id`.

## Tests
+3 (practice-key seam + updated aggregate/TUI fixtures). **559 loop/cockpit/resolver tests pass**, ruff check + format + pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qe4uGwYbVtE5CFZdsBwata
