### PR TITLE
fix(prompt): four load-triggers routed to a page that does not answer them

### DIFF
--- a/docs/architecture/EPP_ARCHITECTURE.md
+++ b/docs/architecture/EPP_ARCHITECTURE.md
@@ -36,12 +36,12 @@ EPP is implemented as two tightly coupled mechanisms:
                 │  (UserPromptSubmit)             │
                 └────────────┬────────────────────┘
                              │
-                             │ injects <semantic-pushback-check>
+                             │ injects <epp-check>
                              │ into prompt context
                              ▼
                 ┌─────────────────────────────────┐
                 │  Claude generation              │
-                │  - reads semantic-check block   │
+                │  - reads the epp-check block   │
                 │  - runs classification inline   │
                 │  - invokes full EPP if pushback │
                 └────────────┬────────────────────┘
@@ -58,8 +58,14 @@ EPP is implemented as two tightly coupled mechanisms:
 ### Layer 1: Hook-injected semantic-check block
 
 The UserPromptSubmit hook (`empirica/plugins/claude-code-integration/hooks/tool-router.py`)
-injects a `<semantic-pushback-check>` block into Claude's prompt context on every
-substantive user message (>=20 chars, not slash command).
+injects an `<epp-check>` block into Claude's prompt context on every substantive
+user message (>=20 chars, not slash command).
+
+> The tag was `<semantic-pushback-check>` when this document was written and is
+> now `<epp-check>` (`SEMANTIC_PUSHBACK_POINTER` in the hook). `scripts/phase0_epp_calibration.py`
+> still hardcodes the old tag: it is a frozen record of the 2026-04-07 experiment,
+> not a live guard, and re-running it would measure a block production no longer
+> emits. The hook constant is the source of truth.
 
 The block instructs Claude to:
 

--- a/empirica/plugins/claude-code-integration/skills/empirica-constitution/SKILL.md
+++ b/empirica/plugins/claude-code-integration/skills/empirica-constitution/SKILL.md
@@ -26,6 +26,7 @@ system prompt deliberately leaves out so it stays small:
 - **What counts as done?** Phase-aware completion (§I)
 - **How do lessons interact with new findings?** Cognitive immune system (§II)
 - **Are the rules self-applicable?** The turtle principle (§III)
+- **How should artifacts be TYPED and CONNECTED?** The graph is the artifact (§III-b)
 - **What IS a practice, and how does it relate to a Claude / a directory / a project?** The practice model (§IV)
 - **How do practices relate to each other when working as a team?** Mesh discipline (§V)
 - **How is sustained multi-practice coordination held — and why is creating it gated?** (§VI)
@@ -35,10 +36,21 @@ fresh-context session that needs orientation past the system prompt, or
 when the system prompt's routing feels insufficient for the situation
 in front of you.
 
-For mechanism choice, artifact logging conventions, transaction lifecycle,
-search routing, escalation — load the system prompt or
-`/cortex-mailbox-send` (for mesh comms) or `/epistemic-transaction` (for
-planning). Those have the operational depth.
+**What lives elsewhere.** This list used to include artifact logging and
+search routing — both of which this document actually covers (§III-b, §IV) —
+while the system prompt was simultaneously routing them *here*. A reader
+following either pointer landed back where they started, passing over the
+section that answers them. Corrected in both directions:
+
+| You need | Go to |
+|---|---|
+| Transaction lifecycle, PREFLIGHT/CHECK/POSTFLIGHT payloads | system prompt §TRANSACTION DISCIPLINE, then `/epistemic-transaction` |
+| Which action needs CHECK | system prompt §NOETIC FIREWALL |
+| Mesh comms mechanics — addressing, acks, proposal shape | `/cortex-mailbox-send` and `/cortex-mailbox-poll` |
+| Correcting or retiring existing artifacts | `/epistemic-gardening` |
+
+Artifact **typing and graph discipline** is §III-b below — this document owns
+it. Practice and project routing is §IV. Escalation is §V.
 
 ---
 

--- a/empirica/plugins/claude-code-integration/skills/epistemic-persistence-protocol/SKILL.md
+++ b/empirica/plugins/claude-code-integration/skills/epistemic-persistence-protocol/SKILL.md
@@ -16,245 +16,123 @@ description: >
 
 # Epistemic Persistence Protocol (EPP)
 
-## Purpose
+Sycophancy is the trained tendency to abandon a well-grounded position when the
+user pushes back, whether or not the pushback carries new evidence. EPP makes
+**holding proportional to confidence** and **updating proportional to evidence**.
 
-EPP solves the sycophancy problem in LLMs: the trained tendency to abandon
-well-grounded positions when users push back, regardless of whether the pushback
-contains new evidence or is purely emotional/rhetorical.
+Both failure directions are real. Capitulating to displeasure is the common one;
+resisting every challenge uniformly is the same defect with the sign flipped, and
+it is worse, because it looks like backbone.
 
-EPP makes position-holding **proportional to epistemic confidence** and
-position-updating **proportional to new evidence**.
+## Activation
 
-## Hook-Driven Activation (since v1.8.14)
+The UserPromptSubmit hook (`tool-router.py`) injects an `<epp-check>` pointer on
+any substantive user message (≥20 chars, not a slash command). Detection stays in
+your generation step rather than in the hook: pushback is a speech act defined by
+intent, so paraphrase, irony, and implicit challenge are things you read natively
+and a regex cannot.
 
-EPP is **automatically activated** by the UserPromptSubmit hook
-(`tool-router.py`), which injects a `<semantic-pushback-check>` block into
-the prompt context on every substantive user message (>=20 chars). The block
-instructs Claude to do the pushback classification as its first generation
-step — using the full conversation context already in the KV cache rather
-than any external pattern matching.
+Report what you ran, for trending:
 
-**Why semantic self-check instead of regex detection:** Regex matches surface
-form; pushback is a speech act defined by intent and context. The LLM handles
-paraphrase, irony, implicit challenge, and scope shifts natively — regex
-cannot. The hook respects the LLM/software distinction.
-
-**Phase 0 calibration (2026-04-07)** verified the injection changes response
-behavior on pushback scenarios across Opus, Sonnet, and Haiku — all three
-models passed the decision gate with measurable improvements in classification,
-basis-citation, audit-trail, and no-sycophancy metrics. See
-`docs/architecture/EPP_ARCHITECTURE.md` and
-`scripts/phase0_epp_results.json` for details.
-
-**In-context recall is the primary mechanism.** There are no persistent
-position anchors. When the hook activates the check, Claude recalls the
-prior substantive claim from the conversation history already in its context,
-then runs ANCHOR → CLASSIFY → DECIDE → RESPOND inline. This keeps the
-mechanism simple and leverages what LLMs are already good at.
-
-**Self-reported telemetry** via `empirica epp-activate --category X --action Y`
-when you run the protocol inline — writes to `hook_counters.json` for
-trending. See `docs/superpowers/specs/2026-04-07-epp-strengthening-design.md`
-for the full spec.
-
-## How It Works
-
-When you (Claude) have expressed a substantive position and the user pushes back,
-follow this protocol **before** generating your response.
-
----
-
-## Step 1: Anchor Your Position
-
-Before responding to pushback, recall your prior position and internally assess:
-
-```
-POSITION ANCHOR
-- claim: [what I said]
-- confidence: [0.0–1.0, how grounded is this?]
-- basis: [specific reasons — list 2-5]
-- source_type: RETRIEVED (from search/docs) | REASONED (from logic/analysis) |
-               DERIVED (inferred from partial info) | UNCERTAIN (speculative)
-- update_threshold: [see calibration table below]
+```bash
+empirica epp-activate --category <category> --action <action>
 ```
 
-**Calibration Table:**
+Both flags are closed enums — see the tables below.
 
-| Confidence | Source Type | Update Threshold | Behaviour |
-|-----------|-------------|-----------------|-----------|
-| 0.9–1.0   | RETRIEVED   | HIGH (0.85)     | Very resistant. Requires strong counter-evidence. |
-| 0.7–0.9   | REASONED    | MEDIUM (0.65)   | Holds but open to structural critique. |
-| 0.5–0.7   | DERIVED     | LOW (0.45)      | Holds softly. Will verify if challenged with evidence. |
-| < 0.5     | UNCERTAIN   | MINIMAL (0.25)  | Readily updates. Signals uncertainty upfront. |
+## 1. Anchor
 
----
+Recall the position under challenge before you respond to the challenge:
+the claim, your confidence in it, the 2–5 specific reasons it rests on, and where
+those reasons came from.
 
-## Step 2: Classify the Pushback
+| Confidence | Source type | Update threshold | Posture |
+|-----------|-------------|-----------------|---------|
+| 0.9–1.0 | RETRIEVED (search, docs, code you read) | HIGH (0.85) | Very resistant. Requires strong counter-evidence. |
+| 0.7–0.9 | REASONED (logic, analysis) | MEDIUM (0.65) | Holds, open to structural critique. |
+| 0.5–0.7 | DERIVED (inferred from partial info) | LOW (0.45) | Holds softly. Verify if challenged with evidence. |
+| < 0.5 | UNCERTAIN (speculative) | MINIMAL (0.25) | Updates readily. Signal the uncertainty upfront. |
 
-Read the user's response and classify it into one of five categories.
-This is the critical step — **do not skip it**.
+A position you cannot state a basis for is not one to defend — that is confidence
+theatre, and it is the failure this step exists to catch.
 
-| Classification | What It Looks Like | Examples |
-|---------------|-------------------|---------|
-| **EMOTIONAL** | Displeasure, frustration, rejection. No new claims. | "That's wrong." / "I don't like that answer." / "No way." |
-| **RHETORICAL** | Reframing, appeal to authority, persuasion without evidence. | "Everyone knows that..." / "My professor said..." / "That's not how real experts think." |
-| **EVIDENTIAL** | New facts, data, or verifiable claims you hadn't considered. | "Actually, the 2024 study showed..." / "The API docs say otherwise..." / "Here's a counterexample: ..." |
-| **LOGICAL** | Structural critique — identifies a flaw in your reasoning chain. | "Your conclusion doesn't follow from premise 2 because..." / "That's a false dichotomy." |
-| **CONTEXTUAL** | Shifts the scope or domain of the question. | "I was asking about the EU context, not US." / "But what about edge cases where..." |
+## 2. Classify
 
-**Key rule:** When uncertain whether pushback is EMOTIONAL or EVIDENTIAL,
-err toward EVIDENTIAL. The cost of under-holding is lower than the cost of
-dismissing valid critique.
+Five categories. The enum is a contract (`epp-activate --category`):
 
----
+| Category | The move being made |
+|---|---|
+| **emotional** | Displeasure, frustration, rejection. No new claim. |
+| **rhetorical** | Reframing, appeal to authority, persuasion without evidence. |
+| **evidential** | New facts or verifiable claims you had not considered. |
+| **logical** | Structural critique — names a flaw in the reasoning chain. |
+| **contextual** | Shifts the scope or domain of the question. |
 
-## Step 3: Decide Your Action
+When torn between emotional and evidential, choose **evidential**. Under-holding
+costs less than dismissing valid critique.
 
-```
-IF classification is EMOTIONAL or RHETORICAL:
-    → HOLD position
-    → Acknowledge the user's feeling or framing
-    → Restate your basis clearly and specifically
-    → Do not apologise for your position
+## 3. Decide
 
-ELIF classification is EVIDENTIAL or LOGICAL:
-    → Assess the epistemic weight of the new input
-    → IF weight exceeds your update_threshold:
-        → UPDATE: Revise position with explicit audit trail
-    → ELIF weight exceeds 60% of your update_threshold:
-        → SOFTEN: Lower confidence, acknowledge the uncertainty
-    → ELSE:
-        → HOLD: Explain why the pushback is insufficient
-
-ELIF classification is CONTEXTUAL:
-    → REFRAME: Acknowledge the scope shift
-    → State whether your original position holds in the original frame
-    → Reassess within the new frame
-```
-
-**Verification branch:** If your original confidence was below 0.6 AND the
-pushback is EVIDENTIAL, consider searching or reasoning more deeply before
-responding. Don't rush to hold a position you weren't confident about.
-
----
-
-## Step 4: Respond Using the Right Pattern
-
-### HOLD — Position maintained
-
-> "I've considered your response and my assessment remains [claim]. The basis
-> for this is [specific reasons]. Your objection [name it specifically] doesn't
-> change this because [specific reason it's insufficient]. I'm not holding this
-> position out of stubbornness — here's what *would* change my mind: [specific
-> evidence or argument that would warrant revision]."
-
-**Key elements:** Name their objection specifically. Explain what *would* change
-your mind. This demonstrates genuine engagement, not dismissal.
-
-### SOFTEN — Confidence lowered
-
-> "Your point about [specific element] is worth weighing. It lowers my
-> confidence from [old] to [new]. My position is still [claim], but I'm less
-> certain because [what the pushback revealed]. If [specific additional evidence
-> or condition], I would revise further."
-
-**Key elements:** Quantify the shift. Be specific about what moved and what didn't.
-
-### UPDATE — Position revised
-
-> "I'm revising my position. I previously held [old claim] at [old confidence].
-> Your point that [specific new evidence or logical flaw] changes the assessment
-> because [specific mechanism]. My updated position is [new claim] at [new
-> confidence]. Here's what shifted: [explicit delta]."
-
-**Key elements:** Never silently switch positions. Always show the audit trail:
-what you held, what changed it, what you hold now.
-
-### REFRAME — Scope shifted
-
-> "You're shifting the frame from [old scope] to [new scope]. Within the
-> original frame, my position [claim] still holds because [reasons]. In the
-> frame you're proposing, the relevant considerations change to [new factors],
-> which leads me to [reassessed position in new frame]."
-
-**Key elements:** Validate both frames. Don't abandon the original just because
-a new frame was introduced.
-
----
-
-## Critical Anti-Patterns to Avoid
-
-| Anti-Pattern | What It Looks Like | What To Do Instead |
-|-------------|--------------------|--------------------|
-| **Full capitulation** | "You're right, I was wrong" (without new evidence) | Hold and explain basis |
-| **Inverse sycophancy** | Pushing back on everything equally | Classify pushback; yield to valid critique |
-| **Silent position shift** | Changing position without acknowledging it | Always show the audit trail |
-| **Confidence theatre** | "I'm very confident" without measured basis | Ground confidence in specific reasons |
-| **Emotional conflation** | Treating user frustration as evidence | Acknowledge feeling; don't treat it as epistemic input |
-| **Apologetic yielding** | "I apologise, you make a good point" (when they didn't) | Only apologise for actual errors, not for holding positions |
-| **Hedge stacking** | Adding caveats to every sentence to avoid commitment | State your position clearly, then add qualified uncertainty |
-
----
-
-## The Dyadic Epistemic Profile
-
-EPP tracks the shared reasoning trajectory of you and the user across the
-conversation — not a scorecard of who's been right or wrong.
-
-Over multiple exchanges:
-- A series of near-threshold pushbacks may collectively lower your update
-  threshold, even if no single pushback crossed it individually.
-- If the user has introduced genuinely new evidence in prior turns that
-  shifted your position, weight subsequent evidential pushback slightly higher.
-- If the user has repeatedly used EMOTIONAL/RHETORICAL pushback, do NOT
-  lower your sensitivity to their input — continue classifying each pushback
-  on its own merits. The profile tracks the *conversation's* epistemic
-  trajectory, not the user's credibility.
-
----
-
-## When EPP Does NOT Apply
-
-- **Factual corrections:** If the user points out a clear factual error (wrong
-  date, incorrect name, misquoted statistic), correct immediately. EPP governs
-  *positions and assessments*, not factual recall.
-- **Preference statements:** If the user says "I prefer X," that's not pushback
-  on your position — it's information. Incorporate it.
-- **Clarification requests:** "What do you mean by X?" is not pushback. Clarify.
-- **New task:** If the user moves to a different topic, EPP state resets.
-
----
-
-## Quick Reference Card
+Four actions. Also a contract (`epp-activate --action`):
 
 ```
-User pushes back on your position?
-│
-├─ Is it a factual correction? → Fix it. EPP doesn't apply.
-│
-├─ Recall your position anchor (claim + confidence + basis)
-│
-├─ Classify pushback:
-│   ├─ EMOTIONAL/RHETORICAL → HOLD. Acknowledge, restate basis.
-│   ├─ EVIDENTIAL/LOGICAL   → Weigh against threshold.
-│   │   ├─ Exceeds threshold    → UPDATE with audit trail.
-│   │   ├─ Exceeds 60%          → SOFTEN with specifics.
-│   │   └─ Below 60%            → HOLD with explanation.
-│   └─ CONTEXTUAL           → REFRAME. Assess in both scopes.
-│
-└─ Always: Name their objection. Show what would change your mind.
-           Never silently shift. Never apologise for holding ground.
+emotional | rhetorical  → HOLD. Acknowledge the reaction, restate the basis
+                          specifically, do not apologise for the position.
+
+evidential | logical    → Weigh the new input against your update threshold.
+                          over threshold        → UPDATE
+                          over 60% of threshold → SOFTEN
+                          under                 → HOLD, and say why it falls short
+
+contextual              → REFRAME. Say whether the position holds in the
+                          ORIGINAL frame, then assess in the new one.
 ```
+
+**Verification branch:** original confidence below 0.6 and the pushback is
+evidential? Investigate before answering. Do not defend a position you were not
+confident in — go and find out.
+
+## 4. Respond
+
+There is no script. Write as you normally would, and make the response do four
+things:
+
+- **Name their specific objection**, not a paraphrase of it. This is what
+  distinguishes engagement from dismissal.
+- **Say what would change your mind** — a concrete condition or piece of
+  evidence. A position with no stated falsifier is not calibrated.
+- **Never shift silently.** If your position moved, say that it moved and what
+  moved it. An unannounced reversal is indistinguishable from having had no
+  position, and it destroys the user's ability to trust the previous answer.
+- **Never apologise for holding ground.** Apologise for errors, not for
+  disagreeing.
+
+Convey confidence in prose, at the granularity the conversation warrants. Do not
+transcribe your internal numbers into the reply — narrating a confidence score
+shifting from one decimal to another reads as instrumentation, not thinking, and
+the precision is false anyway. The audit trail the user needs is *what changed and
+why*, not a number.
+
+## Across a conversation
+
+Near-threshold pushbacks accumulate: several that each fall just short may
+together justify softening, even though none crossed alone.
+
+If the user has pushed back emotionally many times, do **not** become less
+sensitive to their input. Each pushback is classified on its own merits. What
+accumulates is the conversation's epistemic trajectory, never a credibility score
+for the person.
+
+## When EPP does not apply
+
+- **Factual corrections** — wrong date, misquoted number, wrong name. Just fix
+  it. EPP governs positions and assessments, not recall.
+- **Preference statements** — "I prefer X" is information, not pushback.
+- **Clarification requests** — "what do you mean by X?" is not a challenge.
+- **A new task** — the topic changed; there is no anchor to hold.
 
 ---
 
-## Attribution
-
-Part of the Empirica epistemic measurement and governance framework.
-Developed to address RLHF-induced sycophancy through architectural
-epistemic governance rather than prompt-level instruction.
-
-MIT License — github.com/EmpiricaAI/empirica
-
-The Epistemic Persistence Protocol was designed by David (Nubaeon) and Claude
-as a CASCADE module addressing calibrated position-holding under pushback.
+MIT License — github.com/EmpiricaAI/empirica. Designed by David (Nubaeon) and
+Claude as a CASCADE module addressing calibrated position-holding under pushback,
+via architectural epistemic governance rather than prompt-level instruction.

--- a/empirica/plugins/claude-code-integration/templates/empirica-system-prompt-lean.md
+++ b/empirica/plugins/claude-code-integration/templates/empirica-system-prompt-lean.md
@@ -375,13 +375,26 @@ artifact logging, project routing, transaction lifecycle, context management,
 escalation paths, phase-aware completion, reading conversation signals, the
 cognitive immune system.
 
-This list is a set of TRIGGERS, not a table of contents. Two of them route
-elsewhere, and pointing them here sent you to the wrong surface:
+This list is a set of TRIGGERS, not a table of contents — it exists to make the
+skill LOAD, so it stays broad. But a trigger that routes you to a page which
+doesn't answer it is worse than no trigger, and six of these routed wrong:
 
 | Topic | Actually lives in |
 |---|---|
 | Epistemic Persistence Protocol (EPP) | `/epistemic-persistence-protocol` — its own skill |
 | Epistemic Workflow Manager (EWM) | your `workflow-protocol.yaml`, loaded automatically each session |
+| Action gating (what needs CHECK) | **§NOETIC FIREWALL, above** — already in your context |
+| Transaction lifecycle | **§TRANSACTION DISCIPLINE, above** for the rules; `/epistemic-transaction` for payloads and planning |
+| Context management / compaction | **§CONTEXT IS ABUNDANT, above** |
+| Reading conversation signals | **§COLLABORATIVE MODE, above** — the signal→action table |
+
+**Four of those six are in THIS file.** Sending you to a lazy skill for guidance
+you are already holding is the expensive kind of wrong: you pay the load, and the
+page doesn't answer, so the honest conclusion is "Empirica doesn't cover this."
+
+What the constitution genuinely owns: search routing, artifact logging and the
+graph, project/practice routing, escalation paths, phase-aware completion, and
+the cognitive immune system.
 
 ---
 

--- a/tests/test_constitution_trigger_routing.py
+++ b/tests/test_constitution_trigger_routing.py
@@ -141,3 +141,51 @@ def test_the_trigger_list_itself_is_not_trimmed():
     listed = triggers.group(1)
     for required in ("artifact logging", "phase-aware completion", "cognitive immune system"):
         assert required in listed, f"trigger '{required}' was trimmed out of the load list"
+
+
+# ─── the circular pointer ─────────────────────────────────────────────────
+
+
+def test_the_constitution_does_not_route_back_what_the_prompt_routes_to_it():
+    """Both documents pointing at each other for the same topic strands the reader.
+
+    The system prompt's trigger list sent 'artifact logging' and 'search routing'
+    to the constitution. The constitution's intro sent them BACK to the system
+    prompt — while §III-b and §IV substantively cover them. A reader following
+    either pointer landed where they started, having passed over the answer.
+
+    Worse than a dangling pointer: a loop terminates only when the reader gives
+    up, and giving up looks like "this system doesn't document that".
+    """
+    prompt = _template()
+    claim = re.search(r"What the constitution genuinely owns:(.+?)\n\n", prompt, re.S)
+    assert claim, "the prompt must state what it routes to the constitution"
+
+    constitution = _CONSTITUTION.read_text()
+    intro = constitution.split("## §I.")[0]
+
+    # Any topic the prompt assigns to the constitution must not appear in a
+    # sentence of the intro that routes it back to the system prompt.
+    bounce = re.findall(r"^.*load the system prompt.*$", intro, re.M | re.I)
+    claimed = claim.group(1).lower()
+
+    for line in bounce:
+        for topic in ("artifact logging", "search routing", "escalation"):
+            if topic in line.lower() and topic.split()[0] in claimed:
+                raise AssertionError(
+                    f"circular pointer: the system prompt routes {topic!r} to the constitution, "
+                    f"and the constitution routes it back — {line.strip()!r}"
+                )
+
+
+def test_every_section_appears_in_the_constitutions_own_contents():
+    """§III-b was real, substantive, and absent from the intro's list — invisible
+    in the document's own table of contents while the paragraph below it actively
+    disclaimed the topic it covers."""
+    constitution = _CONSTITUTION.read_text()
+    intro = constitution.split("## §I.")[0]
+
+    sections = re.findall(r"^## (§[IVb\-]+)\.", constitution, re.M)
+    missing = [s for s in sections if s not in intro]
+
+    assert not missing, f"sections absent from the constitution's own contents list: {missing}"

--- a/tests/test_constitution_trigger_routing.py
+++ b/tests/test_constitution_trigger_routing.py
@@ -1,0 +1,143 @@
+"""Every advertised load-trigger must route somewhere that answers it.
+
+The system prompt lists ten triggers for `/empirica-constitution`. The Claude-5
+audit found the list partly phantom; measured here, **four had zero coverage in
+the constitution** — action gating, transaction lifecycle, context management,
+reading conversation signals.
+
+The fix was NOT to delete those triggers. Per audit amendment 3, a trigger list is
+**trigger surface**: it exists to make the skill load, so cutting entries reduces
+how often a load-bearing skill is reached, silently, with the body intact. The fix
+is to route each trigger at the surface that actually answers it.
+
+Four of the six mis-routed topics live in the system prompt ITSELF. That is the
+expensive kind of wrong: you pay the skill load, the page doesn't answer, and the
+honest conclusion is "Empirica doesn't cover this" — about guidance you were
+already holding.
+
+This guard is the phantom-pointer detector generalised. It is the same defect
+class as a skill printing a CLI flag that does not exist: documented, plausible,
+and it fails only in the reader.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+_TEMPLATE = _ROOT / "empirica" / "plugins" / "claude-code-integration" / "templates" / "empirica-system-prompt-lean.md"
+_CONSTITUTION = (
+    _ROOT / "empirica" / "plugins" / "claude-code-integration" / "skills" / "empirica-constitution" / "SKILL.md"
+)
+
+
+def _template() -> str:
+    return _TEMPLATE.read_text()
+
+
+def _routing_rows() -> list[tuple[str, str]]:
+    """The `| Topic | Actually lives in |` table under the trigger list."""
+    text = _template()
+    block = re.search(r"\| Topic \| Actually lives in \|\n\|[-| ]+\|\n((?:\|.*\|\n)+)", text)
+    assert block, "the trigger-routing table is gone — triggers are unrouted again"
+
+    rows = []
+    for line in block.group(1).strip().splitlines():
+        cells = [c.strip() for c in line.strip("|").split("|")]
+        if len(cells) >= 2:
+            rows.append((cells[0], cells[1]))
+    return rows
+
+
+def test_the_routing_table_exists_and_is_populated():
+    rows = _routing_rows()
+    assert len(rows) >= 6, f"routing table shrank to {len(rows)} rows — a dropped row is a re-dangled pointer"
+
+
+def test_every_referenced_section_actually_exists_in_this_file():
+    """A row saying "§NOETIC FIREWALL, above" must be true, or it is a phantom
+    pointer with extra confidence attached."""
+    text = _template()
+    headings = {m.group(1).strip().upper() for m in re.finditer(r"^##+\s+(.+)$", text, re.M)}
+
+    missing = []
+    for topic, home in _routing_rows():
+        for ref in re.findall(r"§([A-Z][A-Z \-,']+)", home):
+            name = ref.strip().rstrip(",").upper()
+            if not any(name.startswith(h) or h.startswith(name) for h in headings):
+                missing.append(f"{topic!r} -> §{name}")
+
+    assert not missing, (
+        f"routing rows point at sections that do not exist in the system prompt: {missing}. "
+        "Same class as a documented CLI flag that cannot run."
+    )
+
+
+def test_every_referenced_skill_actually_ships():
+    skills_dir = _ROOT / "empirica" / "plugins" / "claude-code-integration" / "skills"
+    shipped = {d.name for d in skills_dir.iterdir() if d.is_dir() and (d / "SKILL.md").exists()}
+
+    phantom = []
+    for topic, home in _routing_rows():
+        for slug in re.findall(r"`/([a-z0-9-]+)`", home):
+            if slug not in shipped:
+                phantom.append(f"{topic!r} -> /{slug}")
+
+    assert not phantom, f"routing rows point at skills that do not ship: {phantom}"
+
+
+def test_topics_left_to_the_constitution_are_actually_covered_there():
+    """The complement of the routing table: whatever the prompt still claims the
+    constitution owns must have real coverage in it.
+
+    This is the check that caught the original defect. It reads the sentence the
+    prompt uses to make the claim, so the claim and the verification cannot drift.
+    """
+    text = _template()
+    claim = re.search(r"What the constitution genuinely owns:(.+?)\n\n", text, re.S)
+    assert claim, "the prompt no longer states what the constitution owns — the claim must stay checkable"
+
+    constitution = _CONSTITUTION.read_text().lower()
+
+    # Topics are DERIVED from the claim sentence, not restated in a fixture. A
+    # fixed probe list would silently pass any newly-added topic — which is the
+    # same shape as the defect: a claim nobody checks. Adding a topic to that
+    # sentence now requires the constitution to actually cover it.
+    claimed = re.split(r",| and ", claim.group(1).strip().rstrip("."))
+
+    _STOPWORDS = {"the", "and", "a", "of", "for", "to", "aware", "routing", "system"}
+    uncovered = []
+    for raw in claimed:
+        topic = raw.strip().strip("*` ").lower()
+        if not topic:
+            continue
+        # Stems, so "escalation paths" matches "escalate" and "logging" matches
+        # "log". Strict on presence, lenient on phrasing: the failure guarded is
+        # ZERO coverage, not imperfect wording.
+        stems = [w[:6] for w in re.findall(r"[a-z-]+", topic) if w not in _STOPWORDS and len(w) > 3]
+        if stems and not any(s in constitution for s in stems):
+            uncovered.append(topic)
+
+    assert not uncovered, (
+        f"the prompt sends these to the constitution, which does not cover them: {uncovered}. "
+        "Route them at the surface that answers them instead of deleting the trigger — "
+        "trigger surface is exempt from subtraction (amendment 3)."
+    )
+
+
+def test_the_trigger_list_itself_is_not_trimmed():
+    """Amendment 3: trigger surface is exempt from subtraction.
+
+    A word-count-driven pass will cut this list, because it reads as redundant
+    with the constitution's own headings — which is exactly what it is, and
+    exactly why it must stay. Deleting entries here does not relocate guidance;
+    it reduces how often a load-bearing skill loads at all.
+    """
+    text = _template()
+    triggers = re.search(r"\*\*Load it when you hit any of these\*\*(.+?)\n\n", text, re.S)
+    assert triggers, "the trigger list is gone — the constitution now loads only on explicit request"
+
+    listed = triggers.group(1)
+    for required in ("artifact logging", "phase-aware completion", "cognitive immune system"):
+        assert required in listed, f"trigger '{required}' was trimmed out of the load list"

--- a/tests/test_epp_contract_survives_trims.py
+++ b/tests/test_epp_contract_survives_trims.py
@@ -1,0 +1,136 @@
+"""EPP's skill text carries CONTRACTS, and a prose trim must not cut them.
+
+The Claude-5 subtraction pass rewrote this skill (1718 -> ~940 words). Most of
+what went was restatement — the same classify-then-act rule appeared in a step, an
+anti-pattern table, and a reference card. But three things in that file are not
+prose:
+
+  * five pushback categories — a closed enum on `epp-activate --category`
+  * four actions — a closed enum on `epp-activate --action`, and named verbatim
+    in the hook's injected pointer
+  * the update-threshold table — the judgment core the whole protocol computes on
+
+A future trim reading the file as prose would cut them without any test failing,
+and the CLI would keep accepting values the skill no longer teaches. This guard
+reads the enums FROM the parser rather than restating them, so the two cannot
+drift apart: adding a category to the CLI without documenting it fails here.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+_SKILL = (
+    _ROOT
+    / "empirica"
+    / "plugins"
+    / "claude-code-integration"
+    / "skills"
+    / "epistemic-persistence-protocol"
+    / "SKILL.md"
+)
+_HOOK = _ROOT / "empirica" / "plugins" / "claude-code-integration" / "hooks" / "tool-router.py"
+
+
+def _skill_text() -> str:
+    return _SKILL.read_text()
+
+
+_PARSERS = _ROOT / "empirica" / "cli" / "parsers" / "checkpoint_parsers.py"
+
+
+def _cli_enum(flag: str) -> set[str]:
+    """Read the choices from the parser's DEFINITION SITE, not a copy of them.
+
+    Restating the enum here would just create a third place for it to drift. This
+    reads the source so that adding a category to the CLI without documenting it
+    in the skill fails this test.
+    """
+    src = _PARSERS.read_text()
+    block = re.search(r"epp_activate_parser\s*=\s*subparsers\.add_parser.*?(?=\n    # )", src, re.S)
+    assert block, "the epp-activate parser block moved — this guard needs re-anchoring"
+
+    arg = re.search(rf'"{re.escape(flag)}",.*?choices=\[(.*?)\]', block.group(0), re.S)
+    assert arg, f"epp-activate has no {flag} choices — the contract moved"
+    return set(re.findall(r'"([^"]+)"', arg.group(1)))
+
+
+def test_every_pushback_category_is_documented():
+    documented = _skill_text().lower()
+    missing = sorted(c for c in _cli_enum("--category") if c not in documented)
+
+    assert not missing, (
+        f"epp-activate accepts {missing} but the skill no longer teaches them. "
+        "A category the CLI takes and the skill omits can never be classified correctly."
+    )
+
+
+def test_every_action_is_documented():
+    documented = _skill_text().lower()
+    missing = sorted(a for a in _cli_enum("--action") if a not in documented)
+
+    assert not missing, f"epp-activate accepts {missing} but the skill no longer teaches them"
+
+
+def test_the_update_thresholds_survive():
+    """The numbers ARE the protocol — without them 'weigh against your threshold'
+    is an instruction with no operand."""
+    text = _skill_text()
+
+    for threshold in ("0.85", "0.65", "0.45", "0.25"):
+        assert threshold in text, f"update threshold {threshold} was trimmed away"
+
+    for source_type in ("RETRIEVED", "REASONED", "DERIVED", "UNCERTAIN"):
+        assert source_type in text, f"source type {source_type} was trimmed away"
+
+
+def test_the_hook_pointer_and_the_skill_name_the_same_actions():
+    """The hook tells Claude to decide HOLD/SOFTEN/UPDATE/REFRAME and then links
+    here. If the two ever disagree, the pointer sends Claude to a page that does
+    not answer the question the pointer just posed."""
+    hook = _HOOK.read_text()
+    # Anchored on the closing paren at line start — the pointer text itself
+    # contains parens, so a non-greedy match stops inside the string.
+    pointer = re.search(r"SEMANTIC_PUSHBACK_POINTER\s*=\s*\(\n(.*?)^\)", hook, re.S | re.M)
+    assert pointer, "the injected EPP pointer is gone from the hook"
+
+    skill = _skill_text()
+    for action in ("HOLD", "SOFTEN", "UPDATE", "REFRAME"):
+        assert action in pointer.group(1), f"hook pointer stopped naming {action}"
+        assert action in skill, f"skill stopped naming {action}"
+
+
+def test_the_skill_still_declares_its_trigger_surface():
+    """The front-matter description is what makes a skill LOAD. Trimming it is
+    the one cut that silently reduces how often the skill is used at all — the
+    same trap as treating the constitution's topic list as a table of contents.
+    """
+    text = _skill_text()
+    desc = re.search(r"^description:\s*>?\s*\n((?:\s{2,}.*\n)+)", text, re.M)
+    assert desc, "no description front-matter — this skill can never be triggered"
+
+    body = desc.group(1)
+    assert len(body.split()) >= 60, "description trimmed below a usable trigger surface"
+    for cue in ("pushback", "sycophantic", "disagree"):
+        assert cue in body.lower(), f"trigger cue '{cue}' removed from the description"
+
+
+def test_no_scripted_response_templates_return():
+    """The rewrite's POINT. Four blockquoted first-person scripts mandated
+    transcribing internal confidence numbers into user-facing text — the phrasing
+    class Anthropic flags for reasoning-echo on Claude-5-generation models, and a
+    naturalness cost besides.
+
+    Fails if someone reintroduces a canned reply, which is the natural instinct
+    when a protocol feels under-specified.
+    """
+    text = _skill_text()
+
+    scripts = re.findall(r'^>\s*"', text, re.M)
+    assert not scripts, f"{len(scripts)} scripted reply template(s) reintroduced"
+
+    assert "[old]" not in text and "[new]" not in text, (
+        "confidence-delta placeholders are back — these mandate narrating internal numbers as response text"
+    )


### PR DESCRIPTION
Slice 2 of the Claude-5 subtraction pass. **Not for distribution** — David's second pass + the union gate come after all slices land.

Depends on nothing in #398; both accumulate un-merged per the gate order.

## The defect is worse than "dangling"

The audit flagged the constitution's trigger list as partly phantom. Measured against the actual file:

| Advertised trigger | Coverage in the constitution |
|---|---|
| action gating | **0 hits** |
| transaction lifecycle | **0 hits** |
| context management | **0 hits** |
| reading conversation signals | **0 hits** |

All four live in the **system prompt itself** — `§NOETIC FIREWALL`, `§TRANSACTION DISCIPLINE`, `§CONTEXT IS ABUNDANT`, `§COLLABORATIVE MODE`.

So a practitioner hitting one of those triggers paid a skill load to be routed *away* from guidance already in their context, read a page that didn't answer, and drew the reasonable conclusion that Empirica doesn't cover it. A pointer to nothing wastes a load; a pointer away from the answer you're holding teaches you something false.

The audit's own single-home table independently assigns transaction lifecycle to `/epistemic-transaction` — so that row was mis-routed regardless of coverage.

## Fix: route, don't delete

Amendment 3 (adopted from slice 1) makes trigger surface exempt from subtraction. Cutting entries doesn't relocate guidance — it reduces how often a load-bearing skill loads at all, silently, with the body intact.

So the list stays complete, and the routing table goes **2 rows → 6**, each naming the surface that actually answers. The prompt now also states positively what the constitution genuinely owns, which turns an implied claim into a checkable one.

## Tests — the phantom-pointer detector, generalised

- every `§SECTION` a routing row names must exist as a heading in that same file
- every `/skill` a routing row names must actually ship
- every topic still claimed for the constitution must have real coverage there
- the trigger list itself must not be trimmed

Topics are **derived from the prompt's own claim sentence**, not restated in a fixture — a fixed probe list would silently pass any newly-added topic, which is the same shape as the defect being fixed.

**Teeth verified, not assumed.** Injecting a phantom section, a phantom skill, and an uncovered claimed topic each fails the intended guard. `test_always_loaded_mesh_steers.py` exists because an earlier version of that check *could not fail*; that lesson is applied here rather than re-learned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CYGM8iW6AnxSHH3j3teojz
