### PR TITLE
fix(loops): session-init ai_id keying + don't forget practice loops with a seat

### DIFF
--- a/empirica/core/cockpit/instance_actions.py
+++ b/empirica/core/cockpit/instance_actions.py
@@ -381,7 +381,11 @@ def kill_instance(instance_id: str, force: bool = False) -> KillResult:
 _FORGET_PATTERNS = (
     "instance_projects/{id}.json",
     "sentinel_paused_{id}",
-    "loops_{id}.json",
+    # NB: loops_{id}.json is intentionally NOT forgotten with a seat — loops are
+    # PRACTICE-keyed now (loops_{ai_id}.json). Forgetting an ephemeral seat must
+    # not delete the practice's loop registry (it'd be a foot-gun if `instance
+    # forget` were ever called with an ai_id). Loops are removed via
+    # `loop unregister`, not seat teardown.
     "active_session_{id}",
     "hook_counters_{id}.json",
     "context_usage_{id}.json",

--- a/empirica/plugins/claude-code-integration/hooks/session-init.py
+++ b/empirica/plugins/claude-code-integration/hooks/session-init.py
@@ -1521,15 +1521,26 @@ def _maybe_auto_install_canonical_loops(project_root: Path) -> int:
 
         from pathlib import Path as _Path
 
-        stamp = (
-            _Path.home() / ".empirica" / f"canonical_loops_installed_{instance_id.replace(':', '_').replace('/', '-')}"
-        )
+        # Loops are a PRACTICE concern — dedup stamp + the registry gate key on
+        # the stable ai_id, not the ephemeral seat, so a practice open in N panes
+        # queues its canonical loops ONCE (docs/architecture/AI_ID_AS_ANCHOR.md).
+        # Without this, the gate reads an empty loops_{seat} every new session and
+        # re-queues the phantom install prompt. Mirrors loop-install-pickup.py.
+        # write_pending below stays seat-keyed (matched to its consumer).
+        try:
+            from empirica.utils.session_resolver import InstanceResolver
+
+            loop_key = InstanceResolver.ai_id() or instance_id
+        except Exception:
+            loop_key = instance_id
+
+        stamp = _Path.home() / ".empirica" / f"canonical_loops_installed_{loop_key.replace(':', '_').replace('/', '-')}"
         if stamp.exists():
-            return 0  # gate 4: already auto-installed for this instance
+            return 0  # gate 4: already auto-installed for this practice
 
         from empirica.core.cockpit.loop_registry import LoopRegistry
 
-        registry = LoopRegistry(instance_id)
+        registry = LoopRegistry(loop_key)
         existing = registry.list_loops()
         if existing:
             # Some loops already registered manually — write stamp so we

--- a/tests/test_cockpit_instance_actions.py
+++ b/tests/test_cockpit_instance_actions.py
@@ -56,7 +56,8 @@ def _seed_instance_files(home: Path, instance_id: str) -> list[str]:
     files = [
         home / "instance_projects" / f"{instance_id}.json",
         home / f"sentinel_paused_{instance_id}",
-        home / f"loops_{instance_id}.json",
+        # loops_{id}.json intentionally NOT seeded — loops are practice-keyed now
+        # and are NOT forgotten with a seat (see _FORGET_PATTERNS).
         home / f"active_session_{instance_id}",
         home / f"hook_counters_{instance_id}.json",
         home / f"context_usage_{instance_id}.json",


### PR DESCRIPTION
## What
Post-rekey (#380) audit residuals — "did we miss anything." Two, both fold into the pending patch:

1. **Real miss** — `session-init.py` has a **parallel** canonical-loop auto-install helper (separate from the `loop-install-pickup.py` one already fixed) that keyed its dedup stamp + registry gate on the **ephemeral seat**. Since loops moved to `loops_{ai_id}`, the gate read an empty `loops_{seat}` on every new session → **re-queued the phantom install prompt** (prop_osuft class). Keyed on `ai_id`, mirroring `loop-install-pickup.py`.

2. **Latent foot-gun** — `instance_actions.forget_instance` removed `loops_{id}.json` on seat teardown. Post-rekey `loops_{ai_id}.json` is the **practice** registry, so `instance forget <ai_id>` would delete a practice's loops. Removed `loops_` from `_FORGET_PATTERNS` — loops are removed via `loop unregister`, not seat teardown.

> Residual (noted, deferred): `loop_paused_{id}_*` is still forgotten with a seat — same class, lower impact (un-pauses rather than deletes the registry); needs a test change to fix.

## Tests
session-init + instance_actions suites updated/green (29), broad loop/cockpit suite green (70), ruff check + format + pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qe4uGwYbVtE5CFZdsBwata
