### PR TITLE
rewrite(dispatch-agent): a phantom tool parameter, a false premise, and thresholds standing in for judgment

### DIFF
--- a/empirica/plugins/claude-code-integration/skills/dispatch-agent/SKILL.md
+++ b/empirica/plugins/claude-code-integration/skills/dispatch-agent/SKILL.md
@@ -5,213 +5,111 @@ description: Dispatch subagents with inherited epistemic context from Cortex. Us
 
 # Epistemic Agent Dispatch
 
-**Spawn subagents that inherit relevant knowledge from Cortex.**
+**Retrieve what this practice already learned about the task, and put it in the
+subagent's prompt before spawning.**
 
-Without this skill, subagents arrive blank — they repeat mistakes, miss known
-dead-ends, and lack domain context. With it, they inherit findings, dead-ends,
-anti-patterns, and governance rules from the parent's epistemic state.
+A fresh subagent has the repo and the harness, not your practice's history. It
+cannot know which approach was already tried and abandoned, because that lives in
+your epistemic graph and nothing puts it in front of them. The enrichment step is
+the whole skill; everything below serves it.
 
----
+`subagent_type: "fork"` is the exception — a fork inherits your full conversation
+context, so enrichment is redundant there. Use fork when the subagent needs *what
+you know right now*; use enrichment when it needs *what the practice learned
+before this session*.
 
-## How to Use
-
-Before spawning an Agent tool call, run this skill to enrich the prompt.
-
-```
-/dispatch-agent "Refactor handle_foo to reduce complexity"
-```
-
-Or invoke automatically when you're about to dispatch an agent for non-trivial work.
-
----
-
-## Step 1: Query Cortex for Inherited Context
-
-Use the task description to query Cortex for relevant epistemic artifacts:
+## 1. Retrieve
 
 ```
-mcp__cortex__investigate({
-  "query": "<task description>",
-  "limit": 10
-})
+mcp__cortex__investigate({ "query": "<task description>", "limit": 10 })
 ```
 
-If Cortex is unavailable, fall back to local Empirica CLI:
+Cortex unavailable — local, both runnable as written:
 
 ```bash
-empirica project-search --task "<task description>" --global --output json
+empirica project-search --task "<description>" --global --output json
+empirica project-search --task "<description>" --type assumptions --output json
 ```
 
-## Step 2: Categorize Results
+`--global` widens past this project into shared learnings. There is no `--list`
+on the `*-log` verbs: they WRITE, retrieval is semantic through `project-search`
+or `investigate`.
 
-From the Cortex/search results, extract and categorize:
+## 2. Select
 
-| Category | What to Include | Why |
-|----------|----------------|-----|
-| **Dead-ends** | Failed approaches relevant to this task | Prevent repetition |
-| **Findings** | Discoveries about the domain/files involved | Build on prior knowledge |
-| **Decisions** | Architectural choices affecting this area | Maintain consistency |
-| **Anti-patterns** | Mistakes made in similar work | Avoid known pitfalls |
-| **Governance** | Standing rules for this type of work | Enforce standards |
+Include what would change the subagent's *behaviour*, and leave out what would
+merely inform it — a prompt that recites everything known about a domain buries
+the two lines that matter.
 
-### Filtering Rules
+| Kind | Include when |
+|---|---|
+| **dead_end** | it names an approach for THIS task. Highest-value inheritance — the subagent cannot rediscover a dead end cheaply, it can only re-walk it. Prefer over-including here. |
+| **finding** | the subagent would otherwise have to derive it, or would derive it wrong |
+| **decision** | it constrains how this work must be done, not merely how something came to be |
+| **mistake** | it happened in work of this shape. Reframe as the prohibition, not the story. |
 
-- **Dead-ends**: Include ALL that match (similarity > 0.5). These are the highest-value inheritance — preventing a subagent from wasting time on known failures.
-- **Findings**: Include top 5 by relevance. Too many overwhelm the context.
-- **Decisions**: Include only those affecting the specific files/domain.
-- **Anti-patterns**: Extract from dead-ends and mistakes. Format as "DO NOT: ..."
+Judge relevance by reading the artifact against the task. Similarity scores rank
+candidates; they do not decide inclusion, and a fixed cutoff will drop the one
+dead-end that matters while admitting four findings that don't.
 
-## Step 3: Build the Dispatch Schema
-
-Construct the enriched agent prompt with this structure:
+## 3. Build the prompt
 
 ```markdown
-## Inherited Epistemic Context
+## Inherited context
 
-Your parent agent has relevant knowledge for this task. Study this before starting.
+Your parent practice has already learned the following about this work.
 
-### Dead-Ends (DO NOT repeat these)
-{{for each dead-end}}
+### Do not repeat these — they were tried and failed
 - **Approach:** {{approach}}
   **Why it failed:** {{why_failed}}
-{{end}}
 
-### Relevant Findings
-{{for each finding}}
-- {{finding}} (impact: {{impact}})
-{{end}}
+### Findings
+- {{finding}}
 
-### Architectural Decisions in Effect
-{{for each decision}}
-- **Choice:** {{choice}}
-  **Rationale:** {{rationale}}
-{{end}}
+### Decisions in effect
+- **Choice:** {{choice}} — **because** {{rationale}}
 
-### Anti-Patterns (AVOID these)
-{{for each anti-pattern}}
-- DO NOT: {{pattern}}
-{{end}}
-
-### Governance
-- Run tests after EACH file modification (not after batching)
-- Verify extracted helpers receive all needed variables as parameters
-- Commit only after tests pass
+### Prohibitions
+- DO NOT {{pattern}}
 
 ---
 
-## Your Task
+## Your task
 
 {{original task description}}
 ```
 
-## Step 4: Dispatch with the Agent Tool
+State verification expectations in the task itself — which tests to run and when,
+what counts as done. A subagent's self-report is not evidence; the artifacts it
+leaves (diffs, test output you can re-run) are. Ask for those.
 
-Use the Agent tool with the enriched prompt:
+## 4. Dispatch
 
 ```
 Agent({
-  "description": "{{short 3-5 word description}}",
-  "prompt": "{{enriched prompt from Step 3}}",
+  "description": "<3-5 words>",
+  "prompt": "<enriched prompt>",
   "subagent_type": "general-purpose",
-  "run_in_background": true  // or false if you need results immediately
 })
 ```
 
-## Step 5: Review Before Launch
+Optional, and worth knowing:
 
-Before executing the Agent tool call, present the dispatch payload to the user:
+| Parameter | Use when |
+|---|---|
+| `subagent_type: "fork"` | the subagent needs your live context; enrichment is then redundant |
+| `isolation: "worktree"` | several agents mutate files in parallel and would collide. Costs real setup time and disk — not a default |
+| `model` | a cheaper tier genuinely fits mechanical work, or a harder one fits a judgment call |
 
-> **Dispatching agent:** {{description}}
-> **Inherited context:** {{N}} dead-ends, {{N}} findings, {{N}} decisions
-> **Governance:** {{key rules}}
->
-> Proceed?
+Launch several independent agents in ONE message so they run concurrently.
 
-On high-autonomy tasks, skip the review. On sensitive tasks, wait for confirmation.
+There is no `run_in_background` parameter on this tool — the skill printed one
+for a long time, which is the same defect as a documented CLI flag that cannot
+run: plausible, copied, and it fails only in the caller.
 
----
+## After it returns
 
-## Example: Code Refactoring Dispatch
-
-**Task:** "Refactor handle_session_commands to reduce C901 complexity"
-
-**Cortex query returns:**
-- Dead-end: "CLI handler Tier C agent created parameterless helpers — scope bugs in 20+ files"
-- Finding: "Pattern: extract sequential stages into helpers, pass all variables as parameters"
-- Decision: "Helpers in SAME file, defined BEFORE the function they serve"
-
-**Enriched prompt:**
-
-```markdown
-## Inherited Epistemic Context
-
-### Dead-Ends (DO NOT repeat these)
-- **Approach:** Batch refactoring 35 functions across 12 files with automated extraction
-  **Why it failed:** Created parameterless helpers referencing outer-scope variables. 20+ files broken.
-
-### Relevant Findings
-- Extract sequential stages into helper functions, main becomes orchestrator (impact: 0.8)
-- Each helper must receive ALL referenced variables as parameters (impact: 0.7)
-
-### Anti-Patterns (AVOID these)
-- DO NOT extract helpers without passing variables they reference as parameters
-- DO NOT batch more than 3-4 files per agent — verify each with tests
-- DO NOT create recursive helper chains (_helper_helper_helper)
-
-### Governance
-- Run `python3 -m pytest tests/ -x -q --tb=short` after EACH file
-- Target CC < 15 for main functions
-- No behavior changes — pure structural refactoring
-
----
-
-## Your Task
-
-Refactor all C901 violations in empirica/cli/command_handlers/session_commands.py.
-For each function over CC 15, extract the biggest conditional block into a helper.
-Helpers go in the same file, defined before the function they serve.
-```
-
----
-
-## Cortex Unavailable Fallback
-
-If Cortex MCP is not connected, use local Empirica search:
-
-```bash
-# Semantic search across dead-ends, findings and the rest of the graph.
-# --global widens past this project into the shared learnings pool.
-empirica project-search --task "<description>" --global --output json 2>/dev/null
-
-# Narrow to one artifact kind when the query is broad
-empirica project-search --task "<description>" --type assumptions --output json 2>/dev/null
-```
-
-**There is no `--list` on the `*-log` verbs.** They WRITE artifacts; retrieval
-is semantic and goes through `project-search` (or `investigate`). This block
-used to print `deadend-log --list` and `finding-log --list`, neither of which
-exists — an AI following it got a usage error with no way to tell whether the
-skill was wrong or its own invocation was.
-
-Format the results the same way as the Cortex path.
-
----
-
-## Why This Matters
-
-Without inherited context, subagents:
-- Repeat known dead-ends (wasting time and tokens)
-- Violate established patterns (creating inconsistency)
-- Miss anti-patterns (introducing bugs the parent already learned to avoid)
-- Lack governance (no test discipline, no verification)
-
-With inherited context, subagents:
-- Skip known failures immediately
-- Follow established patterns
-- Avoid known pitfalls
-- Verify their work before claiming completion
-
-The quality difference is measurable — the same C901 refactoring task succeeded
-cleanly with context-aware agents (core/data batch) and failed destructively
-without it (CLI handler batch). Same task, same pattern, different outcome.
-The variable was inherited knowledge.
+Verify rather than accept. A subagent reporting "all green" is an uncalibrated
+self-report; re-run the gates yourself. Anything it learned that outlives the task
+is yours to log — the subagent's epistemic state does not persist into the
+practice, so an unlogged discovery is simply lost.

--- a/tests/test_dispatch_agent_contracts.py
+++ b/tests/test_dispatch_agent_contracts.py
@@ -1,0 +1,127 @@
+"""Every flag and parameter this skill prints must actually exist.
+
+dispatch-agent has now shipped two phantom invocations:
+
+  * `deadend-log --list` / `finding-log --list` — no such flag; fixed in e8a5cf7d5,
+    and the skill now documents the absence so it does not come back
+  * `"run_in_background": true` on the Agent tool — no such parameter, removed in
+    the Claude-5 rewrite
+
+Both are the same defect: documented, plausible, copied, and they fail only in the
+caller. An AI following either got an error with no way to tell whether the skill
+was wrong or its own invocation was — so it debugs itself instead of the doc.
+
+The guard reads flags out of the SKILL and checks them against the live argparse
+definitions, so a flag that is renamed or dropped fails here rather than in
+someone's terminal.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parent.parent
+_SKILL = _ROOT / "empirica" / "plugins" / "claude-code-integration" / "skills" / "dispatch-agent" / "SKILL.md"
+
+
+def _skill() -> str:
+    return _SKILL.read_text()
+
+
+def _cli_invocations() -> list[tuple[str, list[str]]]:
+    """(subcommand, flags) for every `empirica ...` line in a bash block."""
+    out = []
+    for line in re.findall(r"^empirica\s+(.+)$", _skill(), re.M):
+        parts = line.split()
+        if not parts:
+            continue
+        out.append((parts[0], [p for p in parts[1:] if p.startswith("--")]))
+    return out
+
+
+def test_the_skill_prints_at_least_one_cli_invocation():
+    """Guards the guard: if the parse finds nothing, every test below passes
+    vacuously and reports safety it never checked."""
+    assert _cli_invocations(), "no `empirica ...` lines parsed — this guard would be inert"
+
+
+def _live_flags(subcommand: str) -> set[str]:
+    """Flags the REAL parser accepts for a subcommand.
+
+    Built from `create_argument_parser()` rather than shelling out to `--help`:
+    the parser is what actually parses, so this cannot drift from it, and it does
+    not depend on the package being installed on PATH in CI.
+    """
+    from empirica.cli.cli_core import create_argument_parser
+
+    parser = create_argument_parser()
+    subs = next(a for a in parser._subparsers._group_actions if hasattr(a, "choices"))  # type: ignore[union-attr]
+
+    assert subcommand in subs.choices, f"`empirica {subcommand}` is not a real subcommand"
+
+    flags: set[str] = set()
+    for action in subs.choices[subcommand]._actions:
+        flags.update(action.option_strings)
+    return flags
+
+
+@pytest.mark.parametrize("subcommand,flags", _cli_invocations())
+def test_every_printed_flag_exists_on_its_subcommand(subcommand, flags):
+    live = _live_flags(subcommand)
+
+    missing = sorted(f for f in flags if f not in live)
+    assert not missing, f"dispatch-agent prints {missing} on `{subcommand}`, which does not accept them"
+
+
+def test_no_list_flag_creeps_back_onto_the_log_verbs():
+    """The original phantom. `*-log` verbs WRITE; retrieval is semantic."""
+    assert not re.search(r"-log\s+--list", _skill()), "`--list` is back on a *-log verb"
+
+
+def test_no_phantom_agent_parameters():
+    """The Agent tool's real parameters. `run_in_background` was printed here for
+    a long time and does not exist on this tool.
+    """
+    agent_block = re.search(r"Agent\(\{(.*?)\}\)", _skill(), re.S)
+    assert agent_block, "the Agent dispatch example is gone — that IS the skill"
+
+    keys = set(re.findall(r'"(\w+)":', agent_block.group(1)))
+    real = {"description", "prompt", "subagent_type", "model", "isolation"}
+
+    phantom = sorted(keys - real)
+    assert not phantom, f"Agent parameters that do not exist: {phantom}"
+
+
+def test_the_false_blank_subagent_premise_is_gone():
+    """The skill opened with "subagents arrive blank". `fork` inherits the
+    parent's full conversation context, so the premise was false and it argued
+    for enrichment in the one case where enrichment is redundant.
+    """
+    text = _skill()
+
+    assert "arrive blank" not in text
+    assert "fork" in text, "fork must be named — it is when NOT to use this skill"
+
+
+def test_numeric_thresholds_do_not_substitute_for_judgment():
+    """`similarity > 0.5`, `top 5 by relevance`, `no more than 3-4 files` — each
+    read as precision while encoding an arbitrary cut. A fixed cutoff drops the
+    one dead-end that matters and admits four findings that don't.
+    """
+    text = _skill()
+
+    assert not re.search(r"similarity\s*>\s*0\.\d", text)
+    assert not re.search(r"top \d+ by relevance", text)
+
+
+def test_the_trigger_surface_is_intact():
+    """Amendment 3: front-matter is what makes the skill load, exempt from the trim."""
+    desc = re.search(r"^description:\s*(.+)$", _skill(), re.M)
+    assert desc, "no description front-matter — this skill can never trigger"
+
+    body = desc.group(1).lower()
+    for cue in ("dispatch", "agent", "context"):
+        assert cue in body, f"trigger cue '{cue}' removed"


### PR DESCRIPTION
Slice 3 of the Claude-5 pass — and the **first written under amendment 5**: whole-file rewrite, not incremental edit. **1012 → 671 words.**

Taken deliberately as a small self-contained file, to validate the rewrite method before pointing it at the 5790-word `epistemic-transaction` skill.

**Not for distribution** — David's second pass and the union gate come after all slices land.

## Three defects, not verbosity

### 1. A phantom Agent parameter

The dispatch example printed `"run_in_background": true`. **That parameter does not exist on the Agent tool.**

Same class as the `deadend-log --list` phantom this same file shipped until `e8a5cf7d5` — documented, plausible, copied, and it fails only in the caller, who then debugs their own invocation instead of the doc.

Removed. And the two **real** parameters nobody was told about are now documented: `isolation: "worktree"` (parallel agents that would collide on files) and `model`.

### 2. A false premise, arguing for the skill in the one case it doesn't apply

The opening claimed *"subagents arrive blank"*. `subagent_type: "fork"` inherits the parent's full conversation context — so a fork is precisely where enrichment is **redundant**.

The skill now names fork and gives the discriminator: fork when the subagent needs *what you know now*, enrichment when it needs *what the practice learned before this session*.

### 3. Numeric thresholds substituting for judgment

`similarity > 0.5` · `top 5 by relevance` · `no more than 3-4 files per agent`

Each reads as precision while encoding an arbitrary cut. A fixed cutoff drops the one dead-end that matters and admits four findings that don't. Replaced with the actual criterion: **include what would change the subagent's behaviour, not what would inform it.**

## Also cut

- The hand-rolled `Proceed?` confirmation ceremony — the harness owns permissions.
- A 40-line worked example restating the skeleton printed directly above it.

## Added, because it was missing and matters more than anything cut

A subagent's "all green" is an uncalibrated self-report — verify by re-running the gates yourself. And log what it learned: **the subagent's epistemic state does not persist into the practice**, so an unlogged discovery is simply lost.

## Verification

Both `project-search` invocations **run** — checked, not asserted (`rc=0` each).

8 guards, **4 fail against the pre-rewrite file**. Flags are read from `create_argument_parser()` — the parser that actually parses — so a renamed flag fails here rather than in someone's terminal.

One test guards the guard: if the invocation parse finds nothing, every flag check below it would pass vacuously and report safety it never verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CYGM8iW6AnxSHH3j3teojz
