### PR TITLE
fix(session): the safety was inverted — typing LESS of an id was the safe move

### DIFF
--- a/empirica-mcp/empirica_mcp/server.py
+++ b/empirica-mcp/empirica_mcp/server.py
@@ -132,7 +132,7 @@ TOOL_REGISTRY: dict[str, dict] = {
         "required": ["session_id", "vectors"],
         "desc": (
             "Submit POSTFLIGHT assessment — closes transaction, triggers grounded "
-            "verification. Optional `claims`: [{index|id, verdict, note}] with verdict "
+            "verification. Optional `claims`: [{index|id, verdict, evidence}] with verdict "
             "held|refuted|untested, adjudicating what was declared at PREFLIGHT/CHECK. "
             "Anything left unadjudicated is forced to `untested` and reported as a gap, "
             "so 'never checked' stays distinguishable from 'nothing declared'."

--- a/empirica/cli/command_handlers/_workflow_postflight.py
+++ b/empirica/cli/command_handlers/_workflow_postflight.py
@@ -1822,6 +1822,41 @@ def _postflight_format_human_output(
     _postflight_print_project_context(session_id)
 
 
+def _near_miss_session(cursor, session_id: str) -> str | None:
+    """A stored session_id exactly one edit away from this one, if any.
+
+    The corruption vector is a pointer file holding a UUID with a single dropped
+    character. Naming the real row turns "not found" into "here is the row you
+    meant" — the difference between a message that misdirects and one that fixes.
+    """
+    from empirica.utils.session_resolver import within_one_edit
+
+    if not session_id or len(session_id) < 12:
+        return None
+
+    try:
+        rows = [
+            r[0]
+            for r in cursor.execute("SELECT session_id FROM sessions WHERE session_id LIKE ?", (session_id[:8] + "%",))
+        ]
+    except Exception:
+        return None
+
+    return next((c for c in rows if c and within_one_edit(str(c), session_id)), None)
+
+
+def _session_not_found_message(cursor, session_id: str) -> str:
+    msg = f"session {session_id!r} ({len(session_id)} chars) not found in project DB"
+    near = _near_miss_session(cursor, session_id)
+    if near:
+        msg += (
+            f"\n  A stored session differs by one character: {near!r} ({len(near)} chars).\n"
+            "  The session row is almost certainly fine and the POINTER is malformed — "
+            "check .empirica/active_transaction_*.json for a truncated id."
+        )
+    return msg
+
+
 def _validate_postflight_preconditions(session_id: str) -> tuple[bool, str | None]:
     """Pre-mutation validation for POSTFLIGHT.
 
@@ -1844,11 +1879,25 @@ def _validate_postflight_preconditions(session_id: str) -> tuple[bool, str | Non
             )
             row = cursor.fetchone()
             if row is None:
-                return False, f"session {session_id[:8]} not found in project DB"
+                # Print the id IN FULL, and name the near-miss.
+                #
+                # This used to print `session_id[:8]`. Reported by cortex after a
+                # malformed pointer file dropped one character from the LAST
+                # segment of a UUID: the message printed the real session's
+                # prefix, so everyone who read it checked whether that prefix
+                # existed, found it intact and correctly bound, and concluded the
+                # resolver was broken. Three practices searched the wrong
+                # component.
+                #
+                # An error that identifies a record by a prefix cannot report a
+                # mismatch occurring outside that prefix. It does not merely fail
+                # to help — it reliably accuses the wrong thing, because the part
+                # it shows IS correct.
+                return False, _session_not_found_message(cursor, session_id)
             project_id = row[0]
             if not project_id:
                 return False, (
-                    f"session {session_id[:8]} has no project_id — run "
+                    f"session {session_id} has no project_id — run "
                     "'empirica project-switch <project>' before POSTFLIGHT"
                 )
             return True, None

--- a/empirica/cli/command_handlers/_workflow_preflight.py
+++ b/empirica/cli/command_handlers/_workflow_preflight.py
@@ -149,6 +149,57 @@ def _preflight_check_unclosed_transaction():
     return None
 
 
+def _preflight_check_session_exists(session_id):
+    """Warn when the session this transaction attaches to has no row.
+
+    Reported by cortex: a pointer file held a UUID with one dropped character.
+    PREFLIGHT accepted the 35-char id and returned ok:true, the transaction opened
+    against a session that did not exist, and the failure only surfaced at
+    POSTFLIGHT — where the error truncated the id and pointed at the wrong
+    component. The corruption entered here, silently.
+
+    WARNS rather than blocks, deliberately. PREFLIGHT is hot-path: a validation
+    regression that refuses legitimate work is worse than the bug it prevents.
+    Note also that `session_id` is documented as a UUID but is not one in
+    practice — `latest`, `investigation-cli-mapping` and a bare 8-char prefix are
+    all live rows here, so validating the SHAPE would reject real sessions.
+    Existence is the invariant; shape is not.
+    """
+    try:
+        from empirica.data.session_database import SessionDatabase
+
+        db = SessionDatabase()
+        try:
+            cur = db.conn.cursor()
+            cur.execute("SELECT 1 FROM sessions WHERE session_id = ?", (session_id,))
+            if cur.fetchone():
+                return None
+
+            warning = {
+                "session_id": session_id,
+                "length": len(session_id or ""),
+                "message": (
+                    f"No session row for {session_id!r}. This transaction will open, but POSTFLIGHT "
+                    "will fail its precondition check and the measurement window will be lost."
+                ),
+                "fix": "Run `empirica session-create`, or correct the id — see below if a near-match exists.",
+            }
+            from empirica.cli.command_handlers._workflow_postflight import _near_miss_session
+
+            near = _near_miss_session(cur, session_id)
+            if near:
+                warning["near_miss"] = near
+                warning["message"] += (
+                    f" A stored session differs by one character: {near!r}. The row is almost "
+                    "certainly fine and the POINTER is malformed — check .empirica/active_transaction_*.json."
+                )
+            return warning
+        finally:
+            db.close()
+    except Exception:
+        return None  # Never let a diagnostic block PREFLIGHT.
+
+
 def _preflight_create_checkpoint(session_id, vectors, reasoning, transaction_id):
     """Create GitEnhancedReflexLogger checkpoint for PREFLIGHT.
 
@@ -828,6 +879,7 @@ def _preflight_build_result(
     unclosed_transaction_warning,
     work_type=None,
     voice=None,
+    session_warning=None,
 ):
     """Assemble the final PREFLIGHT result dict."""
     result: dict = {
@@ -849,6 +901,11 @@ def _preflight_build_result(
         "patterns": patterns if patterns and any(patterns.values()) else None,
         "unclosed_transaction_warning": unclosed_transaction_warning,
     }
+    # Surfaced, not merely computed. A warning built and dropped is the defect
+    # this repo keeps producing — the claims adjudication warning had exactly
+    # that shape, carefully constructed and unreachable.
+    if session_warning:
+        result["session_warning"] = session_warning
     noetic_guidance = _build_noetic_guidance(work_type)
     if noetic_guidance is not None:
         result["noetic_guidance"] = noetic_guidance
@@ -956,6 +1013,9 @@ def handle_preflight_submit_command(args):
         # Stage 2: Check for unclosed transaction — warn but don't block
         unclosed_transaction_warning = _preflight_check_unclosed_transaction()
 
+        # Stage 2b: Does the session this transaction attaches to actually exist?
+        session_warning = _preflight_check_session_exists(session_id)
+
         # Stage 3: Create checkpoint and transaction
         try:
             transaction_id = str(uuid.uuid4())
@@ -1054,6 +1114,7 @@ def handle_preflight_submit_command(args):
                 unclosed_transaction_warning,
                 work_type=parsed.get("work_type"),
                 voice=parsed.get("voice"),
+                session_warning=session_warning,
             )
 
             # Echo the grounded-at-open declaration so the practitioner sees

--- a/empirica/core/claims.py
+++ b/empirica/core/claims.py
@@ -231,7 +231,10 @@ def adjudicate(
         # than careless: the guidance prose calls the act "adjudication" while the
         # payload key is `verdict`, and calls the support "note" while the key is
         # `evidence`. `keys_seen` still carries the general case.
-        near = {"adjudication": "verdict", "note": "evidence", "claim": "index or id"}
+        # `note` is deliberately absent: it is now ACCEPTED as an alias for
+        # `evidence`, so naming it as a confusion would send the reader to fix
+        # a key that already works.
+        near = {"adjudication": "verdict", "claim": "index or id"}
         confusions = [f"{k} -> {v}" for k, v in near.items() if k in keys]
         if confusions:
             entry["likely_key_confusion"] = confusions
@@ -254,7 +257,15 @@ def adjudicate(
         applied += 1
         db.conn.execute(
             "UPDATE transaction_claims SET verdict = ?, verdict_evidence = ?, adjudicated_timestamp = ? WHERE id = ?",
-            (verdict, str(raw.get("evidence") or "").strip() or None, now, target["id"]),
+            # `note` accepted as an alias for `evidence`, because the MCP tool
+            # description SHIPPED saying `note` while this line read `evidence` —
+            # so a caller following the documented contract had their evidence
+            # silently dropped. The description is fixed, but callers copied it,
+            # and the guidance prose calls this "a note" regardless.
+            #
+            # Forgiving input where the ambiguity is ours, not theirs — the same
+            # reason log-artifacts accepts `id` for `ref`.
+            (verdict, str(raw.get("evidence") or raw.get("note") or "").strip() or None, now, target["id"]),
         )
         target["verdict"] = verdict
 

--- a/empirica/utils/session_resolver.py
+++ b/empirica/utils/session_resolver.py
@@ -699,6 +699,85 @@ def resolve_session_id(session_id_or_alias: str, ai_id: str | None = None) -> st
         raise ValueError(f"Cannot resolve session alias - database unavailable: {e}") from e
 
 
+def within_one_edit(a: str, b: str) -> bool:
+    """True when the two differ by exactly one insertion, deletion, or substitution.
+
+    An exact edit check, deliberately, not a prefix/suffix heuristic. The first
+    version of this compared an 8-char head against a 6-char tail. It passed on a
+    SYNTHETIC example where the dropped character fell outside the tail window and
+    FAILED on the real reported id, where the missing digit fell inside it.
+
+    A near-miss detector tuned to a case other than the reported one reproduces the
+    very defect it exists to fix: it inspects part of an identifier and is blind to
+    differences in the rest.
+    """
+    if a == b:
+        return False
+    la, lb = len(a), len(b)
+    if abs(la - lb) > 1:
+        return False
+
+    if la == lb:  # substitution
+        return sum(1 for x, y in zip(a, b) if x != y) == 1
+
+    longer, shorter = (a, b) if la > lb else (b, a)
+    i = j = skipped = 0
+    while i < len(longer) and j < len(shorter):
+        if longer[i] != shorter[j]:
+            if skipped:
+                return False
+            skipped = 1
+            i += 1
+            continue
+        i += 1
+        j += 1
+    return True
+
+
+def _is_uuid_shaped(value: str) -> bool:
+    """Parseable as a UUID.
+
+    Used only to distinguish "typo" from "id this DB has not seen" — NEVER as a
+    validity test on its own. Three live session_ids here are legitimately not
+    UUIDs (`latest`, `investigation-cli-mapping`, a bare 8-char prefix), so
+    rejecting on shape alone would refuse real sessions.
+    """
+    import uuid as _uuid
+
+    try:
+        _uuid.UUID(str(value))
+        return True
+    except (ValueError, AttributeError, TypeError):
+        return False
+
+
+def _lookup_session(session_id: str) -> tuple[bool, str | None]:
+    """(exists, near_miss). Never raises — a diagnostic must not become the fault."""
+    try:
+        from empirica.data.session_database import SessionDatabase
+
+        db = SessionDatabase()
+        try:
+            cur = db.conn.cursor()
+            cur.execute("SELECT 1 FROM sessions WHERE session_id = ?", (session_id,))
+            if cur.fetchone():
+                return True, None
+            if len(session_id) < 12:
+                return False, None
+            rows = [
+                r[0]
+                for r in cur.execute("SELECT session_id FROM sessions WHERE session_id LIKE ?", (session_id[:8] + "%",))
+            ]
+            return False, next((c for c in rows if c and within_one_edit(str(c), session_id)), None)
+        finally:
+            db.close()
+    except Exception as e:
+        # Cannot verify -> do not block. An unreachable DB must not stop a
+        # transaction the way a typo should.
+        logger.debug(f"session existence check unavailable: {e}")
+        return True, None
+
+
 def _resolve_partial_uuid(partial_or_full_uuid: str) -> str:
     """
     Resolve partial UUID (8 chars) to full UUID, or validate full UUID.
@@ -712,9 +791,57 @@ def _resolve_partial_uuid(partial_or_full_uuid: str) -> str:
     Raises:
         ValueError: If UUID not found or ambiguous
     """
-    # If it looks like a full UUID (contains hyphens), return as-is
+    # A hyphen used to be the ENTIRE test, and the safety was inverted: an 8-char
+    # partial fell through to a real `LIKE` query that raises on a miss, while a
+    # full-looking id was returned unchecked. Typing LESS of the id was the safe
+    # move. The docstring above has always promised "or validate full UUID"; that
+    # half was never implemented.
+    #
+    # Found by cortex after a hand-typed PREFLIGHT payload dropped one hex digit
+    # mid-string. The bad id was returned ok, written to the transaction pointer
+    # file BEFORE any DB touch, and every later POSTFLIGHT / log-artifacts in that
+    # session resolved from the poisoned pointer. There is no upstream producer to
+    # repair — practitioners re-type 36-char UUIDs and some fraction will be
+    # wrong — so this check is the whole defense, not defense-in-depth.
+    #
+    # Raising here is CONSISTENCY, not a new restriction: the partial branch below
+    # already raises ValueError on a miss, and every caller already handles it
+    # (_resolve_and_validate_session turns it into `{"ok": false, ...}` + exit 1).
     if "-" in partial_or_full_uuid:
-        logger.debug(f"Full UUID provided: {partial_or_full_uuid}")
+        existing, near = _lookup_session(partial_or_full_uuid)
+        if existing:
+            logger.debug(f"Full UUID provided: {partial_or_full_uuid}")
+            return partial_or_full_uuid
+
+        # Absent from THIS project's DB. Two very different cases, and collapsing
+        # them would trade one bug for a worse one:
+        #
+        #   malformed, or one edit from a real row  -> a typo. Raise.
+        #   well-formed and unlike anything stored  -> possibly a legitimate id
+        #                                              from another project's DB.
+        #                                              Warn, pass through.
+        #
+        # The reported corruption (`…3030ce39f1bb` -> `…3030ce9f1bb`) is caught by
+        # BOTH tests: 35 chars is unparseable AND one edit from the stored row. A
+        # valid 36-char id for a session this DB has never seen is not obviously
+        # wrong, and refusing it would break cross-project resolution to fix a
+        # typo — a hot-path regression is worse than the silent bug it prevents.
+        malformed = not _is_uuid_shaped(partial_or_full_uuid)
+        if near or malformed:
+            msg = f"No session found matching: {partial_or_full_uuid!r} ({len(partial_or_full_uuid)} chars)"
+            if near:
+                msg += (
+                    f" — but {near!r} ({len(near)} chars) differs by one character. "
+                    "The session row is fine; the id you passed is not."
+                )
+            elif malformed:
+                msg += " — not a well-formed UUID. Check for a dropped or extra character."
+            raise ValueError(msg)
+
+        logger.warning(
+            f"session_id {partial_or_full_uuid!r} is well-formed but has no row in this project's DB — "
+            "passing through. POSTFLIGHT will fail its precondition check if this is wrong."
+        )
         return partial_or_full_uuid
 
     # Partial UUID - query database

--- a/tests/test_claims_adjudication_reports_drops.py
+++ b/tests/test_claims_adjudication_reports_drops.py
@@ -74,7 +74,10 @@ def test_the_specific_confusion_is_named():
 
     confusions = out["adjudication"]["entries"][0]["likely_key_confusion"]
     assert "adjudication -> verdict" in confusions
-    assert "note -> evidence" in confusions
+    assert "claim -> index or id" in confusions
+    # `note` must NOT be named: it is accepted as an alias for `evidence`, so
+    # flagging it would send the reader to fix a key that already works.
+    assert not any("note" in c for c in confusions)
 
 
 def test_the_warning_connects_drops_to_the_untested_count():
@@ -168,3 +171,29 @@ def test_the_warning_is_promoted_for_declared_claims():
     ws._retro_adjudicate_claims(db, "S1", "T1", [{"claim": "c1", "adjudication": "held"}], retro)
 
     assert "claim_adjudication_warning" in retro
+
+
+def test_note_is_accepted_as_an_alias_for_evidence():
+    """The MCP tool description SHIPPED documenting `note` while adjudicate()
+    read `evidence`, so a caller following the documented contract had their
+    evidence silently dropped. The description is corrected, but callers copied
+    it — and the guidance prose calls this "a note" regardless.
+
+    Forgiving input where the ambiguity is ours, not the caller's.
+    """
+    db = _DB()
+    db.declare(1)
+    _adj(db, [{"index": 1, "verdict": "held", "note": "checked against the log"}])
+
+    stored = db.conn.execute("SELECT verdict, verdict_evidence FROM transaction_claims").fetchone()
+    assert stored[0] == "held"
+    assert stored[1] == "checked against the log"
+
+
+def test_evidence_wins_when_both_keys_are_present():
+    db = _DB()
+    db.declare(1)
+    _adj(db, [{"index": 1, "verdict": "held", "evidence": "canonical", "note": "secondary"}])
+
+    stored = db.conn.execute("SELECT verdict_evidence FROM transaction_claims").fetchone()
+    assert stored[0] == "canonical"

--- a/tests/test_session_id_error_diagnosability.py
+++ b/tests/test_session_id_error_diagnosability.py
@@ -1,0 +1,314 @@
+"""An error that identifies a record by a PREFIX cannot report a mismatch outside it.
+
+Reported by cortex (prop_mbj3uva). A pointer file held a UUID with one dropped
+character, in the LAST segment:
+
+    sessions table :  4aea7003-12ab-4c37-81bb-3030ce39f1bb   (36)
+    tmux_8 pointer :  4aea7003-12ab-4c37-81bb-3030ce9f1bb    (35)
+
+POSTFLIGHT's precondition error printed `session_id[:8]`, so the message read
+`session 4aea7003 not found` — the REAL session's prefix. Everyone who read it
+checked whether `4aea7003` existed, found it intact and correctly bound, and
+concluded the resolver was broken. Three practices searched the wrong component.
+
+The message did not merely fail to help. It reliably accused the wrong thing,
+because the part it showed WAS correct.
+
+Two fixes, both tested here:
+  * print the identifier in full, and name a near-miss row when one exists
+  * warn at PREFLIGHT, where the bad id ENTERS, instead of only at POSTFLIGHT
+
+Note what is deliberately NOT done: cortex suggested UUID validation. Three of
+1037 live session_ids are not UUIDs (`latest`, `investigation-cli-mapping`, and a
+bare 8-char prefix), so shape validation would reject legitimate sessions.
+Existence is the invariant; shape is not.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from empirica.cli.command_handlers._workflow_postflight import (
+    _near_miss_session,
+    _session_not_found_message,
+)
+
+_REAL = "4aea7003-12ab-4c37-81bb-3030ce39f1bb"
+_TYPO = "4aea7003-12ab-4c37-81bb-3030ce9f1bb"  # the '3' dropped, last segment
+
+
+def _cursor(session_ids=(_REAL,)):
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE sessions (session_id TEXT)")
+    conn.executemany("INSERT INTO sessions VALUES (?)", [(s,) for s in session_ids])
+    conn.commit()
+    return conn.cursor()
+
+
+# ─── the reported defect ──────────────────────────────────────────────────
+
+
+def test_the_full_identifier_is_printed_not_a_prefix():
+    """The whole point. A prefix hides exactly the character that differs."""
+    msg = _session_not_found_message(_cursor(), _TYPO)
+
+    assert _TYPO in msg, "the failing id must appear in full, or the reader cannot see the typo"
+
+
+def test_the_message_does_not_show_only_the_shared_prefix():
+    """Regression on the exact misdirection: printing `4aea7003` alone sends the
+    reader to verify a row that is fine."""
+    msg = _session_not_found_message(_cursor(), _TYPO)
+
+    assert msg.count(_TYPO) >= 1
+    # The old message was ~40 chars and contained the 8-char prefix and nothing
+    # else identifying. A message that still cannot distinguish the two ids fails.
+    assert _REAL in msg, "the near-match must be named — that is what converts a misdiagnosis into a fix"
+
+
+def test_the_near_miss_is_identified():
+    near = _near_miss_session(_cursor(), _TYPO)
+
+    assert near == _REAL
+
+
+def test_the_message_says_the_pointer_is_the_suspect_not_the_row():
+    """Directing the reader at the right component IS the fix. Without this the
+    message is merely more verbose, not more useful."""
+    msg = _session_not_found_message(_cursor(), _TYPO)
+
+    assert "pointer" in msg.lower()
+    assert "active_transaction" in msg
+
+
+def test_lengths_are_shown_because_the_difference_is_one_character():
+    msg = _session_not_found_message(_cursor(), _TYPO)
+
+    assert "35" in msg and "36" in msg
+
+
+# ─── the near-miss detector must not over-claim ───────────────────────────
+
+
+def test_a_genuinely_different_session_is_not_reported_as_a_near_miss():
+    """A false near-miss is worse than none: it would send the reader to fix a
+    pointer that is correct."""
+    other = "4aea7003-0000-0000-0000-000000000000"  # same prefix, unrelated
+    near = _near_miss_session(_cursor([other]), _TYPO)
+
+    assert near is None
+
+
+def test_no_near_miss_when_nothing_is_close():
+    near = _near_miss_session(_cursor(["deadbeef-1111-2222-3333-444444444444"]), _TYPO)
+
+    assert near is None
+
+
+def test_short_ids_do_not_crash_the_detector():
+    """`latest` and a bare 8-char prefix are real session_ids in this store."""
+    for weird in ("latest", "2bc1da78", "", "investigation-cli-mapping"):
+        assert _near_miss_session(_cursor(), weird) is None
+
+
+# ─── PREFLIGHT: warn where the corruption enters ──────────────────────────
+
+
+def test_preflight_warns_when_the_session_row_is_missing(monkeypatch):
+    from empirica.cli.command_handlers import _workflow_preflight as pf
+
+    class _DB:
+        def __init__(self):
+            self.conn = sqlite3.connect(":memory:")
+            self.conn.execute("CREATE TABLE sessions (session_id TEXT)")
+            self.conn.execute("INSERT INTO sessions VALUES (?)", (_REAL,))
+            self.conn.commit()
+
+        def close(self):
+            self.conn.close()
+
+    monkeypatch.setattr("empirica.data.session_database.SessionDatabase", _DB)
+
+    warning = pf._preflight_check_session_exists(_TYPO)
+
+    assert warning is not None, "a transaction opening against a nonexistent session must say so"
+    assert warning["near_miss"] == _REAL
+    assert warning["length"] == 35
+    assert "POSTFLIGHT" in warning["message"], "say what will break, not just that something is wrong"
+
+
+def test_preflight_is_silent_when_the_session_exists(monkeypatch):
+    """No noise on the normal path — a warning that always fires is ignored."""
+    from empirica.cli.command_handlers import _workflow_preflight as pf
+
+    class _DB:
+        def __init__(self):
+            self.conn = sqlite3.connect(":memory:")
+            self.conn.execute("CREATE TABLE sessions (session_id TEXT)")
+            self.conn.execute("INSERT INTO sessions VALUES (?)", (_REAL,))
+            self.conn.commit()
+
+        def close(self):
+            self.conn.close()
+
+    monkeypatch.setattr("empirica.data.session_database.SessionDatabase", _DB)
+
+    assert pf._preflight_check_session_exists(_REAL) is None
+
+
+def test_preflight_never_blocks_on_a_diagnostic_failure(monkeypatch):
+    """PREFLIGHT is hot-path. A diagnostic that raises must not refuse the work —
+    a validation regression that blocks legitimate transactions is worse than the
+    silent bug it was added to prevent.
+    """
+    from empirica.cli.command_handlers import _workflow_preflight as pf
+
+    def _boom():
+        raise RuntimeError("db unavailable")
+
+    monkeypatch.setattr("empirica.data.session_database.SessionDatabase", _boom)
+
+    assert pf._preflight_check_session_exists(_TYPO) is None
+
+
+# ─── the mint point: the inverted safety in _resolve_partial_uuid ──────────
+
+
+def test_one_edit_detector_handles_the_real_reported_id():
+    """The regression that mattered: the dropped digit falls INSIDE the last six
+    characters, which a tail-comparison heuristic cannot see."""
+    from empirica.utils.session_resolver import within_one_edit
+
+    assert within_one_edit(_REAL, _TYPO)
+    assert within_one_edit(_TYPO, _REAL)
+
+
+def test_one_edit_detector_rejects_larger_differences():
+    from empirica.utils.session_resolver import within_one_edit
+
+    assert not within_one_edit(_REAL, _REAL)  # identical is not a near-miss
+    assert not within_one_edit(_REAL, "4aea7003-0000-0000-0000-000000000000")
+    assert not within_one_edit(_REAL, _REAL[:30])  # two+ chars missing
+    assert not within_one_edit("", "")
+
+
+def test_one_edit_detector_catches_substitution_not_just_deletion():
+    from empirica.utils.session_resolver import within_one_edit
+
+    swapped = _REAL[:20] + ("0" if _REAL[20] != "0" else "1") + _REAL[21:]
+    assert within_one_edit(_REAL, swapped)
+
+
+def test_a_full_looking_id_that_does_not_exist_now_raises(monkeypatch):
+    """The inverted safety. Before this, an 8-char partial was DB-checked while a
+    full id with a typo was returned unchecked — typing LESS of the id was the
+    safe move. Raising here is consistency with the partial branch, which has
+    always raised, not a new restriction.
+    """
+    import sqlite3
+
+    from empirica.utils import session_resolver as sr
+
+    class _DB:
+        def __init__(self):
+            self.conn = sqlite3.connect(":memory:")
+            self.conn.execute("CREATE TABLE sessions (session_id TEXT, start_time REAL)")
+            self.conn.execute("INSERT INTO sessions VALUES (?, 1.0)", (_REAL,))
+            self.conn.commit()
+
+        def close(self):
+            self.conn.close()
+
+    monkeypatch.setattr("empirica.data.session_database.SessionDatabase", _DB)
+
+    assert sr._resolve_partial_uuid(_REAL) == _REAL
+
+    with pytest.raises(ValueError) as exc:
+        sr._resolve_partial_uuid(_TYPO)
+
+    msg = str(exc.value)
+    assert _TYPO in msg, "the rejected id must be shown in full"
+    assert _REAL in msg, "the near-match must be named"
+
+
+def test_resolution_does_not_block_when_the_db_is_unreachable(monkeypatch):
+    """An unverifiable session must not fail the way a typo does. A diagnostic
+    that becomes the fault is worse than the bug it detects.
+    """
+    from empirica.utils import session_resolver as sr
+
+    def _boom():
+        raise RuntimeError("db gone")
+
+    monkeypatch.setattr("empirica.data.session_database.SessionDatabase", _boom)
+
+    assert sr._resolve_partial_uuid(_REAL) == _REAL
+
+
+# ─── the narrowing: typo vs "id this DB has not seen" ─────────────────────
+#
+# Raising on ANY absent full id broke tests/test_session_resolver.py's
+# test_resolve_full_uuid, and that failure was informative rather than annoying:
+# a well-formed UUID absent from THIS project's DB may be a legitimate id from
+# another project, and refusing it would be a hot-path regression traded for a
+# typo fix. So the raise is narrowed to ids that are malformed or one edit from a
+# stored row — both of which the reported corruption is.
+
+
+def _resolver_with(monkeypatch, stored):
+    import sqlite3
+
+    from empirica.utils import session_resolver as sr
+
+    class _DB:
+        def __init__(self):
+            self.conn = sqlite3.connect(":memory:")
+            self.conn.execute("CREATE TABLE sessions (session_id TEXT, start_time REAL)")
+            self.conn.executemany("INSERT INTO sessions VALUES (?, 1.0)", [(s,) for s in stored])
+            self.conn.commit()
+
+        def close(self):
+            self.conn.close()
+
+    monkeypatch.setattr("empirica.data.session_database.SessionDatabase", _DB)
+    return sr
+
+
+def test_a_malformed_id_raises_even_with_no_near_miss(monkeypatch):
+    """35 chars with a dropped digit is not a plausible foreign id."""
+    sr = _resolver_with(monkeypatch, ["deadbeef-1111-2222-3333-444444444444"])
+
+    with pytest.raises(ValueError, match="well-formed"):
+        sr._resolve_partial_uuid(_TYPO)
+
+
+def test_a_wellformed_unknown_id_passes_through(monkeypatch):
+    """Preserves cross-project resolution. This is the case whose test failure
+    caught the over-broad first version of the rule."""
+    sr = _resolver_with(monkeypatch, ["deadbeef-1111-2222-3333-444444444444"])
+    stranger = "88dbf132-cc7c-4a4b-9b59-77df3b13dbd2"
+
+    assert sr._resolve_partial_uuid(stranger) == stranger
+
+
+def test_a_wellformed_id_one_edit_from_a_stored_row_still_raises(monkeypatch):
+    """The near-miss signal outranks well-formedness — a single substitution
+    inside a valid UUID is a typo, not a foreign session."""
+    sr = _resolver_with(monkeypatch, [_REAL])
+    swapped = _REAL[:20] + ("0" if _REAL[20] != "0" else "1") + _REAL[21:]
+
+    assert len(swapped) == 36
+    with pytest.raises(ValueError) as exc:
+        sr._resolve_partial_uuid(swapped)
+    assert _REAL in str(exc.value)
+
+
+def test_non_uuid_aliases_are_untouched_by_the_shape_test(monkeypatch):
+    """`latest` and friends must never be judged on UUID shape — they route
+    through the alias path, and three such ids are live in this store."""
+    from empirica.utils.session_resolver import _is_uuid_shaped
+
+    for alias in ("latest", "investigation-cli-mapping", "2bc1da78"):
+        assert not _is_uuid_shaped(alias)


### PR DESCRIPTION
Root-caused by cortex across a long thread (prop_mbj3uva, prop_b35vpw2v) after a hand-typed PREFLIGHT payload dropped one hex digit mid-UUID.

## The inverted safety

```python
if "-" in partial_or_full_uuid:
    return partial_or_full_uuid       # no check, ever
```

A hyphen was the entire test. Fall through to the **partial** branch instead and you get a real query that raises on a miss:

| Input | Path | Outcome |
|---|---|---|
| `4aea7003` | DB prefix query | ✅ resolved, or raises |
| `4aea7003-…-3030ce9f1bb` (35 chars, absent) | hyphen fast-path | ❌ returned as-is, `ok:true` |

**Typing less of the identifier was the safe move.** The docstring has always promised *"or validate full UUID"*; that half was never written.

It becomes durable because the bad id is written to the transaction pointer file **before** the first DB touch — so every later POSTFLIGHT and `log-artifacts` in that session resolves from a poisoned pointer.

## The error that hid it

```python
f"session {session_id[:8]} not found in project DB"
```

The typo was in the **last** segment, so this printed the *real* session's prefix. Everyone who read it verified `4aea7003`, found it intact and correctly bound, and concluded the resolver was broken. Three practices searched the wrong component.

> An error that identifies a record by a prefix cannot report a mismatch outside that prefix. It does not merely fail to help — it reliably accuses the wrong thing, because the part it shows *is* correct.

Now prints the id in full with both lengths, names any row one edit away, and points at the pointer file.

## Narrowed after the full suite disagreed with me

The first version raised on **any** absent full id. That broke `test_session_resolver.py::test_resolve_full_uuid`, and the failure was correct: a well-formed UUID absent from *this* project's DB may be a legitimate id from another project, and refusing it trades a silent typo for a hot-path regression — the worse of the two.

```
absent AND (malformed OR one-edit-from-a-stored-row)  -> raise
absent AND well-formed AND unlike anything stored     -> warn, pass through
```

The reported corruption trips **both** limbs, so that case is fully closed while cross-project resolution still works.

**No UUID validation**, which cortex proposed. Measured first: 3 of 1037 live session ids are not UUIDs — `latest`, `investigation-cli-mapping`, a bare `2bc1da78`. Shape validation would have rejected real sessions including the `latest` alias much of the tooling uses. Existence is the invariant; shape only distinguishes typo from stranger.

## Two more found while reading

- **PREFLIGHT** now warns when the session row is missing — the entry point where corruption lands. It *warns* rather than blocks, because PREFLIGHT is hot-path.
- **The MCP tool description** documented `claims: [{index|id, verdict, note}]` while `adjudicate()` reads `evidence`. A caller following the shipped contract had their evidence silently dropped — and `note` is exactly what this morning's separate adjudication bug report contained. Our published schema was a partial cause of that bug. Description corrected **and** `note` accepted as an alias, because the ambiguity was ours.

## A mistake worth recording

My first near-miss detector compared an 8-char head against a 6-char tail. It passed on my **synthetic** example, where the dropped character fell outside the tail window, and failed on cortex's **real** id, where the missing digit fell inside it.

I had written a near-miss detector with the same defect as the message it replaces: inspecting part of an identifier, blind to the rest. Caught only because I used their literal id as the fixture. It is now an exact one-edit check.

## Verification

- Full suite on this branch: **5792 passed, 8 skipped, 0 failed**
- Before narrowing: 5785 passed, 1 failed — the failure that drove the narrowing
- Touched-area files: 58 tests green

Not touched: `required: ["session_id", "vectors"]` on the three MCP tools. That is a schema change with codex/ecodex seats downstream and wants its own decision rather than riding a bug fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CYGM8iW6AnxSHH3j3teojz
