### PR TITLE
fix(loops): single source of truth for canonical-loop auto-install (dedupe + fix drift)

### DIFF
--- a/empirica/core/cockpit/canonical_loops.py
+++ b/empirica/core/cockpit/canonical_loops.py
@@ -51,6 +51,7 @@ instead — project config takes precedence over this catalog.
 
 from __future__ import annotations
 
+import contextlib
 from typing import Any
 
 CANONICAL_LOOPS: list[dict[str, Any]] = [
@@ -147,8 +148,85 @@ def canonical_loop_by_name(name: str) -> dict[str, Any] | None:
     return None
 
 
+def maybe_queue_canonical_install(instance_id: str, project_root: Any, requested_by: str) -> int:
+    """Queue install-pending for each auto-installable canonical loop — the
+    SINGLE SOURCE OF TRUTH for the SessionStart (``session-init.py``) and
+    UserPromptSubmit (``loop-install-pickup.py``) hooks.
+
+    These previously each held their own copy of this cascade and drifted:
+    ``session-init`` lacked both the ``opt_in_only`` carve-out (so it queued
+    ``cortex-mailbox-poll`` — the wake-on-event loop — on every new session) and
+    the ``scheduler_kind`` passthrough, while ``loop-install-pickup`` had them
+    (from the #361 fix). One helper keeps them from drifting again.
+
+    Gate cascade:
+      1. project has ``.empirica/`` (opted into empirica)
+      2. dedup stamp absent — once per PRACTICE (``canonical_loops_installed_{ai_id}``)
+      3. the practice's loop registry is empty (don't clobber manual config)
+      4. per loop: skip ``opt_in_only`` (e.g. ``cortex-mailbox-poll`` — wake-on-event
+         is the canonical trigger; cron-only harnesses opt in via ``loop register``)
+
+    Loops are PRACTICE-keyed (docs/architecture/AI_ID_AS_ANCHOR.md): the stamp +
+    registry gate key on the stable ``ai_id``; ``write_pending`` stays seat-keyed
+    (its consumer is the seat's pickup hook). Returns the count queued (0 on any
+    failed gate). Never raises — hooks must not crash the prompt/session.
+    """
+    from pathlib import Path
+
+    try:
+        if not Path(project_root).joinpath(".empirica").is_dir():
+            return 0  # gate 1
+        # Loops are a practice concern — dedup + registry gate on the stable ai_id.
+        try:
+            from empirica.utils.session_resolver import InstanceResolver
+
+            loop_key = InstanceResolver.ai_id() or instance_id
+        except Exception:
+            loop_key = instance_id
+        empirica_home = Path.home() / ".empirica"
+        safe_key = loop_key.replace(":", "_").replace("/", "-")
+        stamp = empirica_home / f"canonical_loops_installed_{safe_key}"
+        if stamp.exists():
+            return 0  # gate 2
+
+        from empirica.core.cockpit.loop_registry import LoopRegistry
+
+        if LoopRegistry(loop_key).list_loops():
+            stamp.parent.mkdir(parents=True, exist_ok=True)
+            stamp.write_text("skipped: registry already had entries\n")
+            return 0  # gate 3
+
+        from empirica.core.cockpit.loop_install_request import write_pending
+
+        installed = 0
+        for entry in CANONICAL_LOOPS:
+            if entry.get("opt_in_only"):
+                continue  # gate 4: opt-in only (wake-on-event is canonical)
+            # One loop's write failure must not drop the rest — best-effort.
+            with contextlib.suppress(Exception):
+                write_pending(
+                    instance_id=instance_id,  # seat-keyed bridge → the seat's pickup hook
+                    name=entry["name"],
+                    interval=entry.get("interval", "15m"),
+                    description=entry.get("description", ""),
+                    base_interval=entry.get("base_interval"),
+                    max_interval=entry.get("max_interval"),
+                    requested_by=requested_by,
+                    body_skill=entry.get("body_skill"),
+                    scheduler_kind=entry.get("scheduler_kind"),
+                )
+                installed += 1
+        if installed:
+            stamp.parent.mkdir(parents=True, exist_ok=True)
+            stamp.write_text(f"installed {installed} canonical loop(s) via {requested_by}\n")
+        return installed
+    except Exception:
+        return 0  # never crash the caller
+
+
 __all__ = [
     "CANONICAL_LOOPS",
     "canonical_loop_by_name",
     "canonical_loop_names",
+    "maybe_queue_canonical_install",
 ]

--- a/empirica/plugins/claude-code-integration/hooks/loop-install-pickup.py
+++ b/empirica/plugins/claude-code-integration/hooks/loop-install-pickup.py
@@ -62,88 +62,17 @@ installed by you.
 
 
 def _maybe_auto_install_canonical_loops(instance_id: str, project_root: Path) -> int:
-    """Zero-touch install on every UserPromptSubmit (works with --resume,
-    unlike SessionStart which only fires on new sessions).
+    """Zero-touch install on every UserPromptSubmit (works with --resume, unlike
+    SessionStart which only fires on new sessions).
 
-    Same four-gate cascade as the original session-init helper:
-      1. resolvable instance_id (caller already provides)
-      2. project has `.empirica/` (signals empirica intent)
-      3. registry empty (don't clobber manual config)
-      4. no stamp file (only install once per instance lifetime)
-
-    Returns count of canonical loops queued; 0 if any gate fails.
-    The stamp file (`~/.empirica/canonical_loops_installed_<instance>`)
-    makes this idempotent — subsequent prompts skip after first fire.
+    Thin wrapper over the single source of truth
+    ``canonical_loops.maybe_queue_canonical_install`` — the practice-keyed,
+    opt_in_only-aware, scheduler_kind-passing cascade shared with
+    ``session-init.py`` (they previously each held a copy that drifted).
     """
-    try:
-        if not project_root.joinpath(".empirica").is_dir():
-            return 0  # gate 2
-        # Loops are a PRACTICE concern — dedup stamp + the registry gate key on
-        # the stable ai_id, not the ephemeral seat, so a practice open in N panes
-        # queues its canonical loops ONCE and `enable` writes one unit per
-        # practice (docs/architecture/AI_ID_AS_ANCHOR.md). enable() resolves the
-        # same ai_id key. The pending write/consume pair stays seat-keyed — it
-        # just surfaces the request to the current seat's AI, which then runs
-        # `empirica loop enable` (itself ai_id-resolving).
-        try:
-            from empirica.utils.session_resolver import InstanceResolver
+    from empirica.core.cockpit.canonical_loops import maybe_queue_canonical_install
 
-            loop_key = InstanceResolver.ai_id() or instance_id
-        except Exception:
-            loop_key = instance_id
-        empirica_home = Path.home() / ".empirica"
-        safe_inst = loop_key.replace(":", "_").replace("/", "-")
-        stamp = empirica_home / f"canonical_loops_installed_{safe_inst}"
-        if stamp.exists():
-            return 0  # gate 4
-
-        from empirica.core.cockpit.loop_registry import LoopRegistry
-
-        registry = LoopRegistry(loop_key)
-        if registry.list_loops():
-            stamp.parent.mkdir(parents=True, exist_ok=True)
-            stamp.write_text("skipped: registry already had entries\n")
-            return 0  # gate 3
-
-        from empirica.core.cockpit.canonical_loops import CANONICAL_LOOPS
-        from empirica.core.cockpit.loop_install_request import write_pending
-
-        # Gate 5: cortex-mailbox-poll is OPT-IN ONLY. Wake-on-event (the
-        # persistent listener) is the canonical mesh trigger; the 30s poller is
-        # redundant on any wake-on-event seat and only wanted on harnesses that
-        # CANNOT do wake-on-event (cron-only VMs, isolated cloud) — where the user
-        # opts in explicitly via `empirica loop register`. So NEVER auto-queue a
-        # loop flagged `opt_in_only`. Genuine housekeeping crons (message-cleanup)
-        # are not flagged and still auto-install. (David 2026-07-19: "wake on
-        # event should be the only mesh trigger unless the user opts in"; cortex
-        # prop_osuft3rn, extension prop_syrvccyu6.)
-        installed = 0
-        for entry in CANONICAL_LOOPS:
-            scheduler_kind = entry.get("scheduler_kind")
-            if entry.get("opt_in_only"):
-                continue  # opt-in only — the user registers it themselves
-            try:
-                write_pending(
-                    instance_id=instance_id,
-                    name=entry["name"],
-                    interval=entry.get("interval", "15m"),
-                    description=entry.get("description", ""),
-                    base_interval=entry.get("base_interval"),
-                    max_interval=entry.get("max_interval"),
-                    requested_by="user-prompt-submit",
-                    body_skill=entry.get("body_skill"),
-                    scheduler_kind=scheduler_kind,  # DEFECT 1: was dropped → wrongly defaulted to cron-create
-                )
-                installed += 1
-            except Exception:
-                pass
-
-        if installed:
-            stamp.parent.mkdir(parents=True, exist_ok=True)
-            stamp.write_text(f"installed {installed} canonical loop(s) via UserPromptSubmit\n")
-        return installed
-    except Exception:
-        return 0  # never crash the user prompt
+    return maybe_queue_canonical_install(instance_id, project_root, requested_by="user-prompt-submit")
 
 
 def main() -> int:

--- a/empirica/plugins/claude-code-integration/hooks/session-init.py
+++ b/empirica/plugins/claude-code-integration/hooks/session-init.py
@@ -1509,71 +1509,17 @@ def _maybe_auto_install_canonical_loops(project_root: Path) -> int:
     Returns the count of canonical loops queued (0 if any gate failed).
     """
     try:
+        from empirica.core.cockpit.canonical_loops import maybe_queue_canonical_install
         from empirica.utils.session_resolver import get_instance_id
 
         instance_id = get_instance_id()
         if not instance_id:
             return 0  # gate 1: no instance_id (headless / unknown)
-
-        empirica_dir = project_root / ".empirica"
-        if not empirica_dir.is_dir():
-            return 0  # gate 2: project hasn't been empirica-initialized
-
-        from pathlib import Path as _Path
-
-        # Loops are a PRACTICE concern — dedup stamp + the registry gate key on
-        # the stable ai_id, not the ephemeral seat, so a practice open in N panes
-        # queues its canonical loops ONCE (docs/architecture/AI_ID_AS_ANCHOR.md).
-        # Without this, the gate reads an empty loops_{seat} every new session and
-        # re-queues the phantom install prompt. Mirrors loop-install-pickup.py.
-        # write_pending below stays seat-keyed (matched to its consumer).
-        try:
-            from empirica.utils.session_resolver import InstanceResolver
-
-            loop_key = InstanceResolver.ai_id() or instance_id
-        except Exception:
-            loop_key = instance_id
-
-        stamp = _Path.home() / ".empirica" / f"canonical_loops_installed_{loop_key.replace(':', '_').replace('/', '-')}"
-        if stamp.exists():
-            return 0  # gate 4: already auto-installed for this practice
-
-        from empirica.core.cockpit.loop_registry import LoopRegistry
-
-        registry = LoopRegistry(loop_key)
-        existing = registry.list_loops()
-        if existing:
-            # Some loops already registered manually — write stamp so we
-            # don't auto-install on top of user intent next time.
-            stamp.parent.mkdir(parents=True, exist_ok=True)
-            stamp.write_text("skipped: registry already had entries\n")
-            return 0  # gate 3: not fresh
-
-        # All gates pass — queue install-pending for each canonical loop.
-        from empirica.core.cockpit.canonical_loops import CANONICAL_LOOPS
-        from empirica.core.cockpit.loop_install_request import write_pending
-
-        installed = 0
-        for entry in CANONICAL_LOOPS:
-            try:
-                write_pending(
-                    instance_id=instance_id,
-                    name=entry["name"],
-                    interval=entry.get("interval", "15m"),
-                    description=entry.get("description", ""),
-                    base_interval=entry.get("base_interval"),
-                    max_interval=entry.get("max_interval"),
-                    requested_by="session-init",
-                    body_skill=entry.get("body_skill"),
-                )
-                installed += 1
-            except Exception:
-                pass
-
-        if installed:
-            stamp.parent.mkdir(parents=True, exist_ok=True)
-            stamp.write_text(f"installed {installed} canonical loop(s) at session-init\n")
-        return installed
+        # Single source of truth — practice-keyed, opt_in_only-aware,
+        # scheduler_kind-passing. session-init's old inline copy lacked the
+        # opt_in_only carve-out + scheduler_kind (it queued cortex-mailbox-poll
+        # on every new session); delegating fixes that drift permanently.
+        return maybe_queue_canonical_install(instance_id, project_root, requested_by="session-init")
     except Exception:
         return 0
 

--- a/tests/test_session_init_canonical_loops.py
+++ b/tests/test_session_init_canonical_loops.py
@@ -115,11 +115,14 @@ def test_skips_when_registry_already_has_loops(session_init_module, tmp_path):
     assert len(stamp_glob) == 1
 
 
-def test_pending_install_file_carries_skill_body(session_init_module, tmp_path):
-    """After auto-install, the pending install-request file should contain
-    the actual cortex polling body (from the skill) — not the generic
-    `your actual work here` placeholder. Confirms server-side merge
-    (from earlier commit) integrates with auto-install."""
+def test_auto_install_queues_housekeeping_and_skips_opt_in(session_init_module, tmp_path):
+    """Auto-install queues the non-opt-in canonical loops (message-cleanup) with
+    a well-formed install template, and does NOT queue opt_in_only loops
+    (cortex-mailbox-poll — wake-on-event is the canonical trigger).
+
+    This pins the fix for the drift that the shared-helper dedup closed:
+    session-init used to lack the opt_in_only carve-out and queued
+    cortex-mailbox-poll on every new session."""
     import json
 
     project = _make_empirica_project(tmp_path)
@@ -127,9 +130,8 @@ def test_pending_install_file_carries_skill_body(session_init_module, tmp_path):
     assert count >= 1
 
     home = Path(tmp_path / "home")
-    pending = list((home / ".empirica").glob("loop_install_pending_*_cortex-mailbox-poll.json"))
-    assert len(pending) == 1
-    data = json.loads(pending[0].read_text())
-    template = data.get("prompt_template", "")
-    assert "cortex_inbox_poll" in template
-    assert "your actual work here" not in template
+    mc = list((home / ".empirica").glob("loop_install_pending_*_message-cleanup.json"))
+    assert len(mc) == 1
+    assert json.loads(mc[0].read_text()).get("prompt_template")  # real template, not blank
+    # opt_in_only loops must NOT be auto-queued.
+    assert not list((home / ".empirica").glob("loop_install_pending_*_cortex-mailbox-poll.json"))


### PR DESCRIPTION
## What (broccoli 1.12.33 blocker)
The canonical-loop auto-install cascade was **hand-duplicated** across `session-init.py` (SessionStart) and `loop-install-pickup.py` (UserPromptSubmit) — and the copies had **drifted**: session-init lacked the `opt_in_only` carve-out *and* the `scheduler_kind` passthrough that loop-install-pickup got from #361.

**Consequence (real latent bug):** SessionStart was queuing `cortex-mailbox-poll` — the wake-on-event, opt-in-only loop — on **every new session**. A recurrence of the phantom-install-prompt bug the duplication was hiding.

## Fix
Extracted the practice-keyed, `opt_in_only`-aware, `scheduler_kind`-passing cascade to **`canonical_loops.maybe_queue_canonical_install()`** — one source of truth both hooks now delegate to (thin wrappers). Can't drift again.

## Tests
Repurposed `test_session_init_canonical_loops`: the old assertion validated cortex-mailbox-poll's server-side skill-body *merge* via auto-install — a path no longer taken. It now pins the correct behavior: **message-cleanup queued** with a real template, **cortex-mailbox-poll NOT queued**. 20 + 141 loop/cockpit tests pass, ruff + format + pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qe4uGwYbVtE5CFZdsBwata
