### PR TITLE
fix(compliance): make compliance-report --tests actually complete locally (parallel + configurable timeout)

### DIFF
--- a/empirica/cli/command_handlers/compliance_report_commands.py
+++ b/empirica/cli/command_handlers/compliance_report_commands.py
@@ -9,6 +9,7 @@ Machine-readable JSON + human-readable summary.
 
 import json
 import logging
+import os
 import subprocess
 import time
 from pathlib import Path
@@ -1235,7 +1236,18 @@ def run_compliance_report(
 
     # Optional checks (slow)
     if include_tests:
-        pytest_raw = _run_check("pytest", ["python3", "-m", "pytest", "tests/", "-q", "--tb=line"], timeout=300)
+        # The full suite is ~5k tests. Parallelize with pytest-xdist when it's
+        # importable (-n auto ≈ cores× faster) so the LOCAL gate actually finishes
+        # instead of timing out — a serial run overran the old hardcoded 300s,
+        # which cascaded into a governance_integrity failure (pytest left
+        # unmapped). Timeout is generous + env-overridable.
+        import importlib.util
+
+        pytest_cmd = ["python3", "-m", "pytest", "tests/", "-q", "--tb=line"]
+        if importlib.util.find_spec("xdist") is not None:
+            pytest_cmd += ["-n", "auto"]  # pytest-xdist installed → parallelize
+        pytest_timeout = int(os.environ.get("EMPIRICA_COMPLIANCE_PYTEST_TIMEOUT", "1200"))
+        pytest_raw = _run_check("pytest", pytest_cmd, timeout=pytest_timeout)
         results.append(_parse_pytest_result(pytest_raw))
 
     if include_dep_audit:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,6 +119,7 @@ test = [
     "pytest-asyncio>=0.21",
     "pytest-cov>=4.1",
     "pytest-mock>=3.11",
+    "pytest-xdist>=3.6",          # parallel `-n auto` — keeps `compliance-report --tests` from timing out locally
     "dirty-equals>=0.7",
 ]
 lint = [


### PR DESCRIPTION
## Why
`compliance-report --tests` hardcoded a **300s** pytest timeout; the full ~5k-test tree overruns it serially, so the check always came back `fail`/timeout locally — and that **cascaded into a governance_integrity failure** (pytest left unmapped in the compliance crosswalk). So the local gate couldn't catch test failures before the CI round-trip.

## Fix
- Run pytest with `-n auto` when **pytest-xdist** is importable (≈cores× faster; detected via `importlib.util.find_spec`, no hard dep, no import error).
- Timeout is **env-overridable** (`EMPIRICA_COMPLIANCE_PYTEST_TIMEOUT`, default 1200s) instead of hardcoded 300.
- Added `pytest-xdist` to the `test` extras so the parallel path is available on any dev install.

## Verified
Full `compliance-report --tests --dep-audit --security` now **completes**: 4874 passed / 2 known local-only fails / 9 skipped in ~292s parallel, and governance_integrity clears. Score **0.875 → 0.9375** (only trufflehog/secret_scan still unavailable as a tool). ruff + pyright clean, `test_compliance_config` 23/23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qe4uGwYbVtE5CFZdsBwata